### PR TITLE
 [修正]Xenoインポートで突然失敗する問題を修正

### DIFF
--- a/Niconicome/Models/Local/State/LocalState.cs
+++ b/Niconicome/Models/Local/State/LocalState.cs
@@ -5,6 +5,7 @@
     {
         bool IsSettingWindowOpen { get; set; }
         bool IsDebugMode { get; set; }
+        bool IsImportingFromXeno { get; set; }
     }
 
     public class LocalState : ILocalState
@@ -18,6 +19,11 @@
         /// デバッグフラグ
         /// </summary>
         public bool IsDebugMode { get; set; }
+
+        /// <summary>
+        /// インポート中フラグ
+        /// </summary>
+        public bool IsImportingFromXeno { get; set; }
 
     }
 }

--- a/Niconicome/Models/Network/NetworkVideoHandler.cs
+++ b/Niconicome/Models/Network/NetworkVideoHandler.cs
@@ -9,6 +9,7 @@ using Niconicome.Models.Domain.Local.Store;
 using Niconicome.Models.Playlist;
 using State = Niconicome.Models.Local.State;
 using DWatch = Niconicome.Models.Domain.Niconico.Watch;
+using Niconicome.Extensions.System;
 
 namespace Niconicome.Models.Network
 {
@@ -110,6 +111,7 @@ namespace Niconicome.Models.Network
             if (netResult.SucceededCount == videosCount) netResult.IsSucceededAll = true;
 
             this.messageHandler.AppendMessage($"動画の追加処理が完了しました。({netResult.SucceededCount}件)");
+            this.messageHandler.AppendMessage("-".Repeat(50));
 
             return netResult;
         }
@@ -190,6 +192,7 @@ namespace Niconicome.Models.Network
             if (netResult.SucceededCount == videosCount) netResult.IsSucceededAll = true;
 
             this.messageHandler.AppendMessage($"{netResult.SucceededCount}件の動画情報を更新しました。");
+            this.messageHandler.AppendMessage("-".Repeat(50));
 
             return netResult;
         }

--- a/Niconicome/Models/Network/Watch.cs
+++ b/Niconicome/Models/Network/Watch.cs
@@ -37,11 +37,12 @@ namespace Niconicome.Models.Network
 
     public class Watch : IWatch
     {
-        public Watch(WatchInfo::IWatchInfohandler handler, ILocalSettingHandler settingHandler, INiconicoUtils utils)
+        public Watch(WatchInfo::IWatchInfohandler handler, ILocalSettingHandler settingHandler, INiconicoUtils utils, ILogger logger)
         {
             this.handler = handler;
             this.settingHandler = settingHandler;
             this.utils = utils;
+            this.logger = logger;
         }
 
         private readonly WatchInfo::IWatchInfohandler handler;
@@ -50,6 +51,8 @@ namespace Niconicome.Models.Network
 
         private readonly INiconicoUtils utils;
 
+        private readonly ILogger logger;
+
         /// <summary>
         /// 動画情報を取得する
         /// </summary>
@@ -57,6 +60,34 @@ namespace Niconicome.Models.Network
         /// <param name="info"></param>
         /// <returns></returns>
         public async Task<IResult> TryGetVideoInfoAsync(string nicoId, IVideoInfo info, WatchInfo::WatchInfoOptions options = WatchInfo::WatchInfoOptions.Default)
+        {
+            IResult result;
+
+            try
+            {
+                result = await this.GetVideoInfoAsync(nicoId, info, options);
+            }
+            catch (Exception e)
+            {
+                var failedResult = new Result();
+                this.logger.Error($"動画情報の取得中にエラーが発生しました。(id:{nicoId})", e);
+                failedResult.IsSucceeded = false;
+                failedResult.Message = $"動画情報の取得中にエラーが発生しました。(詳細: id:{nicoId}, message: {e.Message})";
+                return failedResult;
+            }
+
+            return result;
+
+        }
+
+        /// <summary>
+        /// 実装
+        /// </summary>
+        /// <param name="nicoId"></param>
+        /// <param name="info"></param>
+        /// <param name="options"></param>
+        /// <returns></returns>
+        private async Task<IResult> GetVideoInfoAsync(string nicoId, IVideoInfo info, WatchInfo::WatchInfoOptions options = WatchInfo::WatchInfoOptions.Default)
         {
             WatchInfo::IDomainVideoInfo retrieved;
             var result = new Result();
@@ -121,7 +152,6 @@ namespace Niconicome.Models.Network
 
 
             return result;
-
         }
     }
 

--- a/Niconicome/ViewModels/Setting/Pages/ImportPageViewModel.cs
+++ b/Niconicome/ViewModels/Setting/Pages/ImportPageViewModel.cs
@@ -56,6 +56,7 @@ namespace Niconicome.ViewModels.Setting.Pages
                  this.StartFetch();
                  this.XenoImportProgressVisibility = Visibility.Visible;
                  this.importCTS = new CancellationTokenSource();
+                 WS::SettingPage.State.IsImportingFromXeno = true;
 
                  var setting = new XenoImportSettings()
                  {
@@ -80,6 +81,7 @@ namespace Niconicome.ViewModels.Setting.Pages
 
                  this.CompleteFetch();
                  this.XenoImportProgressVisibility = Visibility.Hidden;
+                 WS::SettingPage.State.IsImportingFromXeno = false;
 
              });
 
@@ -89,6 +91,7 @@ namespace Niconicome.ViewModels.Setting.Pages
                 this.importCTS = null;
                 this.CompleteFetch();
                 this.XenoImportProgressVisibility = Visibility.Hidden;
+                WS::SettingPage.State.IsImportingFromXeno = false;
             });
 
             this.SelectedParent = WS::SettingPage.PlaylistTreeHandler.GetRootPlaylist();

--- a/Niconicome/ViewModels/Setting/SettingMainViewModel.cs
+++ b/Niconicome/ViewModels/Setting/SettingMainViewModel.cs
@@ -37,14 +37,14 @@ namespace Niconicome.ViewModels.Setting
             string uri = page switch
             {
                 SettingPages.FileSettings => "/Views/Setting/Pages/FileSettingsPage.xaml",
-                SettingPages.ExternalSoftwareSettings=> "/Views/Setting/Pages/ExternalSoftwareSettingsPage.xaml",
-                SettingPages.DebugSettings=> "/Views/Setting/Pages/DebugSettingsPage.xaml",
-                SettingPages.Restore=> "/Views/Setting/Pages/RestorePage.xaml",
+                SettingPages.ExternalSoftwareSettings => "/Views/Setting/Pages/ExternalSoftwareSettingsPage.xaml",
+                SettingPages.DebugSettings => "/Views/Setting/Pages/DebugSettingsPage.xaml",
+                SettingPages.Restore => "/Views/Setting/Pages/RestorePage.xaml",
                 SettingPages.ApplicationInfo => "/Views/Setting/Pages/AppinfoPage.xaml",
-                SettingPages.Import=> "/Views/Setting/Pages/ImportPage.xaml",
+                SettingPages.Import => "/Views/Setting/Pages/ImportPage.xaml",
                 _ => "/Views/Setting/Pages/EmptyPage.xaml",
             };
-            this.PageUri = new Uri(uri,UriKind.Relative);
+            this.PageUri = new Uri(uri, UriKind.Relative);
         }
 
         public MaterialDesign::ISnackbarMessageQueue SnackbarMessageQueue { get; init; }
@@ -69,19 +69,22 @@ namespace Niconicome.ViewModels.Setting
 
             //クリックした要素を取得
             Point pos = e.GetPosition(panel);
-            var target= Utils.HitTest<TextBlock>(panel, pos);
+            var target = Utils.HitTest<TextBlock>(panel, pos);
             if (target is null) return;
             var targetBorder = target.GetParent<Border>();
             if (targetBorder is null) return;
+            if (panel.DataContext is not SettingMainViewModel vm) return;
+            if (WS::SettingPage.State.IsImportingFromXeno)
+            {
+                vm.SnackbarMessageQueue.Enqueue("インポート作業中のためページ遷移できません。");
+                return;
+            }
 
             this.ResetSelectedItem();
             targetBorder.BorderBrush = Utils.ConvertToBrush("#757575");
             this.currentSelected = targetBorder;
 
-            if (panel.DataContext is SettingMainViewModel vm)
-            {
-                vm.Navigate(this.GetPages(target.Text));
-            }
+            vm.Navigate(this.GetPages(target.Text));
         }
 
         private Border? currentSelected;
@@ -106,8 +109,8 @@ namespace Niconicome.ViewModels.Setting
                 "URL設定" => SettingPages.UrlSettings,
                 "デバッグ設定" => SettingPages.DebugSettings,
                 "アプリ情報" => SettingPages.ApplicationInfo,
-                "回復"=>SettingPages.Restore,
-                "インポート"=>SettingPages.Import,
+                "回復" => SettingPages.Restore,
+                "インポート" => SettingPages.Import,
                 _ => SettingPages.None
             };
         }
@@ -126,7 +129,7 @@ namespace Niconicome.ViewModels.Setting
             this.AssociatedObject.Navigated += this.OnNavigate;
         }
 
-        private void OnNavigate(object? sender,EventArgs e)
+        private void OnNavigate(object? sender, EventArgs e)
         {
             if (this.AssociatedObject is null) return;
             while (this.AssociatedObject.CanGoBack)

--- a/Niconicome/Views/LogWindow.xaml
+++ b/Niconicome/Views/LogWindow.xaml
@@ -34,7 +34,7 @@
                 <materialDesign:PackIcon Kind="Clipboard"/>
             </Button>
         </DockPanel>
-        <TextBox Padding="4" BorderThickness="1" BorderBrush="#e7e7e7" IsReadOnly="True" Grid.Row="1" Text="{Binding Message,UpdateSourceTrigger=PropertyChanged,Mode=OneWay}">
+        <TextBox Padding="4" BorderThickness="1" BorderBrush="#e7e7e7" IsReadOnly="True" Grid.Row="1" Text="{Binding Message,UpdateSourceTrigger=PropertyChanged,Mode=OneWay}" TextWrapping="Wrap">
             <i:Interaction.Behaviors>
                 <vm:LogWindowBehavior/>
             </i:Interaction.Behaviors>


### PR DESCRIPTION
# 概要
## 修正
- Xenoインポートで突然失敗する問題を修正 #45
## 変更
- ログの改行を有効化
- ネットワーク処理の出力に区切りを挿入
- インポート作業中のページ遷移を禁止した