### PR TITLE
[追加]並列動画取得数に関する設定を追加

### DIFF
--- a/Niconicome/Models/Domain/Local/Store/Types/Settings.cs
+++ b/Niconicome/Models/Domain/Local/Store/Types/Settings.cs
@@ -139,5 +139,7 @@ namespace Niconicome.Models.Domain.Local.Store.Types
         public static string MaxCommentCount { get; private set; } = "maxcommentcount";
         public static string IsDownloadingVideoInfoEnable { get; private set; } = "isdownloadingvideoinfoenable";
         public static string IsDownloadingVideoInfoInJsonEnable { get; private set; } = "isdownloadingvideoinfoinjsonenable";
+        public static string MaxParallelFetchCount { get; private set; } = "maxparallelfetchcount";
+        public static string FetchSleepInterval { get; private set; } = "fetchsleepinterval";
     }
 }

--- a/Niconicome/Models/Local/LocalSettingHandler.cs
+++ b/Niconicome/Models/Local/LocalSettingHandler.cs
@@ -150,6 +150,8 @@ namespace Niconicome.Models.Local
                 Settings.LimitCommentsCount => STypes::SettingNames.LimitCommentCount,
                 Settings.DLVideoInfo => STypes::SettingNames.IsDownloadingVideoInfoEnable,
                 Settings.VideoInfoInJson => STypes::SettingNames.IsDownloadingVideoInfoInJsonEnable,
+                Settings.MaxFetchCount => STypes::SettingNames.MaxParallelFetchCount,
+                Settings.FetchSleepInterval => STypes::SettingNames.FetchSleepInterval,
                 _ => null
             };
         }
@@ -190,5 +192,7 @@ namespace Niconicome.Models.Local
         MaxCommentsCount,
         DLVideoInfo,
         VideoInfoInJson,
+        MaxFetchCount,
+        FetchSleepInterval,
     }
 }

--- a/Niconicome/ViewModels/Mainpage/DownloadSettingsViewModel.cs
+++ b/Niconicome/ViewModels/Mainpage/DownloadSettingsViewModel.cs
@@ -101,8 +101,6 @@ namespace Niconicome.ViewModels.Mainpage
                    var dlFromQueue = WS::Mainpage.SettingHandler.GetBoolSetting(Settings.DLAllFromQueue);
 
 
-                   WS::Mainpage.Messagehandler.AppendMessage($"動画のダウンロードを開始します。({videoCount}件)");
-                   this.SnackbarMessageQueue.Enqueue($"動画のダウンロードを開始します。({videoCount}件)");
                    WS::Mainpage.DownloadTasksHandler.StageVIdeos(videos, setting, allowDupe);
 
                    if (dlFromQueue)

--- a/Niconicome/ViewModels/Setting/Pages/DownloadSettingPageViewModel.cs
+++ b/Niconicome/ViewModels/Setting/Pages/DownloadSettingPageViewModel.cs
@@ -7,6 +7,7 @@ using WS = Niconicome.Workspaces;
 using Local = Niconicome.Models.Local;
 using System.ComponentModel;
 using Niconicome.Models.Local;
+using Niconicome.ViewModels.Mainpage.Utils;
 
 namespace Niconicome.ViewModels.Setting.Pages
 {
@@ -38,20 +39,42 @@ namespace Niconicome.ViewModels.Setting.Pages
             }
 
             this.isDownloadVideoInfoInJsonEnableField = WS::SettingPage.SettingHandler.GetBoolSetting(Settings.VideoInfoInJson);
-            this.maxParallelDownloadCountFIeld = maxP;
-            this.maxParallelSegmentDownloadCountField = maxSP;
             this.isDownloadFromQueueEnableField = WS::SettingPage.SettingHandler.GetBoolSetting(Settings.DLAllFromQueue);
             this.isDupeOnStageAllowedField = WS::SettingPage.SettingHandler.GetBoolSetting(Settings.AllowDupeOnStage);
             this.isOverrideVideoFileDTToUploadedDTField = WS::SettingPage.SettingHandler.GetBoolSetting(Settings.OverrideVideoFileDTToUploadedDT);
+
+            var n1 = new ComboboxItem<int>(1, "1");
+            var n2 = new ComboboxItem<int>(2, "2");
+            var n3 = new ComboboxItem<int>(3, "3");
+            var n4 = new ComboboxItem<int>(4, "4");
+
+            this.SelectableMaxParallelDownloadCount = new List<ComboboxItem<int>>() { n1, n2, n3, n4 };
+            this.maxParallelDownloadCountFIeld = maxP switch
+            {
+                1 => n1,
+                2 => n2,
+                3 => n3,
+                4 => n4,
+                _ => n4,
+            };
+            this.maxParallelSegmentDownloadCountField = maxSP switch
+            {
+                1 => n1,
+                2 => n2,
+                3 => n3,
+                4 => n4,
+                _ => n4,
+            };
+
         }
 
         private int commentOffsetField;
 
         private bool isAutoSwitchOffsetEnableField;
 
-        private int maxParallelDownloadCountFIeld;
+        private ComboboxItem<int> maxParallelDownloadCountFIeld;
 
-        private int maxParallelSegmentDownloadCountField;
+        private ComboboxItem<int> maxParallelSegmentDownloadCountField;
 
         private bool isDownloadFromQueueEnableField;
 
@@ -60,6 +83,8 @@ namespace Niconicome.ViewModels.Setting.Pages
         private bool isOverrideVideoFileDTToUploadedDTField;
 
         private bool isDownloadVideoInfoInJsonEnableField;
+
+        public List<ComboboxItem<int>> SelectableMaxParallelDownloadCount { get; init; }
 
         /// <summary>
         /// コメントのオフセット
@@ -82,23 +107,15 @@ namespace Niconicome.ViewModels.Setting.Pages
         /// <summary>
         /// 最大並列DL数
         /// </summary>
-        public int MaxParallelDownloadCount { get => this.maxParallelDownloadCountFIeld; set => this.Savesetting(ref this.maxParallelDownloadCountFIeld, value, Settings.MaxParallelDL); }
+        public ComboboxItem<int> MaxParallelDownloadCount { get => this.maxParallelDownloadCountFIeld; set => this.Savesetting(ref this.maxParallelDownloadCountFIeld, value, Settings.MaxParallelDL); }
 
         /// <summary>
         /// 最大セグメント並列DL数
         /// </summary>
-        public int MaxParallelSegmentDownloadCount
+        public ComboboxItem<int> MaxParallelSegmentDownloadCount
         {
             get => this.maxParallelSegmentDownloadCountField;
-            set
-            {
-                if (value > 5)
-                {
-                    WS::SettingPage.SnackbarMessageQueue.Enqueue("セグメントの最大並列ダウンロード数は5です");
-                    return;
-                }
-                this.Savesetting(ref this.maxParallelSegmentDownloadCountField, value, Settings.MaxParallelSegDl);
-            }
+            set => this.Savesetting(ref this.maxParallelSegmentDownloadCountField, value, Settings.MaxParallelSegDl);
         }
 
         /// <summary>
@@ -127,13 +144,27 @@ namespace Niconicome.ViewModels.Setting.Pages
     [Obsolete("Desinger", true)]
     class DownloadSettingPageViewModelD
     {
+        public DownloadSettingPageViewModelD()
+        {
+            var n1 = new ComboboxItem<int>(1, "1");
+            var n2 = new ComboboxItem<int>(2, "2");
+            var n3 = new ComboboxItem<int>(3, "3");
+            var n4 = new ComboboxItem<int>(4, "4");
+
+            this.SelectableMaxParallelDownloadCount = new List<ComboboxItem<int>>() { n1, n2, n3, n4 };
+            this.MaxParallelDownloadCount = n3;
+            this.MaxParallelSegmentDownloadCount = n4;
+        }
+
         public int CommentOffsetFIeld { get; set; } = 40;
 
         public bool IsAutoSwitchOffsetEnable { get; set; } = true;
 
-        public int MaxParallelDownloadCount { get; set; } = 3;
+        public List<ComboboxItem<int>> SelectableMaxParallelDownloadCount { get; init; }
 
-        public int MaxParallelSegmentDownloadCount { get; set; } = 1;
+        public ComboboxItem<int> MaxParallelDownloadCount { get; set; }
+
+        public ComboboxItem<int> MaxParallelSegmentDownloadCount { get; set; }
 
         public bool IsDownloadFromQueueEnable { get; set; } = true;
 

--- a/Niconicome/ViewModels/Setting/Pages/GeneralSettingsPageViewModel.cs
+++ b/Niconicome/ViewModels/Setting/Pages/GeneralSettingsPageViewModel.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Niconicome.Models.Auth;
 using Niconicome.Models.Local;
+using Niconicome.ViewModels.Mainpage.Utils;
 using WS = Niconicome.Workspaces;
 
 namespace Niconicome.ViewModels.Setting.Pages
@@ -14,8 +15,6 @@ namespace Niconicome.ViewModels.Setting.Pages
         public GeneralSettingsPageViewModel()
         {
             this.isAutologinEnableField = WS::SettingPage.SettingHandler.GetBoolSetting(Settings.AutologinEnable);
-            this.maxFetchParallelCountField = WS::SettingPage.SettingHandler.GetIntSetting(Settings.MaxFetchCount);
-            this.fetchSleepIntervalFIeld = WS::SettingPage.SettingHandler.GetIntSetting(Settings.FetchSleepInterval);
 
             var normal = new AutoLoginTypes(AutoLoginTypeString.Normal, "パスワードログイン");
             var wv2 = new AutoLoginTypes(AutoLoginTypeString.Webview2, "Webview2とCookieを共有");
@@ -29,15 +28,47 @@ namespace Niconicome.ViewModels.Setting.Pages
                 AutoLoginTypeString.Webview2 => wv2,
                 _ => normal
             };
+
+            var n1 = new ComboboxItem<int>(1, "1");
+            var n2 = new ComboboxItem<int>(2, "2");
+            var n3 = new ComboboxItem<int>(3, "3");
+            var n4 = new ComboboxItem<int>(4, "4");
+            var n5 = new ComboboxItem<int>(5, "5");
+
+            this.SelectablefetchSleepInterval = new List<ComboboxItem<int>> { n1, n2, n3, n4, n5 };
+            this.SelectableMaxParallelFetch = new List<ComboboxItem<int>>() { n1, n2, n3, n4 };
+
+
+            var maxFetchParallelCount = WS::SettingPage.SettingHandler.GetIntSetting(Settings.MaxFetchCount);
+            var fetchSleepInterval = WS::SettingPage.SettingHandler.GetIntSetting(Settings.FetchSleepInterval);
+
+            this.maxFetchParallelCountField = maxFetchParallelCount switch
+            {
+                1 => n1,
+                2 => n2,
+                3 => n3,
+                4 => n4,
+                _ => n4,
+            };
+
+            this.fetchSleepIntervalFIeld = fetchSleepInterval switch
+            {
+                1 => n1,
+                2 => n2,
+                3 => n3,
+                4 => n4,
+                5 => n5,
+                _ => n4,
+            };
         }
 
         private bool isAutologinEnableField;
 
         private string empty = string.Empty;
 
-        private int maxFetchParallelCountField;
+        private ComboboxItem<int> maxFetchParallelCountField;
 
-        private int fetchSleepIntervalFIeld;
+        private ComboboxItem<int> fetchSleepIntervalFIeld;
 
         private AutoLoginTypes selectedAutoLoginTypeField;
 
@@ -59,6 +90,16 @@ namespace Niconicome.ViewModels.Setting.Pages
         }
 
         /// <summary>
+        /// 同時取得数
+        /// </summary>
+        public List<ComboboxItem<int>> SelectableMaxParallelFetch { get; init; }
+
+        /// <summary>
+        /// スリープ間隔
+        /// </summary>
+        public List<ComboboxItem<int>> SelectablefetchSleepInterval { get; init; }
+
+        /// <summary>
         /// 自動ログイン
         /// </summary>
         public bool IsAutologinEnable { get => this.isAutologinEnableField; set => this.Savesetting(ref this.isAutologinEnableField, value, Settings.AutologinEnable); }
@@ -66,25 +107,49 @@ namespace Niconicome.ViewModels.Setting.Pages
         /// <summary>
         /// 動画情報最大並列取得数
         /// </summary>
-        public int MaxFetchParallelCount { get => this.maxFetchParallelCountField; set => this.Savesetting(ref this.maxFetchParallelCountField, value, Settings.MaxFetchCount); }
+        public ComboboxItem<int> MaxFetchParallelCount
+        {
+            get => this.maxFetchParallelCountField;
+            set => this.Savesetting(ref this.maxFetchParallelCountField, value, Settings.MaxFetchCount);
+        }
 
         /// <summary>
         /// 待機間隔
         /// </summary>
-        public int FetchSleepInterval { get => this.fetchSleepIntervalFIeld; set => this.Savesetting(ref this.fetchSleepIntervalFIeld, value, Settings.FetchSleepInterval); }
+        public ComboboxItem<int> FetchSleepInterval { get => this.fetchSleepIntervalFIeld; set => this.Savesetting(ref this.fetchSleepIntervalFIeld, value, Settings.FetchSleepInterval); }
     }
 
     class GeneralSettingsPageViewModelD
     {
+
+        public GeneralSettingsPageViewModelD()
+        {
+            var n1 = new ComboboxItem<int>(1, "1");
+            var n2 = new ComboboxItem<int>(2, "2");
+            var n3 = new ComboboxItem<int>(3, "3");
+            var n4 = new ComboboxItem<int>(4, "4");
+            var n5 = new ComboboxItem<int>(5, "5");
+
+            this.SelectablefetchSleepInterval = new List<ComboboxItem<int>> { n1, n2, n3, n4, n5 };
+            this.SelectableMaxParallelFetch = new List<ComboboxItem<int>>() { n1, n2, n3, n4 };
+
+            this.MaxFetchParallelCount = n3;
+            this.FetchSleepInterval = n5;
+        }
+
         public bool IsAutologinEnable { set; get; } = true;
 
         public List<AutoLoginTypes> SelectableAutoLoginTypes { get; init; } = new();
 
         public AutoLoginTypes SelectedAutoLoginType { get; init; } = new AutoLoginTypes(AutoLoginTypeString.Normal, "パスワード");
 
-        public int MaxFetchParallelCount { get; set; } = 3;
+        public List<ComboboxItem<int>> SelectableMaxParallelFetch { get; init; }
 
-        public int FetchSleepInterval { get; set; } = 5;
+        public List<ComboboxItem<int>> SelectablefetchSleepInterval { get; init; }
+
+        public ComboboxItem<int> MaxFetchParallelCount { get; set; } 
+
+        public ComboboxItem<int> FetchSleepInterval { get; set; }
 
     }
 
@@ -94,11 +159,24 @@ namespace Niconicome.ViewModels.Setting.Pages
         {
             this.Value = value;
             this.DisplayValue = displayvalue;
+
+            var n1 = new ComboboxItem<int>(1, "1");
+            var n2 = new ComboboxItem<int>(2, "2");
+            var n3 = new ComboboxItem<int>(3, "3");
+            var n4 = new ComboboxItem<int>(4, "4");
+            var n5 = new ComboboxItem<int>(5, "5");
+
+            this.SelectablefetchSleepInterval = new List<ComboboxItem<int>> { n1, n2, n3, n4, n5 };
+            this.SelectableMaxParallelFetch = new List<ComboboxItem<int>>() { n1, n2, n3, n4 };
         }
 
         public string Value { get; init; }
 
         public string DisplayValue { get; init; }
+
+        public List<ComboboxItem<int>> SelectableMaxParallelFetch { get; init; }
+
+        public List<ComboboxItem<int>> SelectablefetchSleepInterval { get; init; }
 
 
     }

--- a/Niconicome/ViewModels/Setting/Pages/GeneralSettingsPageViewModel.cs
+++ b/Niconicome/ViewModels/Setting/Pages/GeneralSettingsPageViewModel.cs
@@ -14,6 +14,8 @@ namespace Niconicome.ViewModels.Setting.Pages
         public GeneralSettingsPageViewModel()
         {
             this.isAutologinEnableField = WS::SettingPage.SettingHandler.GetBoolSetting(Settings.AutologinEnable);
+            this.maxFetchParallelCountField = WS::SettingPage.SettingHandler.GetIntSetting(Settings.MaxFetchCount);
+            this.fetchSleepIntervalFIeld = WS::SettingPage.SettingHandler.GetIntSetting(Settings.FetchSleepInterval);
 
             var normal = new AutoLoginTypes(AutoLoginTypeString.Normal, "パスワードログイン");
             var wv2 = new AutoLoginTypes(AutoLoginTypeString.Webview2, "Webview2とCookieを共有");
@@ -32,6 +34,10 @@ namespace Niconicome.ViewModels.Setting.Pages
         private bool isAutologinEnableField;
 
         private string empty = string.Empty;
+
+        private int maxFetchParallelCountField;
+
+        private int fetchSleepIntervalFIeld;
 
         private AutoLoginTypes selectedAutoLoginTypeField;
 
@@ -56,21 +62,29 @@ namespace Niconicome.ViewModels.Setting.Pages
         /// 自動ログイン
         /// </summary>
         public bool IsAutologinEnable { get => this.isAutologinEnableField; set => this.Savesetting(ref this.isAutologinEnableField, value, Settings.AutologinEnable); }
+
+        /// <summary>
+        /// 動画情報最大並列取得数
+        /// </summary>
+        public int MaxFetchParallelCount { get => this.maxFetchParallelCountField; set => this.Savesetting(ref this.maxFetchParallelCountField, value, Settings.MaxFetchCount); }
+
+        /// <summary>
+        /// 待機間隔
+        /// </summary>
+        public int FetchSleepInterval { get => this.fetchSleepIntervalFIeld; set => this.Savesetting(ref this.fetchSleepIntervalFIeld, value, Settings.FetchSleepInterval); }
     }
 
     class GeneralSettingsPageViewModelD
     {
         public bool IsAutologinEnable { set; get; } = true;
 
-        /// <summary>
-        /// 選択可能な自動ログインの種別
-        /// </summary>
         public List<AutoLoginTypes> SelectableAutoLoginTypes { get; init; } = new();
 
-        /// <summary>
-        /// 自動ログインの種別
-        /// </summary>
         public AutoLoginTypes SelectedAutoLoginType { get; init; } = new AutoLoginTypes(AutoLoginTypeString.Normal, "パスワード");
+
+        public int MaxFetchParallelCount { get; set; } = 3;
+
+        public int FetchSleepInterval { get; set; } = 5;
 
     }
 

--- a/Niconicome/ViewModels/Setting/SettingaBase.cs
+++ b/Niconicome/ViewModels/Setting/SettingaBase.cs
@@ -4,6 +4,7 @@ using System.Windows.Navigation;
 using Microsoft.Xaml.Behaviors;
 using Niconicome.Extensions.System.Diagnostics;
 using Niconicome.Models.Local;
+using Niconicome.ViewModels.Mainpage.Utils;
 using WS = Niconicome.Workspaces;
 
 namespace Niconicome.ViewModels.Setting
@@ -40,6 +41,39 @@ namespace Niconicome.ViewModels.Setting
             }
 
             fiels = data;
+            this.OnPropertyChanged(propertyname);
+
+        }
+
+        /// <summary>
+        /// 設定を保存する
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="fiels"></param>
+        /// <param name="data"></param>
+        /// <param name="settingname"></param>
+        /// <param name="propertyname"></param>
+        protected void Savesetting<T>(ref ComboboxItem<T> field, ComboboxItem<T> data, Settings setting, [CallerMemberName] string? propertyname = null)
+        {
+            if (data.Value is bool boolData)
+            {
+                WS::SettingPage.SettingHandler.SaveSetting(boolData, setting);
+            }
+            else if (data.Value is string stringData)
+            {
+                WS::SettingPage.SettingHandler.SaveSetting(stringData, setting);
+            }
+            else if (data.Value is int intData)
+            {
+                WS::SettingPage.SettingHandler.SaveSetting(intData, setting);
+            }
+            else
+            {
+                return;
+            }
+
+            field = data;
+
             this.OnPropertyChanged(propertyname);
 
         }

--- a/Niconicome/Views/Setting/Pages/DownloadSettingPage.xaml
+++ b/Niconicome/Views/Setting/Pages/DownloadSettingPage.xaml
@@ -38,16 +38,6 @@
                 <TextBox HorizontalAlignment="Right" Margin="10 0" Width="60" Text="{Binding CommentOffsetFIeld,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}" HorizontalContentAlignment="Right"/>
             </DockPanel>
             <Separator BorderThickness="1" BorderBrush="#e7e7e7" Margin="0 8"/>
-             <DockPanel Visibility="Collapsed">
-                <materialDesign:PackIcon Kind="AutoFix" Foreground="SkyBlue">
-                    <materialDesign:PackIcon.RenderTransform>
-                        <TranslateTransform Y="7"/>
-                    </materialDesign:PackIcon.RenderTransform>
-                </materialDesign:PackIcon>
-                <Label Content="公式動画でコメントのオフセットを無効にする(推奨)"/>
-                <ToggleButton HorizontalAlignment="Right" Margin="10 0" IsChecked="{Binding IsAutoSwitchOffsetEnable}"/>
-            </DockPanel>
-            <Separator BorderThickness="1" BorderBrush="#e7e7e7" Margin="0 8"/>
             <DockPanel>
                 <materialDesign:PackIcon Kind="DownloadMultiple" Foreground="SkyBlue">
                     <materialDesign:PackIcon.RenderTransform>
@@ -55,7 +45,7 @@
                     </materialDesign:PackIcon.RenderTransform>
                 </materialDesign:PackIcon>
                 <Label Content="最大並列ダウンロード数" ToolTip="大きなすぎる場合、失敗する確率が高くなります"/>
-                <TextBox Text="{Binding MaxParallelDownloadCount,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}" HorizontalAlignment="Right" Margin="10 0" Width="60" HorizontalContentAlignment="Right" />
+                <ComboBox SelectedItem="{Binding MaxParallelDownloadCount,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}" HorizontalAlignment="Right" Margin="10 0" Width="60" HorizontalContentAlignment="Right" ItemsSource="{Binding SelectableMaxParallelDownloadCount}" DisplayMemberPath="DisplayValue"/>
             </DockPanel>
             <Separator BorderThickness="1" BorderBrush="#e7e7e7" Margin="0 8"/>
             <DockPanel>
@@ -65,7 +55,7 @@
                     </materialDesign:PackIcon.RenderTransform>
                 </materialDesign:PackIcon>
                 <Label Content="HLSセグメントファイルの最大並列ダウンロード数（推奨値：1）" />
-                <TextBox Text="{Binding MaxParallelSegmentDownloadCount,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}" HorizontalAlignment="Right" Margin="10 0" Width="60" HorizontalContentAlignment="Right" />
+                <ComboBox SelectedItem="{Binding MaxParallelSegmentDownloadCount,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}" HorizontalAlignment="Right" Margin="10 0" Width="60" HorizontalContentAlignment="Right" ItemsSource="{Binding SelectableMaxParallelDownloadCount}" DisplayMemberPath="DisplayValue" />
             </DockPanel>
             <Separator BorderThickness="1" BorderBrush="#e7e7e7" Margin="0 8"/>
             <DockPanel>

--- a/Niconicome/Views/Setting/Pages/DownloadSettingPage.xaml
+++ b/Niconicome/Views/Setting/Pages/DownloadSettingPage.xaml
@@ -89,7 +89,7 @@
             </DockPanel>
             <Separator BorderThickness="1" BorderBrush="#e7e7e7" Margin="0 8"/>
             <DockPanel>
-                <materialDesign:PackIcon Kind="SortCalendarDescending" Foreground="SkyBlue">
+                <materialDesign:PackIcon Kind="CodeJson" Foreground="SkyBlue">
                     <materialDesign:PackIcon.RenderTransform>
                         <TranslateTransform Y="7"/>
                     </materialDesign:PackIcon.RenderTransform>

--- a/Niconicome/Views/Setting/Pages/GeneralPage.xaml
+++ b/Niconicome/Views/Setting/Pages/GeneralPage.xaml
@@ -48,6 +48,26 @@
                 <ComboBox HorizontalAlignment="Right" Width="300" ItemsSource="{Binding SelectableAutoLoginTypes}" SelectedItem="{Binding SelectedAutoLoginType}" DisplayMemberPath="DisplayValue"/>
             </DockPanel>
             <Separator BorderThickness="1" BorderBrush="#e7e7e7" Margin="0 8"/>
+            <DockPanel>
+                <materialDesign:PackIcon Kind="DownloadNetwork" Foreground="SkyBlue">
+                    <materialDesign:PackIcon.RenderTransform>
+                        <TranslateTransform Y="7"/>
+                    </materialDesign:PackIcon.RenderTransform>
+                </materialDesign:PackIcon>
+                <Label Content="動画情報取得時の並列取得数"/>
+                <TextBox Text="{Binding MaxFetchParallelCount,UpdateSourceTrigger=PropertyChanged}" HorizontalAlignment="Right" Width="200"/>
+            </DockPanel>
+            <Separator BorderThickness="1" BorderBrush="#e7e7e7" Margin="0 8"/>
+            <DockPanel>
+                <materialDesign:PackIcon Kind="Sleep" Foreground="SkyBlue">
+                    <materialDesign:PackIcon.RenderTransform>
+                        <TranslateTransform Y="7"/>
+                    </materialDesign:PackIcon.RenderTransform>
+                </materialDesign:PackIcon>
+                <Label Content="動画情報取得時の待機間隔(動画数)"/>
+                <TextBox Text="{Binding FetchSleepInterval,UpdateSourceTrigger=PropertyChanged}" HorizontalAlignment="Right" Width="200"/>
+            </DockPanel>
+            <Separator BorderThickness="1" BorderBrush="#e7e7e7" Margin="0 8"/>
         </StackPanel>
         
     </Grid>

--- a/Niconicome/Views/Setting/Pages/GeneralPage.xaml
+++ b/Niconicome/Views/Setting/Pages/GeneralPage.xaml
@@ -55,7 +55,7 @@
                     </materialDesign:PackIcon.RenderTransform>
                 </materialDesign:PackIcon>
                 <Label Content="動画情報取得時の並列取得数"/>
-                <TextBox Text="{Binding MaxFetchParallelCount,UpdateSourceTrigger=PropertyChanged}" HorizontalAlignment="Right" Width="200"/>
+                <ComboBox SelectedItem="{Binding MaxFetchParallelCount,UpdateSourceTrigger=PropertyChanged}" ItemsSource="{Binding SelectableMaxParallelFetch}" DisplayMemberPath="DisplayValue" HorizontalContentAlignment="Right" HorizontalAlignment="Right" Width="100"/>
             </DockPanel>
             <Separator BorderThickness="1" BorderBrush="#e7e7e7" Margin="0 8"/>
             <DockPanel>
@@ -65,7 +65,7 @@
                     </materialDesign:PackIcon.RenderTransform>
                 </materialDesign:PackIcon>
                 <Label Content="動画情報取得時の待機間隔(動画数)"/>
-                <TextBox Text="{Binding FetchSleepInterval,UpdateSourceTrigger=PropertyChanged}" HorizontalAlignment="Right" Width="200"/>
+                <ComboBox SelectedItem="{Binding FetchSleepInterval,UpdateSourceTrigger=PropertyChanged}" ItemsSource="{Binding SelectablefetchSleepInterval}" DisplayMemberPath="DisplayValue" HorizontalContentAlignment="Right" HorizontalAlignment="Right" Width="100"/>
             </DockPanel>
             <Separator BorderThickness="1" BorderBrush="#e7e7e7" Margin="0 8"/>
         </StackPanel>


### PR DESCRIPTION
# 概要
## 追加
- 並列動画取得数に関する設定を追加 #138 
## 変更
- 数値系の設定をセレクトボックスに変更
## 修正
- DL時に二重にメッセージが登録される問題を修正