### PR TITLE
[修正]動画情報の取得失敗が握りつぶされる問題を修正

### DIFF
--- a/Niconicome/Models/Domain/Niconico/Video/Channel/ChannelVideoHandler.cs
+++ b/Niconicome/Models/Domain/Niconico/Video/Channel/ChannelVideoHandler.cs
@@ -126,10 +126,14 @@ namespace Niconicome.Models.Domain.Niconico.Video.Channel
         /// <returns></returns>
         private async Task<IEnumerable<ITreeVideoInfo>> ConvertToTreeVideoInfo(IEnumerable<string> ids)
         {
-            return await ids.Select(async (id) =>
+            return await ids.Select(async (id, index) =>
                 {
+                    if (index % 4 == 0)
+                    {
+                        await Task.Delay(10 * 1000);
+                    }
                     var videoInfo = new VIdeoInfo();
-                    var result = await this.watch.TryGetVideoInfoAsync(id, videoInfo,WatchInfo::WatchInfoOptions.NoDmcData);
+                    var result = await this.watch.TryGetVideoInfoAsync(id, videoInfo, WatchInfo::WatchInfoOptions.NoDmcData);
                     return videoInfo.ConvertToTreeVideoInfo();
                 }).WhenAll();
         }

--- a/Niconicome/Models/Domain/Niconico/Video/Channel/ChannelVideoHandler.cs
+++ b/Niconicome/Models/Domain/Niconico/Video/Channel/ChannelVideoHandler.cs
@@ -13,9 +13,17 @@ using WatchInfo = Niconicome.Models.Domain.Niconico.Watch;
 
 namespace Niconicome.Models.Domain.Niconico.Video.Channel
 {
+    public interface IChannelResult
+    {
+        List<ITreeVideoInfo> RetrievedVideos { get; }
+
+        int FailedCounts { get; }
+        bool IsSucceededAll { get; }
+    }
+
     public interface IChannelVideoHandler
     {
-        Task<List<ITreeVideoInfo>> GetVideosAsync(string channelId);
+        Task<IChannelResult> GetVideosAsync(string channelId, Action<string> onMessage);
         Exception? CurrentException { get; }
     }
 
@@ -42,8 +50,10 @@ namespace Niconicome.Models.Domain.Niconico.Video.Channel
         /// </summary>
         /// <param name="channelId"></param>
         /// <returns></returns>
-        public async Task<List<ITreeVideoInfo>> GetVideosAsync(string channelId)
+        public async Task<IChannelResult> GetVideosAsync(string channelId, Action<string> onMessage)
         {
+            var result = new ChannelResult();
+
             string html;
             try
             {
@@ -67,10 +77,11 @@ namespace Niconicome.Models.Domain.Niconico.Video.Channel
                 throw new InvalidOperationException();
             }
 
+            onMessage($"チャンネル内で{ids.Count()}件の動画を発見しました。");
             IEnumerable<ITreeVideoInfo> videos;
             try
             {
-                videos = await this.ConvertToTreeVideoInfo(ids);
+                videos = await this.ConvertToTreeVideoInfo(ids, onMessage, result);
             }
             catch (Exception e)
             {
@@ -78,7 +89,14 @@ namespace Niconicome.Models.Domain.Niconico.Video.Channel
                 throw new InvalidOperationException();
             }
 
-            return videos.ToList();
+            if (result.FailedCounts == 0)
+            {
+                result.IsSucceededAll = true;
+            }
+
+            result.RetrievedVideos.AddRange(videos);
+
+            return result;
         }
 
 
@@ -124,18 +142,45 @@ namespace Niconicome.Models.Domain.Niconico.Video.Channel
         /// </summary>
         /// <param name="ids"></param>
         /// <returns></returns>
-        private async Task<IEnumerable<ITreeVideoInfo>> ConvertToTreeVideoInfo(IEnumerable<string> ids)
+        private async Task<IEnumerable<ITreeVideoInfo>> ConvertToTreeVideoInfo(IEnumerable<string> ids, Action<string> onMessage, ChannelResult cResult)
         {
-            return await ids.Select(async (id, index) =>
+            int allVideos = ids.Count();
+            var allResult = new List<ITreeVideoInfo>();
+
+            foreach (var item in ids.Select((id, index) => new { id, index }))
+            {
+                if ((item.index + 1) % 5 == 0)
                 {
-                    if (index % 4 == 0)
-                    {
-                        await Task.Delay(10 * 1000);
-                    }
-                    var videoInfo = new VIdeoInfo();
-                    var result = await this.watch.TryGetVideoInfoAsync(id, videoInfo, WatchInfo::WatchInfoOptions.NoDmcData);
-                    return videoInfo.ConvertToTreeVideoInfo();
-                }).WhenAll();
+                    onMessage("待機中(10s)");
+                    await Task.Delay(10 * 1000);
+                }
+                onMessage($"{item.id}を取得中({item.index + 1}/{allVideos})");
+                var videoInfo = new VIdeoInfo();
+                var result = await this.watch.TryGetVideoInfoAsync(item.id, videoInfo, WatchInfo::WatchInfoOptions.NoDmcData);
+                if (!result.IsSucceeded)
+                {
+                    onMessage($"{item.id}の取得に失敗しました。(詳細:{result.Message})");
+                    cResult.FailedCounts++;
+                }
+                else
+                {
+                    allResult.Add(videoInfo.ConvertToTreeVideoInfo());
+                }
+            }
+
+            return allResult;
         }
+    }
+
+    /// <summary>
+    /// チャンネル動画の取得結果
+    /// </summary>
+    public class ChannelResult : IChannelResult
+    {
+        public List<ITreeVideoInfo> RetrievedVideos { get; init; } = new();
+
+        public int FailedCounts { get; set; }
+
+        public bool IsSucceededAll { get; set; }
     }
 }

--- a/Niconicome/Models/Network/NetworkVideoHandler.cs
+++ b/Niconicome/Models/Network/NetworkVideoHandler.cs
@@ -25,6 +25,7 @@ namespace Niconicome.Models.Network
 
     public interface INetworkResult
     {
+        bool IsFailed { get; set; }
         bool IsSucceededAll { get; set; }
         int SucceededCount { get; set; }
         int FailedCount { get; set; }
@@ -286,6 +287,12 @@ namespace Niconicome.Models.Network
 
     public class NetworkResult : INetworkResult
     {
+        /// <summary>
+        /// 処理失敗フラグ
+        /// </summary>
+        public bool IsFailed { get; set; }
+
+
         /// <summary>
         /// 全ての処理に成功
         /// </summary>


### PR DESCRIPTION
# 概要
## 修正
- 動画情報取得の際にスリープ処理を入れるように修正
- リモートプレイリストの取得に失敗した際の挙動を修正 ( #15 )
## 追加
- ```NetworkResult```クラスに失敗した際のフラグを追加