### PR TITLE
[変更]チャンネル登録時に既に登録してある動画は再取得しないようにした #41

### DIFF
--- a/Niconicome/Models/Local/External/Inport/XenoImportGeneralManager.cs
+++ b/Niconicome/Models/Local/External/Inport/XenoImportGeneralManager.cs
@@ -58,7 +58,7 @@ namespace Niconicome.Models.Local.External.Import
 
     public interface IXenoImportGeneralManager
     {
-        Task<IXenoImportTaskResult> InportFromXeno(IXenoImportSettings settings, Action<string> onMessage,CancellationToken token);
+        Task<IXenoImportTaskResult> InportFromXeno(IXenoImportSettings settings, Action<string> onMessage, CancellationToken token);
     }
 
     /// <summary>
@@ -90,7 +90,7 @@ namespace Niconicome.Models.Local.External.Import
         /// <param name="settings"></param>
         /// <param name="onMessage"></param>
         /// <returns></returns>
-        public async Task<IXenoImportTaskResult> InportFromXeno(IXenoImportSettings settings, Action<string> onMessage,CancellationToken token)
+        public async Task<IXenoImportTaskResult> InportFromXeno(IXenoImportSettings settings, Action<string> onMessage, CancellationToken token)
         {
             var taskResult = new XenoImportTaskResult();
             var result = this.importManager.TryImportData(settings.DataFilePath, out Xeno.IXenoImportResult? inportResult);
@@ -107,12 +107,12 @@ namespace Niconicome.Models.Local.External.Import
             {
                 foreach (var child in inportResult.PlaylistInfo.Children)
                 {
-                    await this.AddPlaylistAsync(child, settings.TargetPlaylistId, taskResult, onMessage,token);
+                    await this.AddPlaylistAsync(child, settings.TargetPlaylistId, taskResult, onMessage, token);
                 }
             }
             else
             {
-                await this.AddPlaylistAsync(inportResult.PlaylistInfo, settings.TargetPlaylistId, taskResult, onMessage,token);
+                await this.AddPlaylistAsync(inportResult.PlaylistInfo, settings.TargetPlaylistId, taskResult, onMessage, token);
 
             }
 
@@ -147,7 +147,7 @@ namespace Niconicome.Models.Local.External.Import
             if (playlistInfo.IsRemotePlaylist)
             {
                 onMessage("待機中(10s)");
-                await Task.Delay(10 * 1000,token);
+                await Task.Delay(10 * 1000, token);
 
                 playlist.IsRemotePlaylist = true;
                 playlist.RemoteType = RemoteType.Channel;
@@ -155,7 +155,7 @@ namespace Niconicome.Models.Local.External.Import
                 this.playlistVideoHandler.SetAsRemotePlaylist(id, playlistInfo.RemoteId, playlistInfo.RemoteType);
 
                 var videos = new List<ITreeVideoInfo>();
-                var rResult = await this.remotePlaylistHandler.TryGetChannelVideosAsync(playlistInfo.RemoteId, videos, m => onMessage(m));
+                var rResult = await this.remotePlaylistHandler.TryGetChannelVideosAsync(playlistInfo.RemoteId, videos, new List<string>(), m => onMessage(m));
 
                 if (!rResult.IsFailed)
                 {

--- a/Niconicome/Models/Local/External/Inport/XenoImportGeneralManager.cs
+++ b/Niconicome/Models/Local/External/Inport/XenoImportGeneralManager.cs
@@ -155,7 +155,7 @@ namespace Niconicome.Models.Local.External.Import
                 this.playlistVideoHandler.SetAsRemotePlaylist(id, playlistInfo.RemoteId, playlistInfo.RemoteType);
 
                 var videos = new List<ITreeVideoInfo>();
-                var rResult = await this.remotePlaylistHandler.TryGetChannelVideosAsync(playlistInfo.RemoteId, videos, new List<string>(), m => onMessage(m));
+                var rResult = await this.remotePlaylistHandler.TryGetChannelVideosAsync(playlistInfo.RemoteId, videos, new List<string>(), m => { });
 
                 if (!rResult.IsFailed)
                 {
@@ -177,11 +177,9 @@ namespace Niconicome.Models.Local.External.Import
                 await this.networkVideoHandler.AddVideosAsync(playlistInfo.Videos.Select(v => v.NiconicoId), id, r =>
                 {
                     result.FailedVideoCount++;
-                    onMessage(r.Message);
                 }, v =>
                 {
                     result.SucceededVideoCount++;
-                    onMessage($"{v.NiconicoId}の登録に成功しました。");
                 });
             }
 

--- a/Niconicome/Models/Network/RemotePlaylist.cs
+++ b/Niconicome/Models/Network/RemotePlaylist.cs
@@ -16,7 +16,7 @@ namespace Niconicome.Models.Network
         Task<INetworkResult> TryGetMylistVideosAsync(string id, List<Playlist::ITreeVideoInfo> videos);
         Task<INetworkResult> TryGetUserVideosAsync(string id, List<Playlist::ITreeVideoInfo> videos);
         Task<INetworkResult> TryGetWatchLaterAsync(List<Playlist::ITreeVideoInfo> videos);
-        Task<INetworkResult> TryGetChannelVideosAsync(string id, List<Playlist::ITreeVideoInfo> videos, Action<string> onMessage);
+        Task<INetworkResult> TryGetChannelVideosAsync(string id, List<Playlist::ITreeVideoInfo> videos, IEnumerable<string> registeredVideo, Action<string> onMessage);
         Task<Search::ISearchResult> TrySearchVideosAsync(string keyword, Search::SearchType searchType, int page);
         string? ExceptionDetails { get; }
     }
@@ -185,17 +185,17 @@ namespace Niconicome.Models.Network
         /// <param name="id"></param>
         /// <param name="videos"></param>
         /// <returns></returns>
-        public async Task<INetworkResult> TryGetChannelVideosAsync(string id, List<Playlist::ITreeVideoInfo> videos, Action<string> onMessage)
+        public async Task<INetworkResult> TryGetChannelVideosAsync(string id, List<Playlist::ITreeVideoInfo> videos, IEnumerable<string> registeredVideo, Action<string> onMessage)
         {
             var resultInfo = new NetworkResult();
             IChannelResult result;
             try
             {
-                result = await this.channelVideoHandler.GetVideosAsync(id, m =>
-                {
-                    onMessage(m);
-                    this.messageHandler.AppendMessage(m);
-                });
+                result = await this.channelVideoHandler.GetVideosAsync(id, registeredVideo, m =>
+                 {
+                     onMessage(m);
+                     this.messageHandler.AppendMessage(m);
+                 });
 
             }
             catch

--- a/Niconicome/ViewModels/Mainpage/Subwindows/NetoworkVideoSettingsViewModel.cs
+++ b/Niconicome/ViewModels/Mainpage/Subwindows/NetoworkVideoSettingsViewModel.cs
@@ -78,7 +78,7 @@ namespace Niconicome.ViewModels.Mainpage.Subwindows
                         Playlist::RemoteType.Mylist => await WS::Mainpage.RemotePlaylistHandler.TryGetMylistVideosAsync(id, videos),
                         Playlist::RemoteType.UserVideos => await WS::Mainpage.RemotePlaylistHandler.TryGetUserVideosAsync(id, videos),
                         Playlist::RemoteType.WatchLater => await WS::Mainpage.RemotePlaylistHandler.TryGetWatchLaterAsync(videos),
-                        Playlist::RemoteType.Channel => await WS::Mainpage.RemotePlaylistHandler.TryGetChannelVideosAsync(id, videos, m => this.Message = m),
+                        Playlist::RemoteType.Channel => await WS::Mainpage.RemotePlaylistHandler.TryGetChannelVideosAsync(id, videos, new List<string>(), m => this.Message = m),
                         Playlist::RemoteType.None => new NetworkResult(),
                         _ => new NetworkResult()
                     };

--- a/Niconicome/ViewModels/Mainpage/VideoListViewmodel.cs
+++ b/Niconicome/ViewModels/Mainpage/VideoListViewmodel.cs
@@ -308,7 +308,7 @@ namespace Niconicome.ViewModels.Mainpage
                          RemoteType.Mylist => await WS::Mainpage.RemotePlaylistHandler.TryGetMylistVideosAsync(this.Playlist.RemoteId, videos),
                          RemoteType.UserVideos => await WS::Mainpage.RemotePlaylistHandler.TryGetUserVideosAsync(this.Playlist.RemoteId, videos),
                          RemoteType.WatchLater => await WS::Mainpage.RemotePlaylistHandler.TryGetWatchLaterAsync(videos),
-                         RemoteType.Channel => await WS::Mainpage.RemotePlaylistHandler.TryGetChannelVideosAsync(this.Playlist.RemoteId, videos, m => { }),
+                         RemoteType.Channel => await WS::Mainpage.RemotePlaylistHandler.TryGetChannelVideosAsync(this.Playlist.RemoteId, videos,this.Videos.Select(v=>v.NiconicoId), m => { }),
                          _ => new NetworkResult(),
                      };
 


### PR DESCRIPTION
# 概要
## 変更
- チャンネル登録時に既に登録してある動画は再取得しないようにした #41
- 検索結果登録時に既に登録してある動画は再取得しないようにした #41 
- Xenoインポートのメッセージング処理を変更