### PR TITLE
[修正]有料動画の除法を取得できなかった問題を修正

### DIFF
--- a/Niconicome/Models/Domain/Niconico/Watch/WatchInfohandler.cs
+++ b/Niconicome/Models/Domain/Niconico/Watch/WatchInfohandler.cs
@@ -69,7 +69,7 @@ namespace Niconicome.Models.Domain.Niconico.Watch
     }
     public interface IWatchPageHtmlParser
     {
-        IDmcInfo GetDmcInfo(string sourceHtml, WatchInfoOptions options);
+        IDmcInfo GetDmcInfo(string sourceHtml,string niconicoId, WatchInfoOptions options);
         bool HasJsDataElement { get; }
     }
 
@@ -132,7 +132,7 @@ namespace Niconicome.Models.Domain.Niconico.Watch
             try
             {
                 //htmlをパース
-                info = this.parser.GetDmcInfo(source,options);
+                info = this.parser.GetDmcInfo(source,id,options);
             }
             catch (Exception e)
             {
@@ -167,10 +167,10 @@ namespace Niconicome.Models.Domain.Niconico.Watch
         /// </summary>
         /// <param name="sourceHtml"></param>
         /// <returns></returns>
-        public IDmcInfo GetDmcInfo(string sourceHtml, WatchInfoOptions options)
+        public IDmcInfo GetDmcInfo(string sourceHtml,string niconicoId, WatchInfoOptions options)
         {
             var document = HtmlParser.ParseDocument(sourceHtml);
-            return this.ConvertToDmcData(this.GetApiData(document),options);
+            return this.ConvertToDmcData(this.GetApiData(document),niconicoId,options);
         }
 
         /// <summary>
@@ -206,14 +206,14 @@ namespace Niconicome.Models.Domain.Niconico.Watch
         /// </summary>
         /// <param name="original"></param>
         /// <returns></returns>
-        private IDmcInfo ConvertToDmcData(WatchJson::DataApiData original, WatchInfoOptions options)
+        private IDmcInfo ConvertToDmcData(WatchJson::DataApiData original,string niconicoId, WatchInfoOptions options)
         {
             var info = new DmcInfo
             {
                 //タイトル
                 Title = original?.Video?.Title ?? string.Empty,
                 //ID
-                Id = original?.Video?.Id ?? string.Empty
+                Id = niconicoId,
             };
 
             //投稿日解析

--- a/Niconicome/Models/Network/NetworkVideoHandler.cs
+++ b/Niconicome/Models/Network/NetworkVideoHandler.cs
@@ -8,6 +8,7 @@ using Niconicome.Extensions.System.List;
 using Niconicome.Models.Domain.Local.Store;
 using Niconicome.Models.Playlist;
 using State = Niconicome.Models.Local.State;
+using DWatch = Niconicome.Models.Domain.Niconico.Watch;
 
 namespace Niconicome.Models.Network
 {
@@ -220,7 +221,7 @@ namespace Niconicome.Models.Network
 
                 onStarted(item.video, item.index);
 
-                IResult result = await this.wacthPagehandler.TryGetVideoInfoAsync(item.video.NiconicoId, videoInfo);
+                IResult result = await this.wacthPagehandler.TryGetVideoInfoAsync(item.video.NiconicoId, videoInfo, DWatch::WatchInfoOptions.NoDmcData);
 
                 if (result.IsSucceeded)
                 {
@@ -230,7 +231,7 @@ namespace Niconicome.Models.Network
                 }
                 else
                 {
-                    onFailed(result,item.video);
+                    onFailed(result, item.video);
                 }
             }
 


### PR DESCRIPTION
# 概要
## 修正
- 有料動画の除法を取得できなかった問題を修正 #37 
## 変更
- 動画IDをwatch-api-dataからではなくユーザーの入力を元に決定するように変更