### PR TITLE
[修正]セグメントファイルの取得時の429 Too Many Requests対策 #27

### DIFF
--- a/Niconicome/Models/Domain/Niconico/Download/Video/VideoDownloader.cs
+++ b/Niconicome/Models/Domain/Niconico/Download/Video/VideoDownloader.cs
@@ -101,7 +101,7 @@ namespace Niconicome.Models.Domain.Niconico.Download.Video
                     this.messenger.RemoveHandler(onMessage);
                     return this.GetCancelledResult();
                 }
-                await session.EnsureSessionAsync(settings.NiconicoId,true);
+                await session.EnsureSessionAsync(settings.NiconicoId, true);
 
                 if (!session.IsSessionEnsured)
                 {
@@ -342,10 +342,10 @@ namespace Niconicome.Models.Domain.Niconico.Download.Video
                 var task = taskHandler.RetrieveNextTask();
                 byte[] data;
 
-                if ((task.SequenceZero + 1) % 200 == 0)
+                if ((task.SequenceZero + 1) > this.maxParallelDownloadCount)
                 {
                     this.isSleeping = true;
-                    await Task.Delay(20 * 1000, token);
+                    await Task.Delay(1 * 1000, token);
                     this.isSleeping = false;
                 }
 

--- a/Niconicome/Models/Domain/Niconico/Download/Video/VideoDownloader.cs
+++ b/Niconicome/Models/Domain/Niconico/Download/Video/VideoDownloader.cs
@@ -1,16 +1,15 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.IO;
-using System.Text;
+using System.Linq;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Niconicome.Extensions.System;
-using Niconicome.Models.Domain.Niconico.Watch;
-using Niconicome.Models.Domain.Niconico.Dmc;
-using Niconicome.Models.Domain.Utils;
 using Niconicome.Models.Domain.Local.Store;
+using Niconicome.Models.Domain.Niconico.Dmc;
+using Niconicome.Models.Domain.Niconico.Watch;
+using Niconicome.Models.Domain.Utils;
 
 namespace Niconicome.Models.Domain.Niconico.Download.Video
 {


### PR DESCRIPTION
# 概要
## 修正
- セグメントファイルの取得時に[429](https://developer.mozilla.org/ja/docs/Web/HTTP/Status/429)が頻発する問題を修正 #27 
## 変更
- VideoDownloader.csファイルのusingの削除と並び替え