### PR TITLE
[改善]ユーザーに処理のキャンセル理由等を通知する

### DIFF
--- a/Niconicome/Models/Network/ContentDownloader.cs
+++ b/Niconicome/Models/Network/ContentDownloader.cs
@@ -390,6 +390,10 @@ namespace Niconicome.Models.Network
                             video.Message = "既にダウンロード済の為スキップ";
                             this.currentParallelDownloadingCount--;
                             currentResult.SucceededCount++;
+                            if (currentResult.FirstVideo is null)
+                            {
+                                currentResult.FirstVideo = video;
+                            }
                             this.StartNextDownload(setting, tcs,currentResult, token);
                             return;
                         }
@@ -420,6 +424,10 @@ namespace Niconicome.Models.Network
 
                 this.currentParallelDownloadingCount--;
                 currentResult.SucceededCount++;
+                if (currentResult.FirstVideo is null)
+                {
+                    currentResult.FirstVideo = video;
+                }
                 this.StartNextDownload(setting, tcs,currentResult, token);
             }
             else

--- a/Niconicome/Models/Network/ContentDownloader.cs
+++ b/Niconicome/Models/Network/ContentDownloader.cs
@@ -21,7 +21,7 @@ namespace Niconicome.Models.Network
 {
     public interface IContentDownloader
     {
-        Task DownloadVideos(IEnumerable<ITreeVideoInfo> videos, DownloadSettings setting, CancellationToken token);
+        Task<INetworkResult> DownloadVideos(IEnumerable<ITreeVideoInfo> videos, DownloadSettings setting, CancellationToken token);
     }
 
     public interface IDownloadSettings
@@ -281,16 +281,18 @@ namespace Niconicome.Models.Network
         /// <param name="setting"></param>
         /// <param name="token"></param>
         /// <returns></returns>
-        public Task DownloadVideos(IEnumerable<ITreeVideoInfo> videos, DownloadSettings setting, CancellationToken token)
+        public Task<INetworkResult> DownloadVideos(IEnumerable<ITreeVideoInfo> videos, DownloadSettings setting, CancellationToken token)
         {
+            this.totalVideos = 0;
             this.downloadVideos.Clear();
             this.currentParallelDownloadingCount = 0;
             this.AddVideos(videos);
-            var tcs = new TaskCompletionSource();
+            var tcs = new TaskCompletionSource<INetworkResult>();
+            var result = new NetworkResult();
 
             while (this.CanDownloadNext(token))
             {
-                var _ = this.DownloadAndNext(setting, tcs, token);
+                var _ = this.DownloadAndNext(setting, tcs,result, token);
             }
 
             return tcs.Task;
@@ -309,11 +311,17 @@ namespace Niconicome.Models.Network
         private readonly List<IVideoToDownload> downloadVideos = new();
 
         /// <summary>
+        /// ダウンロードする動画の数
+        /// </summary>
+        private int totalVideos;
+
+        /// <summary>
         /// ダウンロードする動画を追加する
         /// </summary>
         /// <param name="video"></param>
         private void AddVideo(ITreeVideoInfo video)
         {
+            this.totalVideos ++ ;
             if (this.downloadVideos.Any(v => v.Video.Id == video.Id)) return;
             this.downloadVideos.Add(new VideoToDownload(video, this.downloadVideos.Count));
         }
@@ -347,7 +355,7 @@ namespace Niconicome.Models.Network
         /// <param name="tcs"></param>
         /// <param name="token"></param>
         /// <returns></returns>this.messageHandler
-        private async Task DownloadAndNext(DownloadSettings setting, TaskCompletionSource tcs, CancellationToken token)
+        private async Task DownloadAndNext(DownloadSettings setting, TaskCompletionSource<INetworkResult> tcs, INetworkResult currentResult, CancellationToken token)
         {
             if (!token.IsCancellationRequested || this.CanDownloadNext(token))
             {
@@ -381,7 +389,8 @@ namespace Niconicome.Models.Network
                             video.IsSelected = false;
                             video.Message = "既にダウンロード済の為スキップ";
                             this.currentParallelDownloadingCount--;
-                            this.StartNextDownload(setting, tcs, token);
+                            currentResult.SucceededCount++;
+                            this.StartNextDownload(setting, tcs,currentResult, token);
                             return;
                         }
                     }
@@ -392,6 +401,7 @@ namespace Niconicome.Models.Network
 
                 if (!result.IsSucceeded)
                 {
+                    currentResult.FailedCount++;
                     this.messageHandler.AppendMessage($"{video.NiconicoId}のダウンロードに失敗しました。");
                     this.messageHandler.AppendMessage($"詳細: {result.Message}");
                 }
@@ -409,11 +419,16 @@ namespace Niconicome.Models.Network
                 }
 
                 this.currentParallelDownloadingCount--;
-                this.StartNextDownload(setting, tcs, token);
+                currentResult.SucceededCount++;
+                this.StartNextDownload(setting, tcs,currentResult, token);
             }
             else
             {
-                if (!tcs.Task.IsCompleted) tcs.SetResult();
+                if (currentResult.SucceededCount == this.totalVideos)
+                {
+                    currentResult.IsSucceededAll = true;
+                }
+                if (!tcs.Task.IsCompleted) tcs.SetResult(currentResult);
 
             }
 
@@ -425,11 +440,15 @@ namespace Niconicome.Models.Network
         /// </summary>
         /// <param name="tcs"></param>
         /// <param name="token"></param>
-        private async void StartNextDownload(DownloadSettings setting, TaskCompletionSource tcs, CancellationToken token)
+        private async void StartNextDownload(DownloadSettings setting, TaskCompletionSource<INetworkResult> tcs, INetworkResult currentResult, CancellationToken token)
         {
             if (!this.CanDownloadNext(token) && this.IsDownloadCompleted())
             {
-                if (!tcs.Task.IsCompleted) tcs.SetResult();
+                if (currentResult.SucceededCount == this.totalVideos)
+                {
+                    currentResult.IsSucceededAll = true;
+                }
+                if (!tcs.Task.IsCompleted) tcs.SetResult(currentResult);
                 return;
             }
             else if (this.NeedWait())
@@ -440,13 +459,13 @@ namespace Niconicome.Models.Network
 
             if (token.IsCancellationRequested)
             {
-                if (!tcs.Task.IsCompleted) tcs.SetResult();
+                if (!tcs.Task.IsCompleted) tcs.SetResult(currentResult);
                 return;
             }
 
             while (this.CanDownloadNext(token))
             {
-                var _ = this.DownloadAndNext(setting, tcs, token);
+                var _ = this.DownloadAndNext(setting, tcs,currentResult, token);
             }
         }
 

--- a/Niconicome/Models/Network/NetworkVideoHandler.cs
+++ b/Niconicome/Models/Network/NetworkVideoHandler.cs
@@ -28,6 +28,7 @@ namespace Niconicome.Models.Network
         bool IsSucceededAll { get; set; }
         int SucceededCount { get; set; }
         int FailedCount { get; set; }
+        ITreeVideoInfo? FirstVideo { get; set; }
     }
 
     /// <summary>
@@ -299,6 +300,12 @@ namespace Niconicome.Models.Network
         /// 失敗したコンテンツの数
         /// </summary>
         public int FailedCount { get; set; }
+
+        /// <summary>
+        /// 動画情報
+        /// </summary>
+        public ITreeVideoInfo? FirstVideo { get; set; }
+
     }
 
 }

--- a/Niconicome/Models/Network/NetworkVideoHandler.cs
+++ b/Niconicome/Models/Network/NetworkVideoHandler.cs
@@ -25,9 +25,9 @@ namespace Niconicome.Models.Network
 
     public interface INetworkResult
     {
-        bool IsSucceededAll { get; }
-        int SucceededCount { get; }
-        int FailedCount { get; }
+        bool IsSucceededAll { get; set; }
+        int SucceededCount { get; set; }
+        int FailedCount { get; set; }
     }
 
     /// <summary>
@@ -184,6 +184,8 @@ namespace Niconicome.Models.Network
             if (netResult.SucceededCount == videosCount) netResult.IsSucceededAll = true;
 
             this.messageHandler.AppendMessage($"{netResult.SucceededCount}件の動画情報を更新しました。");
+
+            return netResult;
         }
 
         /// <summary>

--- a/Niconicome/Models/Network/NetworkVideoHandler.cs
+++ b/Niconicome/Models/Network/NetworkVideoHandler.cs
@@ -16,11 +16,18 @@ namespace Niconicome.Models.Network
         bool IsVideoDownloaded(string niconicoId);
         string GetFilePath(string niconicoId);
         string GetFilePath(string niconicoId, string foldername);
-        Task AddVideosAsync(IEnumerable<string> videosId, int playlistId, Action<IResult> onFailed, Action<ITreeVideoInfo> onSucceed);
+        Task<INetworkResult> AddVideosAsync(IEnumerable<string> videosId, int playlistId, Action<IResult> onFailed, Action<ITreeVideoInfo> onSucceed);
         Task AddVideosAsync(IEnumerable<ITreeVideoInfo> videos, int playlistId);
-        Task UpdateVideosAsync(IEnumerable<ITreeVideoInfo> videos, string folderPath, Action<ITreeVideoInfo> onSucceeded, CancellationToken ct);
+        Task<INetworkResult> UpdateVideosAsync(IEnumerable<ITreeVideoInfo> videos, string folderPath, Action<ITreeVideoInfo> onSucceeded, CancellationToken ct);
         Task<IEnumerable<ITreeVideoInfo>> GetTreeVideoInfosAsync(IEnumerable<ITreeVideoInfo> ids, Action<ITreeVideoInfo, ITreeVideoInfo> onSucceeded, Action<IResult, ITreeVideoInfo> onFailed, Action<ITreeVideoInfo, int> onStarted, Action<ITreeVideoInfo> onWaiting);
         Task<IEnumerable<ITreeVideoInfo>> GetTreeVideoInfosAsync(IEnumerable<string> ids, Action<ITreeVideoInfo, ITreeVideoInfo> onSucceeded, Action<IResult, ITreeVideoInfo> onFailed, Action<ITreeVideoInfo, int> onStarted, Action<ITreeVideoInfo> onWaiting);
+    }
+
+    public interface INetworkResult
+    {
+        bool IsSucceededAll { get; }
+        int SucceededCount { get; }
+        int FailedCount { get; }
     }
 
     /// <summary>
@@ -61,20 +68,23 @@ namespace Niconicome.Models.Network
         /// <param name="onfailed"></param>
         /// <param name="onSucceed"></param>
         /// <returns></returns>
-        public async Task AddVideosAsync(IEnumerable<string> videoIds, int playlistId, Action<IResult> onfailed, Action<ITreeVideoInfo> onSucceed)
+        public async Task<INetworkResult> AddVideosAsync(IEnumerable<string> videoIds, int playlistId, Action<IResult> onfailed, Action<ITreeVideoInfo> onSucceed)
         {
             var playlist = this.playlistTreeHandler.GetPlaylist(playlistId);
 
-            if (playlist is null) return;
+            var netResult = new NetworkResult();
+
+            if (playlist is null) return netResult;
 
             int videosCount = videoIds.Count();
 
-            if (videosCount == 0) return;
+            if (videosCount == 0) return netResult;
 
             this.messageHandler.AppendMessage($"{videosCount}件の動画を追加します。");
 
             await this.GetTreeVideoInfosAsync(videoIds.Copy(), async (newVideo, video) =>
             {
+                netResult.SucceededCount++;
                 await this.videoThumnailUtility.SetThumbPathAsync(newVideo);
                 int id = this.videoHandler.AddVideo(newVideo, playlist.Id);
                 newVideo.Id = id;
@@ -82,6 +92,7 @@ namespace Niconicome.Models.Network
                 onSucceed(newVideo);
             }, (result, video) =>
             {
+                netResult.FailedCount++;
                 onfailed(result);
                 this.messageHandler.AppendMessage($"動画の取得に失敗しました。(詳細: {result.Message})");
             }, (video, index) =>
@@ -92,7 +103,11 @@ namespace Niconicome.Models.Network
                 video.Message = "待機中...(15s)";
             });
 
-            this.messageHandler.AppendMessage($"動画の追加処理が完了しました。({videosCount}件)");
+            if (netResult.SucceededCount == videosCount) netResult.IsSucceededAll = true;
+
+            this.messageHandler.AppendMessage($"動画の追加処理が完了しました。({netResult.SucceededCount}件)");
+
+            return netResult;
         }
 
         /// <summary>
@@ -132,9 +147,10 @@ namespace Niconicome.Models.Network
         /// <param name="onSucceeded"></param>
         /// <param name="ct"></param>
         /// <returns></returns>
-        public async Task UpdateVideosAsync(IEnumerable<ITreeVideoInfo> videos, string folderPath, Action<ITreeVideoInfo> onSucceeded, CancellationToken ct)
+        public async Task<INetworkResult> UpdateVideosAsync(IEnumerable<ITreeVideoInfo> videos, string folderPath, Action<ITreeVideoInfo> onSucceeded, CancellationToken ct)
         {
             videos = videos.Copy();
+            var netResult = new NetworkResult();
             var i = 0;
             int videosCount = videos.Count();
 
@@ -142,6 +158,7 @@ namespace Niconicome.Models.Network
 
             await this.GetTreeVideoInfosAsync(videos.Copy(), async (newVideo, video) =>
             {
+                netResult.SucceededCount++;
                 video.IsSelected = false;
                 video.Message = "情報を更新しました。";
                 newVideo.Id = video.Id;
@@ -152,6 +169,7 @@ namespace Niconicome.Models.Network
                 onSucceeded(newVideo);
             }, (result, video) =>
             {
+                netResult.FailedCount++;
                 video.Message = "情報の更新に失敗しました。";
                 this.messageHandler.AppendMessage($"{video.NiconicoId}の情報を更新に失敗しました。(詳細: {result.Message ?? "None"})");
             }, (video, _) =>
@@ -163,7 +181,9 @@ namespace Niconicome.Models.Network
                 video.Message = "待機中...(15s)";
             });
 
-            this.messageHandler.AppendMessage($"{videosCount}件の動画情報を更新しました。");
+            if (netResult.SucceededCount == videosCount) netResult.IsSucceededAll = true;
+
+            this.messageHandler.AppendMessage($"{netResult.SucceededCount}件の動画情報を更新しました。");
         }
 
         /// <summary>
@@ -260,4 +280,23 @@ namespace Niconicome.Models.Network
                 (Path.GetDirectoryName(p) ?? string.Empty) == foldername);
         }
     }
+
+    public class NetworkResult : INetworkResult
+    {
+        /// <summary>
+        /// 全ての処理に成功
+        /// </summary>
+        public bool IsSucceededAll { get; set; }
+
+        /// <summary>
+        /// 成功したコンテンツの数
+        /// </summary>
+        public int SucceededCount { get; set; }
+
+        /// <summary>
+        /// 失敗したコンテンツの数
+        /// </summary>
+        public int FailedCount { get; set; }
+    }
+
 }

--- a/Niconicome/Models/Playlist/Tree.cs
+++ b/Niconicome/Models/Playlist/Tree.cs
@@ -234,47 +234,6 @@ namespace Niconicome.Models.Playlist
         }
 
         /// <summary>
-        /// 動画を追加する
-        /// </summary>
-        /// <param name="video"></param>
-        /// <param name="playlistId"></param>
-        public int AddVideo(ITreeVideoInfo video, int playlistId)
-        {
-            try
-            {
-                this.handler.GetPlaylist(playlistId)?.Videos?.Add(video);
-                return this.playlistStoreHandler.AddVideo(video, playlistId);
-            }
-            catch (Exception e)
-            {
-                var logger = Utils::DIFactory.Provider.GetRequiredService<Utils::ILogger>();
-                logger.Error("動画の追加に失敗しました。", e);
-                this.errorMessanger.FireError($"{video.NiconicoId}の保存に失敗しました。操作は反映されません。");
-                return -1;
-            }
-        }
-
-        /// <summary>
-        /// 動画を削除する
-        /// </summary>
-        /// <param name="videoID"></param>
-        /// <param name="playlistId"></param>
-        public void RemoveVideo(int videoID, int playlistId)
-        {
-            try
-            {
-                this.handler.GetPlaylist(playlistId)?.Videos?.RemoveAll(v => v.Id == videoID);
-                this.playlistStoreHandler.RemoveVideo(videoID, playlistId);
-            }
-            catch (Exception e)
-            {
-                var logger = Utils::DIFactory.Provider.GetRequiredService<Utils::ILogger>();
-                logger.Error("動画の削除に失敗しました。", e);
-                this.errorMessanger.FireError($"動画の削除に失敗しました。操作は反映されません。");
-            }
-        }
-
-        /// <summary>
         /// リモートプレイリストとして設定する
         /// </summary>
         /// <param name="playlistId"></param>
@@ -294,16 +253,6 @@ namespace Niconicome.Models.Playlist
         {
             this.playlistStoreHandler.SetAsLocalPlaylist(playlistId);
             this.SetPlaylists();
-        }
-
-        /// <summary>
-        /// 動画情報を更新する
-        /// </summary>
-        /// <param name="video"></param>
-        public void UpdateVideo(ITreeVideoInfo video, bool enableRefresh = true)
-        {
-            this.videoStoreHandler.Update(video);
-            if (enableRefresh) this.SetPlaylists();
         }
 
         /// <summary>

--- a/Niconicome/ViewModels/Mainpage/DownloadSettingsViewModel.cs
+++ b/Niconicome/ViewModels/Mainpage/DownloadSettingsViewModel.cs
@@ -39,7 +39,11 @@ namespace Niconicome.ViewModels.Mainpage
 
             this.DownloadCommand = new CommandBase<object>(_ => this.playlist is not null && !this.isDownloadingField, async _ =>
                {
-                   if (this.playlist is null) return;
+                   if (this.playlist is null)
+                   {
+                       this.SnackbarMessageQueue.Enqueue("プレイリストが選択されていないため、ダウンロードできません");
+                       return;
+                   }
 
                    if (!WS::Mainpage.Session.IsLogin)
                    {

--- a/Niconicome/ViewModels/Mainpage/DownloadSettingsViewModel.cs
+++ b/Niconicome/ViewModels/Mainpage/DownloadSettingsViewModel.cs
@@ -75,10 +75,11 @@ namespace Niconicome.ViewModels.Mainpage
 
                    WS::Mainpage.Messagehandler.AppendMessage($"動画のダウンロードを開始します。({videoCount}件)");
                    this.SnackbarMessageQueue.Enqueue($"動画のダウンロードを開始します。({videoCount}件)");
+                   INetworkResult? result = null;
 
                    try
                    {
-                       await WS::Mainpage.Videodownloader.DownloadVideos(videos, setting, cts.Token);
+                       result = await WS::Mainpage.Videodownloader.DownloadVideos(videos, setting, cts.Token);
 
                    }
                    catch (Exception e)
@@ -87,14 +88,30 @@ namespace Niconicome.ViewModels.Mainpage
                        this.SnackbarMessageQueue.Enqueue($"ダウンロード中にエラーが発生しました。");
                    }
 
-                   if (videoCount > 1)
+                   if (result?.SucceededCount > 1)
                    {
-                       WS::Mainpage.Messagehandler.AppendMessage($"{firstVideo.NiconicoId}ほか{videoCount-1}件の動画をダウンロードしました。");
-                       this.SnackbarMessageQueue.Enqueue($"{firstVideo.NiconicoId}ほか{videoCount-1}件の動画をダウンロードしました。");
+                       if (result?.FirstVideo is not null)
+                       {
+                           WS::Mainpage.Messagehandler.AppendMessage($"{result.FirstVideo}ほか{result.SucceededCount - 1}件の動画をダウンロードしました。");
+                           this.SnackbarMessageQueue.Enqueue($"{result.FirstVideo}ほか{result.SucceededCount - 1}件の動画をダウンロードしました。");
+
+                           if (!result.IsSucceededAll)
+                           {
+                               WS::Mainpage.Messagehandler.AppendMessage($"{result.FailedCount}件の動画のダウンロードに失敗しました。");
+                           }
+                       }
+                   }
+                   else if (result.SucceededCount == 1)
+                   {
+                       if (result?.FirstVideo is not null)
+                       {
+                           WS::Mainpage.Messagehandler.AppendMessage($"{result.FirstVideo}をダウンロードしました。");
+                           this.SnackbarMessageQueue.Enqueue($"{result.FirstVideo}をダウンロードしました。");
+                       }
                    } else
                    {
-                       WS::Mainpage.Messagehandler.AppendMessage($"{firstVideo.NiconicoId}をダウンロードしました。");
-                       this.SnackbarMessageQueue.Enqueue($"{firstVideo.NiconicoId}をダウンロードしました。");
+                       WS::Mainpage.Messagehandler.AppendMessage($"ダウンロード出来ませんでした。");
+                       this.SnackbarMessageQueue.Enqueue($"ダウンロード出来ませんでした。");
                    }
 
                    this.CompleteDownload();

--- a/Niconicome/ViewModels/Mainpage/VideoListViewmodel.cs
+++ b/Niconicome/ViewModels/Mainpage/VideoListViewmodel.cs
@@ -48,7 +48,11 @@ namespace Niconicome.ViewModels.Mainpage
             //種々のコマンドを初期化する
             this.AddVideoCommand = new CommandBase<object>(_ => this.Playlist is not null, async arg =>
             {
-                if (this.Playlist == null) return;
+                if (this.Playlist is null)
+                {
+                    this.SnackbarMessageQueue.Enqueue("プレイリストが選択されていないため、動画を追加できません");
+                    return;
+                }
                 int playlistId = this.Playlist.Id;
 
                 string niconicoId;
@@ -85,7 +89,11 @@ namespace Niconicome.ViewModels.Mainpage
 
             this.RemoveVideoCommand = new CommandBase<ITreeVideoInfo>(_ => true, arg =>
             {
-                if (this.Playlist is null) return;
+                if (this.Playlist is null)
+                {
+                    this.SnackbarMessageQueue.Enqueue("プレイリストが選択されていないため、動画を削除できません");
+                    return;
+                }
 
                 var targetVideos = new List<ITreeVideoInfo>();
 
@@ -132,7 +140,11 @@ namespace Niconicome.ViewModels.Mainpage
 
             this.WatchOnNiconicoCommand = new CommandBase<ITreeVideoInfo>(_ => true, arg =>
             {
-                if (this.Playlist is null) return;
+                if (this.Playlist is null)
+                {
+                    this.SnackbarMessageQueue.Enqueue("プレイリストが選択されていないため、動画を視聴できません");
+                    return;
+                }
                 if (arg is null || arg.AsNullable<ITreeVideoInfo>() is not ITreeVideoInfo videoInfo || videoInfo is null) return;
                 try
                 {
@@ -148,7 +160,11 @@ namespace Niconicome.ViewModels.Mainpage
 
             this.EditPlaylistCommand = new CommandBase<object>(_ => this.Playlist is not null, _ =>
             {
-                if (this.Playlist is null) return;
+                if (this.Playlist is null)
+                {
+                    this.SnackbarMessageQueue.Enqueue("プレイリストが選択されていないため、プレイリスト情報を編集できません");
+                    return;
+                }
                 var window = new EditPlaylist
                 {
                     Owner = Application.Current.MainWindow
@@ -158,7 +174,11 @@ namespace Niconicome.ViewModels.Mainpage
 
             this.AddVideoFromClipboardCommand = new CommandBase<object>(_ => this.Playlist is not null, async _ =>
             {
-                if (this.Playlist == null) return;
+                if (this.Playlist is null)
+                {
+                    this.SnackbarMessageQueue.Enqueue("プレイリストが選択されていないため、動画を追加できません");
+                    return;
+                }
                 int playlistId = this.Playlist.Id;
 
                 var data = Clipboard.GetText();
@@ -221,6 +241,8 @@ namespace Niconicome.ViewModels.Mainpage
 
                 if (this.Playlist is null)
                 {
+
+                    this.SnackbarMessageQueue.Enqueue("プレイリストが選択されていないため、動画を更新できません");
                     return;
                 }
                 int playlistId = this.Playlist.Id;
@@ -238,7 +260,7 @@ namespace Niconicome.ViewModels.Mainpage
 
                 this.cts = new CancellationTokenSource();
 
-               var result = await WS::Mainpage.NetworkVideoHandler.UpdateVideosAsync(this.Videos.Where(v => v.IsSelected), this.Playlist.Folderpath, video => WS::Mainpage.CurrentPlaylist.Update(playlistId, video), this.cts.Token);
+                var result = await WS::Mainpage.NetworkVideoHandler.UpdateVideosAsync(this.Videos.Where(v => v.IsSelected), this.Playlist.Folderpath, video => WS::Mainpage.CurrentPlaylist.Update(playlistId, video), this.cts.Token);
 
                 WS::Mainpage.PlaylistTree.Refresh();
                 WS::Mainpage.CurrentPlaylist.Update(playlistId);
@@ -265,7 +287,13 @@ namespace Niconicome.ViewModels.Mainpage
                          return;
                      }
 
-                     if (this.Playlist is null || !this.Playlist.IsRemotePlaylist || (this.Playlist.RemoteId.IsNullOrEmpty() && this.Playlist.RemoteType != RemoteType.WatchLater)) return;
+                     if (this.Playlist is null)
+                     {
+                         this.SnackbarMessageQueue.Enqueue("プレイリストが選択されていないため、同期できません");
+                         return;
+                     }
+
+                     if (!this.Playlist.IsRemotePlaylist || (this.Playlist.RemoteId.IsNullOrEmpty() && this.Playlist.RemoteType != RemoteType.WatchLater)) return;
 
                      this.StartFetching();
 
@@ -276,7 +304,7 @@ namespace Niconicome.ViewModels.Mainpage
                          RemoteType.Mylist => await WS::Mainpage.RemotePlaylistHandler.TryGetMylistVideosAsync(this.Playlist.RemoteId, videos),
                          RemoteType.UserVideos => await WS::Mainpage.RemotePlaylistHandler.TryGetUserVideosAsync(this.Playlist.RemoteId, videos),
                          RemoteType.WatchLater => await WS::Mainpage.RemotePlaylistHandler.TryGetWatchLaterAsync(videos),
-                         RemoteType.Channel => await WS::Mainpage.RemotePlaylistHandler.TryGetChannelVideosAsync(this.Playlist.RemoteId,videos),
+                         RemoteType.Channel => await WS::Mainpage.RemotePlaylistHandler.TryGetChannelVideosAsync(this.Playlist.RemoteId, videos),
                          _ => false,
                      };
 
@@ -341,7 +369,11 @@ namespace Niconicome.ViewModels.Mainpage
 
             this.SelectAllVideosCommand = new CommandBase<object>(_ => true, _ =>
             {
-                if (this.Playlist is null) return;
+                if (this.Playlist is null)
+                {
+                    this.SnackbarMessageQueue.Enqueue("プレイリストが選択されていないため、処理できません。");
+                    return;
+                }
                 foreach (var video in this.Videos)
                 {
                     video.IsSelected = true;
@@ -351,7 +383,11 @@ namespace Niconicome.ViewModels.Mainpage
             this.DisSelectAllVideosCommand = new CommandBase<object>(_ => true, _ =>
             {
 
-                if (this.Playlist is null) return;
+                if (this.Playlist is null)
+                {
+                    this.SnackbarMessageQueue.Enqueue("プレイリストが選択されていないため、処理できません。");
+                    return;
+                }
                 foreach (var video in this.Videos)
                 {
                     video.IsSelected = false;
@@ -360,7 +396,11 @@ namespace Niconicome.ViewModels.Mainpage
 
             this.SelectAllNotDownloadedVideosCommand = new CommandBase<object>(_ => true, _ =>
             {
-                if (this.Playlist is null) return;
+                if (this.Playlist is null)
+                {
+                    this.SnackbarMessageQueue.Enqueue("プレイリストが選択されていないため、処理できません。");
+                    return;
+                }
                 foreach (var video in this.Videos.Where(v => !v.CheckDownloaded(this.GetFolderPath())))
                 {
                     video.IsSelected = true;
@@ -369,7 +409,11 @@ namespace Niconicome.ViewModels.Mainpage
 
             this.DisSelectAllDownloadedVideosCommand = new CommandBase<object>(_ => true, _ =>
             {
-                if (this.Playlist is null) return;
+                if (this.Playlist is null)
+                {
+                    this.SnackbarMessageQueue.Enqueue("プレイリストが選択されていないため、処理できません。");
+                    return;
+                }
                 foreach (var video in this.Videos.Where(v => v.CheckDownloaded(this.GetFolderPath())))
                 {
                     video.IsSelected = false;
@@ -378,7 +422,11 @@ namespace Niconicome.ViewModels.Mainpage
 
             this.DisSelectAllNotDownloadedVideosCommand = new CommandBase<object>(_ => true, _ =>
             {
-                if (this.Playlist is null) return;
+                if (this.Playlist is null)
+                {
+                    this.SnackbarMessageQueue.Enqueue("プレイリストが選択されていないため、処理できません。");
+                    return;
+                }
                 foreach (var video in this.Videos.Where(v => !v.CheckDownloaded(this.GetFolderPath())))
                 {
                     video.IsSelected = false;
@@ -387,7 +435,11 @@ namespace Niconicome.ViewModels.Mainpage
 
             this.SelectAllDownloadedVideosCommand = new CommandBase<object>(_ => true, _ =>
             {
-                if (this.Playlist is null) return;
+                if (this.Playlist is null)
+                {
+                    this.SnackbarMessageQueue.Enqueue("プレイリストが選択されていないため、処理できません。");
+                    return;
+                }
                 foreach (var video in this.Videos.Where(v => v.CheckDownloaded(this.GetFolderPath())))
                 {
                     video.IsSelected = true;
@@ -396,7 +448,11 @@ namespace Niconicome.ViewModels.Mainpage
 
             this.OpenPlaylistFolder = new CommandBase<object>(_ => true, _ =>
             {
-                if (this.Playlist is null) return;
+                if (this.Playlist is null)
+                {
+                    this.SnackbarMessageQueue.Enqueue("プレイリストが選択されていないため、処理できません。");
+                    return;
+                }
                 string folderPath = this.GetFolderPath();
                 if (folderPath.IsNullOrEmpty() || !Directory.Exists(folderPath)) return;
                 try
@@ -408,7 +464,11 @@ namespace Niconicome.ViewModels.Mainpage
 
             this.FilterCommand = new CommandBase<object>(_ => this.Playlist is not null, _ =>
               {
-                  if (this.Playlist is null) return;
+                  if (this.Playlist is null)
+                  {
+                      this.SnackbarMessageQueue.Enqueue("プレイリストが選択されていないため、処理できません。");
+                      return;
+                  }
 
                   if (this.isFiltered)
                   {
@@ -432,7 +492,11 @@ namespace Niconicome.ViewModels.Mainpage
 
             this.SearchCommand = new CommandBase<object>(_ => this.Playlist is not null, _ =>
              {
-                 if (this.Playlist is null) return;
+                 if (this.Playlist is null)
+                 {
+                     this.SnackbarMessageQueue.Enqueue("プレイリストが選択されていないため、検索画面を表示できません。");
+                     return;
+                 }
 
                  var window = new SearchPage()
                  {
@@ -443,11 +507,20 @@ namespace Niconicome.ViewModels.Mainpage
 
             this.OpenInPlayerAcommand = new CommandBase<object>(_ => true, arg =>
             {
-                if (this.Playlist is null) return;
+                if (this.Playlist is null)
+                {
+                    this.SnackbarMessageQueue.Enqueue("プレイリストが選択されていないため、処理できません。");
+                    return;
+                }
+
                 if (arg is null || arg.AsNullable<ITreeVideoInfo>() is not ITreeVideoInfo videoInfo || videoInfo is null) return;
 
                 string folderPath = this.GetFolderPath();
-                if (!videoInfo.CheckDownloaded(folderPath) || videoInfo.GetFilePath(folderPath).IsNullOrEmpty()) return;
+                if (!videoInfo.CheckDownloaded(folderPath) || videoInfo.GetFilePath(folderPath).IsNullOrEmpty())
+                {
+                    this.SnackbarMessageQueue.Enqueue("動画が保存されていません。");
+                    return;
+                }
 
                 string? appPath = WS::Mainpage.SettingHandler.GetStringSetting(Settings.PlayerAPath);
 
@@ -459,11 +532,20 @@ namespace Niconicome.ViewModels.Mainpage
 
             this.OpenInPlayerBcommand = new CommandBase<object>(_ => true, arg =>
             {
-                if (this.Playlist is null) return;
+                if (this.Playlist is null)
+                {
+                    this.SnackbarMessageQueue.Enqueue("プレイリストが選択されていないため、処理できません。");
+                    return;
+                }
+
                 if (arg is null || arg.AsNullable<ITreeVideoInfo>() is not ITreeVideoInfo videoInfo || videoInfo is null) return;
 
                 string folderPath = this.GetFolderPath();
-                if (!videoInfo.CheckDownloaded(folderPath) || videoInfo.GetFilePath(folderPath).IsNullOrEmpty()) return;
+                if (!videoInfo.CheckDownloaded(folderPath) || videoInfo.GetFilePath(folderPath).IsNullOrEmpty())
+                {
+                    this.SnackbarMessageQueue.Enqueue("動画が保存されていません。");
+                    return;
+                }
 
                 string? appPath = WS::Mainpage.SettingHandler.GetStringSetting(Settings.PlayerBPath);
 
@@ -475,11 +557,19 @@ namespace Niconicome.ViewModels.Mainpage
 
             this.SendIdToappCommand = new CommandBase<object>(_ => true, arg =>
             {
-                if (this.Playlist is null) return;
+                if (this.Playlist is null)
+                {
+                    this.SnackbarMessageQueue.Enqueue("プレイリストが選択されていないため、処理できません。");
+                    return;
+                }
                 if (arg is null || arg.AsNullable<ITreeVideoInfo>() is not ITreeVideoInfo videoInfo || videoInfo is null) return;
 
                 string folderPath = this.GetFolderPath();
-                if (!videoInfo.CheckDownloaded(folderPath) || videoInfo.GetFilePath(folderPath).IsNullOrEmpty()) return;
+                if (!videoInfo.CheckDownloaded(folderPath) || videoInfo.GetFilePath(folderPath).IsNullOrEmpty())
+                {
+                    this.SnackbarMessageQueue.Enqueue("動画が保存されていません。");
+                    return;
+                }
 
                 string? appPath = WS::Mainpage.SettingHandler.GetStringSetting(Settings.AppIdPath);
                 string param = WS::Mainpage.SettingHandler.GetStringSetting(Settings.AppIdParam) ?? string.Empty;
@@ -492,11 +582,20 @@ namespace Niconicome.ViewModels.Mainpage
 
             this.SendUrlToappCommand = new CommandBase<object>(_ => true, arg =>
             {
-                if (this.Playlist is null) return;
+                if (this.Playlist is null)
+                {
+                    this.SnackbarMessageQueue.Enqueue("プレイリストが選択されていないため、処理できません。");
+                    return;
+                }
+
                 if (arg is null || arg.AsNullable<ITreeVideoInfo>() is not ITreeVideoInfo videoInfo || videoInfo is null) return;
 
                 string folderPath = this.GetFolderPath();
-                if (!videoInfo.CheckDownloaded(folderPath) || videoInfo.GetFilePath(folderPath).IsNullOrEmpty()) return;
+                if (!videoInfo.CheckDownloaded(folderPath) || videoInfo.GetFilePath(folderPath).IsNullOrEmpty())
+                {
+                    this.SnackbarMessageQueue.Enqueue("動画が保存されていません。");
+                    return;
+                }
 
                 string? appPath = WS::Mainpage.SettingHandler.GetStringSetting(Settings.AppIdPath);
                 string param = WS::Mainpage.SettingHandler.GetStringSetting(Settings.AppIdParam) ?? string.Empty;
@@ -509,7 +608,12 @@ namespace Niconicome.ViewModels.Mainpage
 
             this.CreatePlaylistCommand = new CommandBase<string>(_ => true, arg =>
             {
-                if (this.Playlist is null) return;
+                if (this.Playlist is null)
+                {
+                    this.SnackbarMessageQueue.Enqueue("プレイリストが選択されていないため、処理できません。");
+                    return;
+                }
+
                 if (arg is null || arg is not string || arg.IsNullOrEmpty()) return;
                 Playlist::PlaylistType type = arg switch
                 {


### PR DESCRIPTION
# 概要
#4への対応
## 変更点
- VMに通知処理を追加
- Modelのダウンローダー・ネットワークハンドラに結果通知を追加
- 不要なコードの削除