### PR TITLE
[修正]動画を追加・削除際にプレイリストのタイトルが変更されるようにした

### DIFF
--- a/Niconicome/Models/Domain/Utils/DIFactory.cs
+++ b/Niconicome/Models/Domain/Utils/DIFactory.cs
@@ -51,7 +51,7 @@ namespace Niconicome.Models.Domain.Utils
             services.AddSingleton<DataBase::IDataBase, DataBase::DataBase>();
             services.AddTransient<Store::IPlaylistStoreHandler, Store::PlaylistStoreHandler>();
             services.AddTransient<Store::IVideoStoreHandler, Store::VideoStoreHandler>();
-            services.AddSingleton<Playlist::IPlaylistTreeHandler, Playlist::PlaylistTreeHandler>();
+            services.AddSingleton<Playlist::IPlaylistVideoHandler, Playlist::PlaylistTreeHandler>();
             services.AddTransient<Playlist::ITreePlaylistInfoHandler, Playlist::TreePlaylistInfoHandler>();
             services.AddTransient<DomainWatch::IWatchPageHtmlParser, DomainWatch::WatchPageHtmlParser>();
             services.AddTransient<DomainWatch::IWatchInfohandler, DomainWatch::WatchInfohandler>();

--- a/Niconicome/Models/Domain/Utils/DIFactory.cs
+++ b/Niconicome/Models/Domain/Utils/DIFactory.cs
@@ -51,7 +51,7 @@ namespace Niconicome.Models.Domain.Utils
             services.AddSingleton<DataBase::IDataBase, DataBase::DataBase>();
             services.AddTransient<Store::IPlaylistStoreHandler, Store::PlaylistStoreHandler>();
             services.AddTransient<Store::IVideoStoreHandler, Store::VideoStoreHandler>();
-            services.AddSingleton<Playlist::IPlaylistTreeHandler, Playlist::PlaylistTreeHandler>();
+            services.AddSingleton<Playlist::IPlaylistVideoHandler, Playlist::PlaylistVideoHandler>();
             services.AddTransient<Playlist::ITreePlaylistInfoHandler, Playlist::TreePlaylistInfoHandler>();
             services.AddTransient<DomainWatch::IWatchPageHtmlParser, DomainWatch::WatchPageHtmlParser>();
             services.AddTransient<DomainWatch::IWatchInfohandler, DomainWatch::WatchInfohandler>();

--- a/Niconicome/Models/Domain/Utils/DIFactory.cs
+++ b/Niconicome/Models/Domain/Utils/DIFactory.cs
@@ -51,7 +51,7 @@ namespace Niconicome.Models.Domain.Utils
             services.AddSingleton<DataBase::IDataBase, DataBase::DataBase>();
             services.AddTransient<Store::IPlaylistStoreHandler, Store::PlaylistStoreHandler>();
             services.AddTransient<Store::IVideoStoreHandler, Store::VideoStoreHandler>();
-            services.AddSingleton<Playlist::IPlaylistVideoHandler, Playlist::PlaylistTreeHandler>();
+            services.AddSingleton<Playlist::IPlaylistVideoHandler, Playlist::PlaylistVideoHandler>();
             services.AddTransient<Playlist::ITreePlaylistInfoHandler, Playlist::TreePlaylistInfoHandler>();
             services.AddTransient<DomainWatch::IWatchPageHtmlParser, DomainWatch::WatchPageHtmlParser>();
             services.AddTransient<DomainWatch::IWatchInfohandler, DomainWatch::WatchInfohandler>();

--- a/Niconicome/Models/Domain/Utils/DIFactory.cs
+++ b/Niconicome/Models/Domain/Utils/DIFactory.cs
@@ -51,7 +51,7 @@ namespace Niconicome.Models.Domain.Utils
             services.AddSingleton<DataBase::IDataBase, DataBase::DataBase>();
             services.AddTransient<Store::IPlaylistStoreHandler, Store::PlaylistStoreHandler>();
             services.AddTransient<Store::IVideoStoreHandler, Store::VideoStoreHandler>();
-            services.AddSingleton<Playlist::IPlaylistVideoHandler, Playlist::PlaylistVideoHandler>();
+            services.AddSingleton<Playlist::IPlaylistTreeHandler, Playlist::PlaylistTreeHandler>();
             services.AddTransient<Playlist::ITreePlaylistInfoHandler, Playlist::TreePlaylistInfoHandler>();
             services.AddTransient<DomainWatch::IWatchPageHtmlParser, DomainWatch::WatchPageHtmlParser>();
             services.AddTransient<DomainWatch::IWatchInfohandler, DomainWatch::WatchInfohandler>();

--- a/Niconicome/Models/Network/NetworkVideoHandler.cs
+++ b/Niconicome/Models/Network/NetworkVideoHandler.cs
@@ -39,7 +39,7 @@ namespace Niconicome.Models.Network
 
         private readonly IWatch wacthPagehandler;
 
-        private readonly IPlaylistTreeHandler playlistTreeHandler;
+        private readonly IPlaylistVideoHandler playlistTreeHandler;
 
         private readonly IVideoHandler videoHandler;
 
@@ -50,7 +50,7 @@ namespace Niconicome.Models.Network
 
         private readonly IVideoThumnailUtility videoThumnailUtility;
 
-        public NetworkVideoHandler(IWatch watchPageHandler, IPlaylistTreeHandler playlistTreeHandler, State::IMessageHandler messageHandler, IVideoFileStorehandler fileStorehandler, IVideoHandler videoHandler, IVideoThumnailUtility videoThumnailUtility)
+        public NetworkVideoHandler(IWatch watchPageHandler, IPlaylistVideoHandler playlistTreeHandler, State::IMessageHandler messageHandler, IVideoFileStorehandler fileStorehandler, IVideoHandler videoHandler, IVideoThumnailUtility videoThumnailUtility)
         {
             this.wacthPagehandler = watchPageHandler;
             this.playlistTreeHandler = playlistTreeHandler;

--- a/Niconicome/Models/Playlist/Tree.cs
+++ b/Niconicome/Models/Playlist/Tree.cs
@@ -21,9 +21,12 @@ using State = Niconicome.Models.Local.State;
 
 namespace Niconicome.Models.Playlist
 {
-    public interface IPlaylistTreeHandler
+    public interface IPlaylistVideoHandler
     {
         int AddPlaylist(int parentId);
+        void AddVideo(ITreeVideoInfo video, int playlistId);
+        void RemoveVideo(int videoId, int playlistId);
+        void UpdateVideo(ITreeVideoInfo video, int playlistId);
         void DeletePlaylist(int playlistID);
         void Update(ITreePlaylistInfo newpaylist);
         void Refresh();
@@ -52,8 +55,6 @@ namespace Niconicome.Models.Playlist
         ITreePlaylistInfo? GetParent(int id);
         ITreePlaylistInfo GetRoot();
         ITreePlaylistInfo GetTree();
-
-
     }
 
     public interface ITreePlaylistInfo : IClonable<ITreePlaylistInfo>
@@ -122,10 +123,12 @@ namespace Niconicome.Models.Playlist
 
     /// <summary>
     /// ViewModelから触るAPI
+    /// これはあくまでメモリ上への動画データしか変更できないため、
+    /// DBのデータを変更したい場合は別途VideoHandlerクラスのインスタンスを利用する必要がある
     /// </summary>
-    public class PlaylistTreeHandler : IPlaylistTreeHandler
+    public class PlaylistVideoHandler : IPlaylistVideoHandler
     {
-        public PlaylistTreeHandler(ITreePlaylistInfoHandler handler, IPlaylistStoreHandler playlistStoreHandler, IVideoStoreHandler videoStoreHandler, State::IErrorMessanger errorMessanger)
+        public PlaylistVideoHandler(ITreePlaylistInfoHandler handler, IPlaylistStoreHandler playlistStoreHandler, IVideoStoreHandler videoStoreHandler, State::IErrorMessanger errorMessanger)
         {
             this.Playlists = new ObservableCollection<ITreePlaylistInfo>();
             BindingOperations.EnableCollectionSynchronization(this.Playlists, new object());
@@ -146,37 +149,39 @@ namespace Niconicome.Models.Playlist
 
         public ObservableCollection<ITreePlaylistInfo> Playlists { get; private set; }
 
+        /// <summary>
+        /// 動画をメモリ上のプレイリストに追加する
+        /// </summary>
+        /// <param name="video"></param>
+        /// <param name="playlistId"></param>
+       　public void AddVideo(ITreeVideoInfo video, int playlistId)
+        {
+            var playlist = this.handler.GetPlaylist(playlistId);
+            playlist?.Videos.AddUnique(video,list=>!list.Any(v=>v.Id==video.Id));
+        }
 
         /// <summary>
-        /// プレイリストを初期化する
+        /// 動画をメモリ上のプレイリストから削除する
         /// </summary>
-        private void SetPlaylists()
+        /// <param name="videoId"></param>
+        /// <param name="playlistId"></param>
+        public void RemoveVideo(int videoId, int playlistId)
         {
-
-            //プレイリストを取得する
-            var playlists = this.playlistStoreHandler.GetAllPlaylists().Select(p =>
-             {
-                 var childPlaylists = this.playlistStoreHandler.GetChildPlaylists(p.Id);
-                 var converted = BindableTreePlaylistInfo.ConvertToTreePlaylistInfo(p, childPlaylists);
-                 if (p.Videos.Count > 0)
-                 {
-                     var videos = p.Videos.Select(v =>
-                     {
-                         var video = this.videoStoreHandler.GetVideo(v.Id);
-                         if (video is null) return new BindableTreeVideoInfo();
-                         return BindableTreeVideoInfo.ConvertToTreeVideoInfo(video);
-                     }).Where(v => !v.Title.IsNullOrEmpty()).Distinct(v => v.Id);
-                     converted.Videos.AddRange(videos);
-                 }
-                 return converted;
-             });
-
-
-            this.handler.MergeRange(playlists);
-            ITreePlaylistInfo treePlaylistInfo = handler.GetTree();
-            this.Playlists.Clear();
-            this.Playlists.Add(treePlaylistInfo);
+            var playlist = this.handler.GetPlaylist(playlistId);
+            playlist?.Videos.RemoveAll(v => v.Id == videoId);
         }
+
+        /// <summary>
+        /// 動画情報を更新する
+        /// </summary>
+        /// <param name="video"></param>
+        /// <param name="playlistId"></param>
+        public void UpdateVideo(ITreeVideoInfo video, int playlistId)
+        {
+            this.RemoveVideo(video.Id, playlistId);
+            this.AddVideo(video, playlistId);
+        }
+
 
         /// <summary>
         /// プレイリストを追加
@@ -313,6 +318,37 @@ namespace Niconicome.Models.Playlist
                 this.playlistStoreHandler.Update(newpaylist);
                 this.SetPlaylists();
             }
+        }
+
+        /// <summary>
+        /// プレイリストを初期化する
+        /// </summary>
+        private void SetPlaylists()
+        {
+
+            //プレイリストを取得する
+            var playlists = this.playlistStoreHandler.GetAllPlaylists().Select(p =>
+            {
+                var childPlaylists = this.playlistStoreHandler.GetChildPlaylists(p.Id);
+                var converted = BindableTreePlaylistInfo.ConvertToTreePlaylistInfo(p, childPlaylists);
+                if (p.Videos.Count > 0)
+                {
+                    var videos = p.Videos.Select(v =>
+                    {
+                        var video = this.videoStoreHandler.GetVideo(v.Id);
+                        if (video is null) return new BindableTreeVideoInfo();
+                        return BindableTreeVideoInfo.ConvertToTreeVideoInfo(video);
+                    }).Where(v => !v.Title.IsNullOrEmpty()).Distinct(v => v.Id);
+                    converted.Videos.AddRange(videos);
+                }
+                return converted;
+            });
+
+
+            this.handler.MergeRange(playlists);
+            ITreePlaylistInfo treePlaylistInfo = handler.GetTree();
+            this.Playlists.Clear();
+            this.Playlists.Add(treePlaylistInfo);
         }
 
     }

--- a/Niconicome/Models/Playlist/Video.cs
+++ b/Niconicome/Models/Playlist/Video.cs
@@ -20,10 +20,11 @@ namespace Niconicome.Models.Playlist
     public class VideoHandler : IVideoHandler
     {
 
-        public VideoHandler(IVideoStoreHandler storeHandler,IPlaylistStoreHandler playlistStoreHandler)
+        public VideoHandler(IVideoStoreHandler storeHandler,IPlaylistStoreHandler playlistStoreHandler,IPlaylistVideoHandler playlistVideoHandler)
         {
             this.videoStoreHandler = storeHandler;
             this.playlistStoreHandler = playlistStoreHandler;
+            this.playlistVideoHandler = playlistVideoHandler;
         }
 
         /// <summary>
@@ -31,7 +32,15 @@ namespace Niconicome.Models.Playlist
         /// </summary>
         private readonly IVideoStoreHandler videoStoreHandler;
 
+        /// <summary>
+        /// DB上のプレイリストにアクセスする
+        /// </summary>
         private readonly IPlaylistStoreHandler playlistStoreHandler;
+
+        /// <summary>
+        /// プレイリストツリーにアクセスする
+        /// </summary>
+        private readonly IPlaylistVideoHandler playlistVideoHandler;
 
         /// <summary>
         /// 動画を追加する
@@ -42,6 +51,7 @@ namespace Niconicome.Models.Playlist
         public int AddVideo(ITreeVideoInfo video, int playlidtId)
         {
             int id = this.playlistStoreHandler.AddVideo(video, playlidtId);
+            this.playlistVideoHandler.AddVideo(video, playlidtId);
             return id;
         }
 
@@ -53,6 +63,7 @@ namespace Niconicome.Models.Playlist
         public void RemoveVideo(int videoID, int playlistID)
         {
             this.playlistStoreHandler.RemoveVideo(videoID, playlistID);
+            this.playlistVideoHandler.RemoveVideo(videoID, playlistID);
         }
 
         /// <summary>

--- a/Niconicome/ViewModels/Mainpage/DownloadSettingsViewModel.cs
+++ b/Niconicome/ViewModels/Mainpage/DownloadSettingsViewModel.cs
@@ -105,7 +105,7 @@ namespace Niconicome.ViewModels.Mainpage
                            }
                        }
                    }
-                   else if (result.SucceededCount == 1)
+                   else if (result?.SucceededCount == 1)
                    {
                        if (result?.FirstVideo is not null)
                        {

--- a/Niconicome/ViewModels/Mainpage/PlayistTreeViewModel.cs
+++ b/Niconicome/ViewModels/Mainpage/PlayistTreeViewModel.cs
@@ -91,7 +91,7 @@ namespace Niconicome.ViewModels.Mainpage
         /// <summary>
         /// プレイリストのツリー
         /// </summary>
-        public IPlaylistTreeHandler? PlaylistTreeHandler { get; private set; }
+        public IPlaylistVideoHandler? PlaylistTreeHandler { get; private set; }
 
         /// <summary>
         /// プレイリストのツリー

--- a/Niconicome/ViewModels/Mainpage/VideoListViewmodel.cs
+++ b/Niconicome/ViewModels/Mainpage/VideoListViewmodel.cs
@@ -38,6 +38,9 @@ namespace Niconicome.ViewModels.Mainpage
             //プレイリスト選択変更イベントを購読する
             WS::Mainpage.CurrentPlaylist.SelectedItemChanged += this.OnSelectedPlaylistChanged;
 
+            //プレイリスト内容更新のイベントを購読する
+            WS::Mainpage.CurrentPlaylist.VideosChanged += (e, s) => this.ChangePlaylistTitle();
+
             this.showMessageBox = showMessageBox;
 
             this.SnackbarMessageQueue = WS::Mainpage.SnackbarMessageQueue;
@@ -896,7 +899,18 @@ namespace Niconicome.ViewModels.Mainpage
                 string name = WS::Mainpage.CurrentPlaylist.CurrentSelectedPlaylist.Name;
                 WS::Mainpage.Messagehandler.AppendMessage($"プレイリスト:{name}");
                 WS::Mainpage.SnackbarMessageQueue.Enqueue($"プレイリスト:{name}");
-                this.PlaylistTitle = $"{this.Playlist.Name}({this.Playlist.Videos.Count}件)";
+                this.ChangePlaylistTitle();
+            }
+        }
+
+        /// <summary>
+        /// プレイリストのタイトルを変更する
+        /// </summary>
+        private void ChangePlaylistTitle()
+        {
+            if (this.Playlist is not null)
+            {
+                this.PlaylistTitle = $"{this.Playlist.Name}({this.Videos.Count}件)";
             }
         }
 

--- a/Niconicome/Workspaces/Mainpage.cs
+++ b/Niconicome/Workspaces/Mainpage.cs
@@ -13,7 +13,7 @@ namespace Niconicome.Workspaces
     static class Mainpage
     {
         public static ISession Session { get; private set; } = DIFactory.Provider.GetRequiredService<ISession>();
-        public static IPlaylistVideoHandler PlaylistTree { get; private set; } = DIFactory.Provider.GetRequiredService<IPlaylistVideoHandler>();
+        public static IPlaylistTreeHandler PlaylistTree { get; private set; } = DIFactory.Provider.GetRequiredService<IPlaylistTreeHandler>();
         public static IVideoHandler VideoHandler { get; private set; } = DIFactory.Provider.GetRequiredService<IVideoHandler>();
         public static ICurrent CurrentPlaylist { get; private set; } = DIFactory.Provider.GetRequiredService<ICurrent>();
         public static IWatch Watch { get; private set; } = DIFactory.Provider.GetRequiredService<IWatch>();

--- a/Niconicome/Workspaces/Mainpage.cs
+++ b/Niconicome/Workspaces/Mainpage.cs
@@ -13,7 +13,7 @@ namespace Niconicome.Workspaces
     static class Mainpage
     {
         public static ISession Session { get; private set; } = DIFactory.Provider.GetRequiredService<ISession>();
-        public static IPlaylistTreeHandler PlaylistTree { get; private set; } = DIFactory.Provider.GetRequiredService<IPlaylistTreeHandler>();
+        public static IPlaylistVideoHandler PlaylistTree { get; private set; } = DIFactory.Provider.GetRequiredService<IPlaylistVideoHandler>();
         public static IVideoHandler VideoHandler { get; private set; } = DIFactory.Provider.GetRequiredService<IVideoHandler>();
         public static ICurrent CurrentPlaylist { get; private set; } = DIFactory.Provider.GetRequiredService<ICurrent>();
         public static IWatch Watch { get; private set; } = DIFactory.Provider.GetRequiredService<IWatch>();

--- a/Niconicome/Workspaces/SettingPage.cs
+++ b/Niconicome/Workspaces/SettingPage.cs
@@ -21,6 +21,6 @@ namespace Niconicome.Workspaces
         public static IRestore Restore { get; private set; } = DIFactory.Provider.GetRequiredService<IRestore>();
         public static MaterialDesign::ISnackbarMessageQueue SnackbarMessageQueue { get; private set; } = new MaterialDesign::SnackbarMessageQueue();
         public static ICurrent Current { get; private set; } = DIFactory.Provider.GetRequiredService<ICurrent>();
-        public static IPlaylistTreeHandler PlaylistTreeHandler { get; private set; } = DIFactory.Provider.GetRequiredService<IPlaylistTreeHandler>();
+        public static IPlaylistVideoHandler PlaylistTreeHandler { get; private set; } = DIFactory.Provider.GetRequiredService<IPlaylistVideoHandler>();
     }
 }

--- a/Niconicome/Workspaces/SettingPage.cs
+++ b/Niconicome/Workspaces/SettingPage.cs
@@ -21,6 +21,6 @@ namespace Niconicome.Workspaces
         public static IRestore Restore { get; private set; } = DIFactory.Provider.GetRequiredService<IRestore>();
         public static MaterialDesign::ISnackbarMessageQueue SnackbarMessageQueue { get; private set; } = new MaterialDesign::SnackbarMessageQueue();
         public static ICurrent Current { get; private set; } = DIFactory.Provider.GetRequiredService<ICurrent>();
-        public static IPlaylistVideoHandler PlaylistTreeHandler { get; private set; } = DIFactory.Provider.GetRequiredService<IPlaylistVideoHandler>();
+        public static IPlaylistTreeHandler PlaylistTreeHandler { get; private set; } = DIFactory.Provider.GetRequiredService<IPlaylistTreeHandler>();
     }
 }


### PR DESCRIPTION
# 概要
## 修正点
- 動画を追加・変更した際にプレイリストタイトルが変更されない問題を修正 ( fix #16 )
- DL設定のVMのnull参照を修正
## 変更点
- メモリ上での動画情報管理の仕組みを変更
プレイリストが保持する動画の一覧は```PlaylistVideoHandler```が責任を持ち、動画の詳細は```Current```が責任を持つようにした。
- PlaylistTreeHandlerクラスのクラス名を分かりやすいように変更