### PR TITLE
[修正]複数のチャンネル動画のインポートに失敗する問題を修正

### DIFF
--- a/Niconicome/Models/Domain/Niconico/Video/Channel/ChannelVideoHandler.cs
+++ b/Niconicome/Models/Domain/Niconico/Video/Channel/ChannelVideoHandler.cs
@@ -149,7 +149,7 @@ namespace Niconicome.Models.Domain.Niconico.Video.Channel
 
             foreach (var item in ids.Select((id, index) => new { id, index }))
             {
-                if ((item.index + 1) % 5 == 0)
+                if ((item.index + 1) % 3 == 0)
                 {
                     onMessage("待機中(10s)");
                     await Task.Delay(10 * 1000);

--- a/Niconicome/Models/Network/NetworkVideoHandler.cs
+++ b/Niconicome/Models/Network/NetworkVideoHandler.cs
@@ -210,7 +210,7 @@ namespace Niconicome.Models.Network
 
             foreach (var item in ids.Select((video, index) => new { video, index }))
             {
-                if (item.index > 0 && (item.index + 1) % 5 == 0)
+                if (item.index > 0 && (item.index + 1) % 3 == 0)
                 {
                     onWaiting(item.video);
                     await Task.Delay(15 * 1000);

--- a/Niconicome/Models/Network/RemotePlaylist.cs
+++ b/Niconicome/Models/Network/RemotePlaylist.cs
@@ -1,14 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
-using UVideo = Niconicome.Models.Domain.Niconico.Video;
+using Niconicome.Models.Domain.Niconico.Video.Channel;
+using Niconicome.Models.Local.State;
 using Mylist = Niconicome.Models.Domain.Niconico.Mylist;
 using Playlist = Niconicome.Models.Playlist;
 using Search = Niconicome.Models.Domain.Niconico.Search;
-using Channel = Niconicome.Models.Domain.Niconico.Video.Channel;
-using Niconicome.Models.Domain.Niconico.Video.Channel;
+using UVideo = Niconicome.Models.Domain.Niconico.Video;
 
 namespace Niconicome.Models.Network
 {
@@ -18,20 +16,21 @@ namespace Niconicome.Models.Network
         Task<INetworkResult> TryGetMylistVideosAsync(string id, List<Playlist::ITreeVideoInfo> videos);
         Task<INetworkResult> TryGetUserVideosAsync(string id, List<Playlist::ITreeVideoInfo> videos);
         Task<INetworkResult> TryGetWatchLaterAsync(List<Playlist::ITreeVideoInfo> videos);
-        Task<INetworkResult> TryGetChannelVideosAsync(string id,List<Playlist::ITreeVideoInfo> videos,Action<string> onMessage);
-        Task<Search::ISearchResult> TrySearchVideosAsync(string keyword, Search::SearchType searchType,int page);
+        Task<INetworkResult> TryGetChannelVideosAsync(string id, List<Playlist::ITreeVideoInfo> videos, Action<string> onMessage);
+        Task<Search::ISearchResult> TrySearchVideosAsync(string keyword, Search::SearchType searchType, int page);
         string? ExceptionDetails { get; }
     }
 
     public class RemotePlaylistHandler : IRemotePlaylistHandler
     {
-        public RemotePlaylistHandler(Mylist::IMylistHandler mylistHandler, UVideo::IUserVideoHandler userHandler,Search::ISearch search,Mylist::IWatchLaterHandler watchLaterHandler,Channel::IChannelVideoHandler channelVideoHandler)
+        public RemotePlaylistHandler(Mylist::IMylistHandler mylistHandler, UVideo::IUserVideoHandler userHandler, Search::ISearch search, Mylist::IWatchLaterHandler watchLaterHandler, IChannelVideoHandler channelVideoHandler, IMessageHandler messageHandler)
         {
             this.mylistHandler = mylistHandler;
             this.userHandler = userHandler;
             this.searchClient = search;
             this.watchLaterHandler = watchLaterHandler;
             this.channelVideoHandler = channelVideoHandler;
+            this.messageHandler = messageHandler;
         }
 
         /// <summary>
@@ -57,12 +56,17 @@ namespace Niconicome.Models.Network
         /// <summary>
         /// チャンネル動画のハンドラ
         /// </summary>
-        private readonly Channel::IChannelVideoHandler channelVideoHandler;
+        private readonly IChannelVideoHandler channelVideoHandler;
 
         /// <summary>
         /// 例外の詳細情報
         /// </summary>
         public string? ExceptionDetails { get; private set; }
+
+        /// <summary>
+        /// 出力
+        /// </summary>
+        private readonly IMessageHandler messageHandler;
 
 
         /// <summary>
@@ -131,13 +135,14 @@ namespace Niconicome.Models.Network
         /// <param name="keyword"></param>
         /// <param name="searchType"></param>
         /// <returns></returns>
-        public async Task<Search::ISearchResult> TrySearchVideosAsync(string keyword, Search::SearchType searchType,int page)
+        public async Task<Search::ISearchResult> TrySearchVideosAsync(string keyword, Search::SearchType searchType, int page)
         {
             Search::ISearchResult result;
             try
             {
-                result = await this.searchClient.SearchAsync(keyword, searchType,page);
-            }catch
+                result = await this.searchClient.SearchAsync(keyword, searchType, page);
+            }
+            catch
             {
                 return new Search::SearchResult { Message = "不明なエラーが発生しました。" };
             }
@@ -186,7 +191,11 @@ namespace Niconicome.Models.Network
             IChannelResult result;
             try
             {
-                result = await this.channelVideoHandler.GetVideosAsync(id,onMessage);
+                result = await this.channelVideoHandler.GetVideosAsync(id, m =>
+                {
+                    onMessage(m);
+                    this.messageHandler.AppendMessage(m);
+                });
 
             }
             catch

--- a/Niconicome/ViewModels/Mainpage/VideoListViewmodel.cs
+++ b/Niconicome/ViewModels/Mainpage/VideoListViewmodel.cs
@@ -308,7 +308,7 @@ namespace Niconicome.ViewModels.Mainpage
                          RemoteType.Mylist => await WS::Mainpage.RemotePlaylistHandler.TryGetMylistVideosAsync(this.Playlist.RemoteId, videos),
                          RemoteType.UserVideos => await WS::Mainpage.RemotePlaylistHandler.TryGetUserVideosAsync(this.Playlist.RemoteId, videos),
                          RemoteType.WatchLater => await WS::Mainpage.RemotePlaylistHandler.TryGetWatchLaterAsync(videos),
-                         RemoteType.Channel => await WS::Mainpage.RemotePlaylistHandler.TryGetChannelVideosAsync(this.Playlist.RemoteId, videos, m => WS::Mainpage.Messagehandler.AppendMessage(m)),
+                         RemoteType.Channel => await WS::Mainpage.RemotePlaylistHandler.TryGetChannelVideosAsync(this.Playlist.RemoteId, videos, m => { }),
                          _ => new NetworkResult(),
                      };
 


### PR DESCRIPTION
# 概要
## 修正
- 複数のチャンネル動画のインポートに失敗する問題を修正 #39 
## 変更
- プレイリスト更新時のメッセージング処理を変更
- スリープ間隔を5から3に変更