### PR TITLE
Develop

### DIFF
--- a/.github/ISSUE_TEMPLATE/------.md
+++ b/.github/ISSUE_TEMPLATE/------.md
@@ -16,5 +16,5 @@ assignees: Hayao-H
 **ご要望を実現することが出来なかった場合、受け入れ可能な代替案はありますか？**
 具体的な説明をお願いします
 
-**Additional context**
-Add any other context or screenshots about the feature request here.
+**備考**
+

--- a/.github/ISSUE_TEMPLATE/----.md
+++ b/.github/ISSUE_TEMPLATE/----.md
@@ -19,7 +19,7 @@ assignees: Hayao-H
 **スクリーンショット**
 可能であれば
 
-**Desktop (please complete the following information):**
+**Desktop (下記の情報の記載をお願いします):**
  - OS:  最低限OSバージョン・64bitか32bitかなどをお願いします
  - Version: アプリケーションのバージョン
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,9 +48,6 @@ jobs:
     if: contains(github.ref, 'tags/v')
     needs: [test, release]
     runs-on: windows-latest
-    strategy:
-      matrix:
-        rid: [win-x64, win-x86]
     env:
       DOTNET_CLI_TELEMETRY_OPTOUT: 1
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
@@ -77,7 +74,7 @@ jobs:
         mkdir ffmpeg/bin
         cd tmp
         $ProgressPreference = 'SilentlyContinue'
-        Invoke-WebRequest https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2021-03-10-12-35/ffmpeg-N-101450-gc35e456f54-win64-lgpl.zip -o ffbin.zip
+        Invoke-WebRequest https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2021-03-27-12-39/ffmpeg-n4.3.2-161-g4383b9e8a3-win64-lgpl-4.3.zip -o ffbin.zip
         Expand-Archive ffbin.zip -Force
         $item = Get-Childitem -Recurse -Filter ffmpeg.exe
         cd ..
@@ -87,16 +84,27 @@ jobs:
     - name: Build
       shell: powershell
       run: |
-        dotnet publish ./Niconicome/Niconicome.csproj  -c Release -r ${{matrix.rid}} -p:PublishSingleFile=true --self-contained true  -o ${{ matrix.rid }}
-        Copy-Item -Recurse ffmpeg/bin ${{ matrix.rid }}
-        Compress-Archive -Path ${{ matrix.rid }} -DestinationPath ${{ matrix.rid }}.zip -CompressionLevel fastest
+        dotnet publish ./Niconicome/Niconicome.csproj  -c Release -r win-x64 -p:PublishSingleFile=true --self-contained true  -o win-x64
+        dotnet publish ./Niconicome/Niconicome.csproj  -c Release -r win-x86 -p:PublishSingleFile=true --self-contained true  -o win-x86
+        Copy-Item -Recurse ffmpeg/bin win-x64
+        Copy-Item -Recurse ffmpeg/bin win-x86
+        Compress-Archive -Path win-x64 -DestinationPath win-x64.zip -CompressionLevel fastest
+        Compress-Archive -Path win-x86 -DestinationPath win-x86.zip -CompressionLevel fastest
     - name: Upload Release Asset
-      id: upload-release-asset 
       uses: actions/upload-release-asset@v1.0.1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ needs.release.outputs.upload_url }}
-        asset_path: ./${{ matrix.rid }}.zip
-        asset_name: niconicome-${{ matrix.rid }}.zip
+        asset_path: ./win-x64.zip
+        asset_name: niconicome-win-x64.zip
+        asset_content_type: application/zip
+    - name: Upload Release Asset
+      uses: actions/upload-release-asset@v1.0.1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ needs.release.outputs.upload_url }}
+        asset_path: ./win-x86.zip
+        asset_name: niconicome-win-x86.zip
         asset_content_type: application/zip

--- a/Niconicome/App.xaml
+++ b/Niconicome/App.xaml
@@ -1,15 +1,15 @@
 ﻿<Application x:Class="Niconicome.App"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+             ShutdownMode="OnMainWindowClose"
              StartupUri="Views/MainWindow.xaml">
     <Application.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="/Style/WindowStyle.xaml"/>
-                <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Light.xaml" />
+                <materialDesign:BundledTheme BaseTheme="Light" PrimaryColor="Purple" SecondaryColor="Lime"  />
                 <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Defaults.xaml" />
-                <ResourceDictionary Source="pack://application:,,,/MaterialDesignColors;component/Themes/Recommended/Primary/MaterialDesignColor.Blue.xaml" />
-                <ResourceDictionary Source="pack://application:,,,/MaterialDesignColors;component/Themes/Recommended/Accent/MaterialDesignColor.Lime.xaml" />
+                <ResourceDictionary Source="/Style/WindowStyle.xaml"/>
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </Application.Resources>

--- a/Niconicome/Extensions/System/List/ObjectModel.cs
+++ b/Niconicome/Extensions/System/List/ObjectModel.cs
@@ -2,14 +2,12 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Niconicome.Extensions.System.List
 {
     static class ObjectModel
     {
-        public static void Addrange<T>(this ObservableCollection<T> list,IEnumerable<T>? sources)
+        public static void Addrange<T>(this ObservableCollection<T> list, IEnumerable<T>? sources)
         {
             if (sources is null) return;
             foreach (var source in sources)
@@ -19,15 +17,28 @@ namespace Niconicome.Extensions.System.List
         }
 
         /// <summary>
+        /// 条件に一致した要素を全て削除する
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="list"></param>
+        /// <param name="predicate"></param>
+        public static void RemoveAll<T>(this ObservableCollection<T> list, Predicate<T> predicate)
+        {
+            var copied = list.Copy();
+            list.Clear();
+            list.Addrange(copied.Where(item => !predicate(item)));
+        }
+
+        /// <summary>
         /// FindIndexの代替。発見できなかった場合は-1を返す。
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="list"></param>
         /// <param name="predicate"></param>
         /// <returns></returns>
-        public static int FindIndex<T>(this ObservableCollection<T> list,Predicate<T> predicate)
+        public static int FindIndex<T>(this ObservableCollection<T> list, Predicate<T> predicate)
         {
-            foreach (var elm in list.Select((content, index) =>new { index,content}))
+            foreach (var elm in list.Select((content, index) => new { index, content }))
             {
                 if (predicate(elm.content)) return elm.index;
             }

--- a/Niconicome/Models/Auth/AutoLogin.cs
+++ b/Niconicome/Models/Auth/AutoLogin.cs
@@ -1,0 +1,113 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.VisualBasic;
+using Niconicome.Models.Domain.Niconico;
+using Niconicome.Models.Local;
+
+namespace Niconicome.Models.Auth
+{
+    interface IAutoLogin
+    {
+        bool IsAUtologinEnable { get; }
+        bool Canlogin();
+        Task<bool> LoginAsync();
+    }
+
+    class AutoLogin : IAutoLogin
+    {
+        public AutoLogin(ISession session, IAccountManager accountManager, ILocalSettingHandler settingHandler, IWebview2SharedLogin webview2SharedLogin)
+        {
+            this.session = session;
+            this.accountManager = accountManager;
+            this.settingHandler = settingHandler;
+            this.webview2SharedLogin = webview2SharedLogin;
+        }
+
+        private readonly ISession session;
+
+        private readonly IAccountManager accountManager;
+
+        private readonly ILocalSettingHandler settingHandler;
+
+        private readonly IWebview2SharedLogin webview2SharedLogin;
+
+        /// <summary>
+        /// 自動ログインが可能であるかどうか
+        /// </summary>
+        /// <returns></returns>
+        public bool Canlogin()
+        {
+            var type = this.GetAutoLoginType();
+
+            return type != AutoLoginType.None;
+        }
+
+        /// <summary>
+        /// ログインを試行する
+        /// </summary>
+        /// <returns></returns>
+        public async Task<bool> LoginAsync()
+        {
+            if (!this.Canlogin()) throw new InvalidOperationException("自動ログインは不可能です。");
+
+            bool result = false;
+            var type = this.GetAutoLoginType();
+
+            if (type == AutoLoginType.Normal)
+            {
+                var cred = this.accountManager.GetUserCredential();
+                result = await this.session.Login(cred);
+            }
+            else if (type == AutoLoginType.Webview2)
+            {
+                result = await this.webview2SharedLogin.TryLogin();
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// 自動ログインが有効であるかどうか
+        /// </summary>
+        public bool IsAUtologinEnable
+        {
+            get => this.settingHandler.GetBoolSetting(Settings.AutologinEnable);
+        }
+
+        /// <summary>
+        /// 自動ログインのタイプを取得する
+        /// </summary>
+        /// <returns></returns>
+        private AutoLoginType GetAutoLoginType()
+        {
+            var mode = this.settingHandler.GetStringSetting(Settings.AutologinMode) ?? AutoLoginTypeString.Normal;
+
+            if (mode == AutoLoginTypeString.Normal)
+            {
+                bool isCredencialSaved = this.accountManager.IsPasswordSaved;
+                if (isCredencialSaved) return AutoLoginType.Normal;
+            }
+            else if (mode == AutoLoginTypeString.Webview2)
+            {
+                bool canLoginWithWebview2 = this.webview2SharedLogin.CanLogin();
+                if (canLoginWithWebview2) return AutoLoginType.Webview2;
+            }
+
+            return AutoLoginType.None;
+        }
+    }
+
+    enum AutoLoginType
+    {
+        None,
+        Normal,
+        Webview2
+    }
+
+    static class AutoLoginTypeString
+    {
+        public const string Normal = "Normal";
+
+        public const string Webview2 = "Webview2";
+    }
+}

--- a/Niconicome/Models/Auth/Webview2SharedLogin.cs
+++ b/Niconicome/Models/Auth/Webview2SharedLogin.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.Threading.Tasks;
+using Niconicome.Models.Domain.Local.Cookies;
+using Niconicome.Models.Domain.Niconico;
+using Niconicome.Models.Domain.Utils;
+
+namespace Niconicome.Models.Auth
+{
+    interface IWebview2SharedLogin
+    {
+        bool CanLogin();
+        Task<bool> TryLogin();
+    }
+
+    class Webview2SharedLogin : IWebview2SharedLogin
+    {
+        public Webview2SharedLogin(IWebview2LocalCookieManager webview2LocalCookieManager, ILogger logger, INicoHttp http, ICookieManager cookieManager)
+        {
+            this.webview2LocalCookieManager = webview2LocalCookieManager;
+            this.logger = logger;
+            this.http = http;
+            this.cookieManager = cookieManager;
+        }
+
+        private readonly IWebview2LocalCookieManager webview2LocalCookieManager;
+
+        private readonly ILogger logger;
+
+        private readonly INicoHttp http;
+
+        private readonly ICookieManager cookieManager;
+
+        /// <summary>
+        /// ログインを試行する
+        /// </summary>
+        /// <returns></returns>
+        public async Task<bool> TryLogin()
+        {
+            IUserCookieInfo cookie;
+
+            try
+            {
+                cookie = this.webview2LocalCookieManager.GetCookieInfo();
+            }
+            catch (Exception e)
+            {
+                this.logger.Error("Webview2からのクッキーの取得に失敗しました。", e);
+                return false;
+            }
+
+            if (cookie.UserSession is null || cookie.UserSessionSecure is null || cookie.Nicosid is null) return false;
+
+            this.cookieManager.AddCookie("user_session", cookie.UserSession);
+            this.cookieManager.AddCookie("user_session_secure", cookie.UserSessionSecure);
+            this.cookieManager.AddCookie("nicosid", cookie.Nicosid);
+
+            var result = await this.CheckIfLoginSucceeded();
+
+            return result;
+        }
+
+        /// <summary>
+        /// ログインに成功したかどうかを確かめる
+        /// </summary>
+        /// <returns></returns>
+        private async Task<bool> CheckIfLoginSucceeded()
+        {
+            var result = await this.http.GetAsync(new Uri(@"https://www.nicovideo.jp/my"));
+
+            if (result.Headers.Contains("Location"))
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// ログイン可能であるかどうかを返す
+        /// </summary>
+        /// <returns></returns>
+        public bool CanLogin()
+        {
+            return this.webview2LocalCookieManager.CanLoginWithWebview2();
+        }
+    }
+}

--- a/Niconicome/Models/Domain/Local/Cookies/ChromeCookieDecryptor.cs
+++ b/Niconicome/Models/Domain/Local/Cookies/ChromeCookieDecryptor.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Security.Cryptography;
+using System.Text;
+using Niconicome.Models.Domain.Utils;
+
+namespace Niconicome.Models.Domain.Local.Cookies
+{
+    public interface IChromeCookieDecryptor
+    {
+        byte[] DecryptCookie(byte[] cipherRaw, byte[] key);
+        byte[] GetEncryptionKey(byte[] rawkey);
+        string ToUtf8String(byte[] data);
+    }
+
+    public class ChromeCookieDecryptor : IChromeCookieDecryptor
+    {
+        public ChromeCookieDecryptor(ILogger logger)
+        {
+            this.logger = logger;
+        }
+
+        private readonly ILogger logger;
+
+        /// <summary>
+        /// 暗号化キーを復号する
+        /// </summary>
+        /// <param name="rawkey"></param>
+        /// <returns></returns>
+        public byte[] GetEncryptionKey(byte[] rawkey)
+        {
+            var cipher = rawkey[5..];
+            byte[] plainText;
+
+            try
+            {
+                plainText = ProtectedData.Unprotect(cipher, null, DataProtectionScope.CurrentUser);
+            }
+            catch (Exception e)
+            {
+                this.logger.Error("cookie暗号化キーの復号に失敗しました。", e);
+                throw new InvalidOperationException($"cookie暗号化キーの復号に失敗しました。(詳細: {e.Message})");
+            }
+
+            return plainText;
+        }
+
+        /// <summary>
+        /// cookieを復号する
+        /// </summary>
+        /// <param name="cipherRaw"></param>
+        /// <param name="key"></param>
+        /// <returns></returns>
+        public byte[] DecryptCookie(byte[] cipherRaw, byte[] key)
+        {
+            var cipher = cipherRaw[15..^16];
+            var nonce = cipherRaw[3..15];
+            var tag = cipherRaw[^16..^0];
+            var plainText = new byte[cipher.Length];
+            var aes = new AesGcm(key);
+
+            aes.Decrypt(nonce, cipher, tag, plainText, null);
+
+            return plainText;
+        }
+
+        /// <summary>
+        /// バイト配列を文字列に変換する
+        /// </summary>
+        /// <param name="data"></param>
+        /// <returns></returns>
+        public string ToUtf8String(byte[] data)
+        {
+            return Encoding.UTF8.GetString(data);
+        }
+    }
+}

--- a/Niconicome/Models/Domain/Local/Cookies/Webview2LocalCookieManager.cs
+++ b/Niconicome/Models/Domain/Local/Cookies/Webview2LocalCookieManager.cs
@@ -1,0 +1,101 @@
+﻿using System.IO;
+using Niconicome.Models.Domain.Local.LocalFile;
+using Niconicome.Models.Domain.Local.SQLite;
+
+namespace Niconicome.Models.Domain.Local.Cookies
+{
+    public interface IUserCookieInfo
+    {
+        bool IsUserSessionExpired { get; }
+        bool IsUserSessionSecureExpired { get; }
+        bool IsNicosidExpired { get; }
+        string? UserSession { get; }
+        string? UserSessionSecure { get; }
+        string? Nicosid { get; }
+    }
+
+    interface IWebview2LocalCookieManager
+    {
+        bool CanLoginWithWebview2();
+        IUserCookieInfo GetCookieInfo();
+    }
+
+    class Webview2LocalCookieManager : IWebview2LocalCookieManager
+    {
+        public Webview2LocalCookieManager(ICookieJsonLoader cookieJsonLoader, ISqliteCookieLoader sqliteCookieLoader, IChromeCookieDecryptor chromeCookieDecryptor)
+        {
+            this.cookieJsonLoader = cookieJsonLoader;
+            this.sqliteCookieLoader = sqliteCookieLoader;
+            this.chromeCookieDecryptor = chromeCookieDecryptor;
+        }
+
+        private readonly ICookieJsonLoader cookieJsonLoader;
+
+        private readonly ISqliteCookieLoader sqliteCookieLoader;
+
+        private readonly IChromeCookieDecryptor chromeCookieDecryptor;
+
+        /// <summary>
+        /// Webview2のcookieを共有可能であるかどうか
+        /// </summary>
+        /// <returns></returns>
+        public bool CanLoginWithWebview2()
+        {
+            var cookiePath = this.sqliteCookieLoader.GetCookiePath(CookieType.Webview2);
+            var jsonPath = this.cookieJsonLoader.GetJsonPath(CookieType.Webview2);
+
+            return File.Exists(cookiePath) && File.Exists(jsonPath);
+        }
+
+        /// <summary>
+        /// Cookieを取得する
+        /// </summary>
+        /// <returns></returns>
+        public IUserCookieInfo GetCookieInfo()
+        {
+            var cookiePath = this.sqliteCookieLoader.GetCookiePath(CookieType.Webview2);
+            var jsonPath = this.cookieJsonLoader.GetJsonPath(CookieType.Webview2);
+
+            var cookies = this.sqliteCookieLoader.GetCookies(cookiePath);
+            var rawKey = this.cookieJsonLoader.GetEncryptedKey(jsonPath);
+            var key = this.chromeCookieDecryptor.GetEncryptionKey(rawKey);
+
+            if (cookies.UserSession is null || cookies.UserSessionSecure is null || cookies.Nicosid is null)
+            {
+                throw new IOException("Cookieの値がnullです。");
+            }
+
+            var usersessionEncrypted = this.chromeCookieDecryptor.DecryptCookie(cookies.UserSession, key);
+            var usersessionSecureEncrypted = this.chromeCookieDecryptor.DecryptCookie(cookies.UserSessionSecure, key);
+            var nicosidEncrypted = this.chromeCookieDecryptor.DecryptCookie(cookies.Nicosid, key);
+
+            var info = new UserCookieInfo()
+            {
+                IsUserSessionExpired = cookies.IsUserSessionExpires,
+                IsUserSessionSecureExpired = cookies.IsUserSessionSecureExpires,
+                IsNicosidExpired = cookies.IsNnicosidExpires,
+                UserSession = this.chromeCookieDecryptor.ToUtf8String(usersessionEncrypted),
+                UserSessionSecure = this.chromeCookieDecryptor.ToUtf8String(usersessionSecureEncrypted),
+                Nicosid = this.chromeCookieDecryptor.ToUtf8String(nicosidEncrypted)
+            };
+
+            return info;
+
+        }
+    }
+
+    class UserCookieInfo:IUserCookieInfo
+    {
+        public bool IsUserSessionExpired { get; set; }
+
+        public bool IsUserSessionSecureExpired { get; set; }
+
+        public bool IsNicosidExpired { get; set; }
+
+        public string? UserSession { get; set; }
+
+        public string? UserSessionSecure { get; set; }
+
+        public string? Nicosid { get; set; }
+    }
+}

--- a/Niconicome/Models/Domain/Local/DataBase.cs
+++ b/Niconicome/Models/Domain/Local/DataBase.cs
@@ -106,8 +106,6 @@ namespace Niconicome.Models.Domain.Local
         {
             BsonMapper.Global.Entity<STypes::Playlist>()
                 .DbRef(playlist => playlist.Videos, STypes::Video.TableName);
-            BsonMapper.Global.Entity<STypes::Video>()
-                .DbRef(video => video.Owner, Niconico::User.TableName);
 
             if (!this.Exists<STypes::Playlist>(STypes::Playlist.TableName, playlist => playlist.IsRoot))
             {

--- a/Niconicome/Models/Domain/Local/LocalFile/CookieJsonLoader.cs
+++ b/Niconicome/Models/Domain/Local/LocalFile/CookieJsonLoader.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.IO;
+using Niconicome.Extensions.System;
+using Niconicome.Models.Domain.Local.SQLite;
+using Niconicome.Models.Domain.Niconico.Net.Json;
+using Niconicome.Models.Domain.Utils;
+using NiconicomeTest.Local.Cookies;
+
+namespace Niconicome.Models.Domain.Local.LocalFile
+{
+    public interface ICookieJsonLoader
+    {
+        byte[] GetEncryptedKey(string path);
+        string GetJsonPath(CookieType type);
+    }
+
+    public class CookieJsonLoader : ICookieJsonLoader
+    {
+        public CookieJsonLoader(ILogger logger)
+        {
+            this.logger = logger;
+        }
+
+        private readonly ILogger logger;
+
+        /// <summary>
+        /// JSONファイルのパスを取得する
+        /// </summary>
+        /// <param name="type"></param>
+        /// <returns></returns>
+        public string GetJsonPath(CookieType type)
+        {
+            return type switch
+            {
+                CookieType.Webview2 => @"Niconicome.exe.WebView2\EBWebView\Local State",
+                _ => throw new InvalidOperationException("そのような種別のcookieには対応していません。")
+            };
+        }
+
+        /// <summary>
+        /// Local Stateファイルを開いて取得する
+        /// </summary>
+        /// <param name="path"></param>
+        /// <returns></returns>
+        public byte[] GetEncryptedKey(string path)
+        {
+            if (!File.Exists(path))
+            {
+                throw new IOException($"指定されたファイルは存在しません。({path})");
+            }
+
+            LocalStateType data;
+
+            try
+            {
+                var source = File.OpenText(path).ReadToEnd();
+                data = JsonParser.DeSerialize<LocalStateType>(source);
+            }
+            catch (Exception e)
+            {
+                this.logger.Error("Local Stateファイルの読み込みでエラーが発生しました。", e);
+                throw new IOException($"Local Stateファイルの読み込みでエラーが発生しました。(詳細:{e.Message})");
+            }
+
+            if (data.OsCrypt.EncryptedKey.IsNullOrEmpty())
+            {
+                throw new IOException("キーの読み取りに失敗しました。");
+            }
+
+            return Convert.FromBase64String(data.OsCrypt.EncryptedKey);
+        }
+    }
+}

--- a/Niconicome/Models/Domain/Local/LocalFile/LocalDirectoryHandler.cs
+++ b/Niconicome/Models/Domain/Local/LocalFile/LocalDirectoryHandler.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Niconicome.Extensions.System;
+using Niconicome.Models.Domain.Utils;
+
+namespace Niconicome.Models.Domain.Local.LocalFile
+{
+    interface ILocalDirectoryHandler
+    {
+        IEnumerable<string> GetVideoIdsFromDirectory(string directoryPath, bool searchSubfolder = true);
+    }
+
+    class LocalDirectoryHandler : ILocalDirectoryHandler
+    {
+        public LocalDirectoryHandler(ILogger logger, INiconicoUtils niconicoUtils)
+        {
+            this.logger = logger;
+            this.niconicoUtils = niconicoUtils;
+        }
+
+        private readonly ILogger logger;
+
+        private readonly INiconicoUtils niconicoUtils;
+
+        /// <summary>
+        /// ローカルディレクトリーからID一覧を取得する
+        /// </summary>
+        /// <param name="directoryPath"></param>
+        /// <param name="searchSubfolder"></param>
+        /// <returns></returns>
+        public IEnumerable<string> GetVideoIdsFromDirectory(string directoryPath, bool searchSubfolder = true)
+        {
+            var option = searchSubfolder ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly;
+            var files = new List<string>();
+
+            try
+            {
+                files.AddRange(Directory.GetFiles(directoryPath, "*.mp4", option));
+            }
+            catch (Exception e)
+            {
+                this.logger.Error("ローカルファイルの探索に失敗しました。", e);
+                throw new IOException("ローカルファイルの探索に失敗しました。");
+            }
+
+            return files.Select(f => this.niconicoUtils.GetIdFromFIleName(f)).Where(f => !f.IsNullOrEmpty());
+
+        }
+    }
+}

--- a/Niconicome/Models/Domain/Local/LocalFile/LocalStateType.cs
+++ b/Niconicome/Models/Domain/Local/LocalFile/LocalStateType.cs
@@ -1,0 +1,18 @@
+﻿using System.Text.Json.Serialization;
+
+namespace NiconicomeTest.Local.Cookies
+{
+
+    public partial class LocalStateType
+    {
+
+        [JsonPropertyName("os_crypt")]
+        public OsCrypt OsCrypt { get; set; } = new();
+    }
+
+    public partial class OsCrypt
+    {
+        [JsonPropertyName("encrypted_key")]
+        public string EncryptedKey { get; set; } = string.Empty;
+    }
+}

--- a/Niconicome/Models/Domain/Local/SQLite/SQliteLoader.cs
+++ b/Niconicome/Models/Domain/Local/SQLite/SQliteLoader.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.IO;
+using Microsoft.Data.Sqlite;
+using Niconicome.Models.Domain.Utils;
+
+namespace Niconicome.Models.Domain.Local.SQLite
+{
+    public interface ISQliteLoader : IDisposable
+    {
+        bool IsConnected { get; }
+        SqliteDataReader GetDataReader(string path, string commandString);
+    }
+
+    /// <summary>
+    /// SQliteハンドラー
+    /// </summary>
+    public class SQliteLoader : ISQliteLoader
+    {
+        public SQliteLoader(ILogger logger)
+        {
+            this.logger = logger;
+        }
+
+        private readonly ILogger logger;
+
+        private SqliteConnection? connection;
+
+        /// <summary>
+        /// コネクションフラグ
+        /// </summary>
+        public bool IsConnected { get => this.connection is not null; }
+
+        /// <summary>
+        /// データリーダーを取得する
+        /// </summary>
+        /// <param name="path"></param>
+        /// <param name="commandString"></param>
+        /// <returns></returns>
+        public SqliteDataReader GetDataReader(string path, string commandString)
+        {
+            if (this.IsConnected)
+            {
+                this.Dispose();
+            }
+
+            if (!File.Exists(path))
+            {
+                throw new IOException($"指定されたデータベースファイルは存在しません(path:{path})");
+            }
+
+
+            try
+            {
+                this.connection = new SqliteConnection($"Data Source = {path}");
+                this.connection.Open();
+            }
+            catch (Exception e)
+            {
+                this.logger.Error($"データベースのオープンに失敗しました。(path:{path})", e);
+                throw new IOException($"データベースのオープンに失敗しました。(詳細:{e.Message})");
+            }
+
+            var command = this.connection.CreateCommand();
+            command.CommandText = commandString;
+
+            return command.ExecuteReader();
+        }
+
+        /// <summary>
+        /// コネクションを破棄する
+        /// </summary>
+        public void Dispose()
+        {
+            this.connection?.Dispose();
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/Niconicome/Models/Domain/Local/Store/PlaylistStoreHandler.cs
+++ b/Niconicome/Models/Domain/Local/Store/PlaylistStoreHandler.cs
@@ -23,6 +23,7 @@ namespace Niconicome.Models.Domain.Local.Store
         bool Exists(int id);
         bool JustifyPlaylists(int Id);
         bool JustifyPlaylists(IEnumerable<int> Id);
+        bool ContainsVideo(string niconicoId, int playlistId);
         void Move(int id, int destId);
         void Copy(int id, int destId);
         void SetAsRemotePlaylist(int id, string remoteId, RemoteType type);
@@ -285,6 +286,20 @@ namespace Niconicome.Models.Domain.Local.Store
         public bool JustifyPlaylists(IEnumerable<int> ids)
         {
             return !ids.Select(id => this.JustifyPlaylists(id)).Any(ok => ok == false);
+        }
+
+
+        /// <summary>
+        /// 指定されたIDの動画を含むかどうかを返す
+        /// </summary>
+        /// <param name="videoId"></param>
+        /// <param name="playlistId"></param>
+        /// <returns></returns>
+        public bool ContainsVideo(string niconicoId, int playlistId)
+        {
+            var playlist = this.GetPlaylist(playlistId);
+            if (playlist is null) return false;
+            return playlist.Videos.Any(v => v.NiconicoId == niconicoId);
         }
 
         /// <summary>

--- a/Niconicome/Models/Domain/Local/Store/Types/Playlist.cs
+++ b/Niconicome/Models/Domain/Local/Store/Types/Playlist.cs
@@ -14,7 +14,18 @@ namespace Niconicome.Models.Domain.Local.Store.Types
         public static string TableName { get; } = "videos";
 
         public int Id { get; private set; }
+
         public int ViewCount { get; set; }
+
+        public int CommentCount { get; set; }
+
+        public int MylistCount { get; set; }
+
+        public int LikeCount { get; set; }
+
+        public int Duration { get; set; }
+
+        public int OwnerID { get; set; }
 
         public string NiconicoId { get; set; } = string.Empty;
 
@@ -30,17 +41,15 @@ namespace Niconicome.Models.Domain.Local.Store.Types
 
         public string ThumbPath { get; set; } = string.Empty;
 
+        public string OwnerName { get; set; } = string.Empty;
+
         public List<string>? Tags { get; set; }
 
         public bool IsDeleted { get; set; }
 
-        public bool IsDownloaded { get; set; }
-
         public bool IsSelected { get; set; }
 
         public List<int>? PlaylistIds { get; set; }
-
-        public User? Owner { get; set; }
 
         public DateTime UploadedOn { get; set; }
 
@@ -83,6 +92,7 @@ namespace Niconicome.Models.Domain.Local.Store.Types
         public int Sequence { get; set; }
 
         public string? PlaylistName { get; set; }
+
         public string? FolderPath { get; set; }
 
         public List<Video> Videos { get; set; } = new();

--- a/Niconicome/Models/Domain/Local/Store/Types/Settings.cs
+++ b/Niconicome/Models/Domain/Local/Store/Types/Settings.cs
@@ -136,6 +136,8 @@ namespace Niconicome.Models.Domain.Local.Store.Types
         public static string ReplaceSingleByteToMultiByte { get; private set; } = "replacesinglebytetomultibyte";
         public static string OverideVideoFileDTToUploadedDT { get; private set; } = "overidevideofiledttouploadeddt";
         public static string LimitCommentCount { get; private set; } = "limitcommentcount";
-        public static string MaxCommentCount { get; set; } = "maxcommentcount";
+        public static string MaxCommentCount { get; private set; } = "maxcommentcount";
+        public static string IsDownloadingVideoInfoEnable { get; private set; } = "isdownloadingvideoinfoenable";
+        public static string IsDownloadingVideoInfoInJsonEnable { get; private set; } = "isdownloadingvideoinfoinjsonenable";
     }
 }

--- a/Niconicome/Models/Domain/Local/Store/Types/Settings.cs
+++ b/Niconicome/Models/Domain/Local/Store/Types/Settings.cs
@@ -131,5 +131,7 @@ namespace Niconicome.Models.Domain.Local.Store.Types
         public static string AutoLoginMode { get; private set; } = "autologinmode";
         public static string MaxParallelDownloadCount { get; private set; } = "maxparalleldownloadcount";
         public static string MaxParallelSegmentDownloadCount { get; private set; } = "maxparallelsegmentdownloadcount";
+        public static string DownloadAllWhenPushDLButton { get; private set; } = "downloadallwhenpushdlbutton";
+        public static string AllowDupeOnStage { get; private set; } = "allowdupeonstage";
     }
 }

--- a/Niconicome/Models/Domain/Local/Store/Types/Settings.cs
+++ b/Niconicome/Models/Domain/Local/Store/Types/Settings.cs
@@ -127,6 +127,8 @@ namespace Niconicome.Models.Domain.Local.Store.Types
         public static string IsCopyEnable { get; private set; } = "iscopyenable";
         public static string IsAutoSwitchOffsetEnable { get; set; } = "isautoswitchoffsetenable";
         public static string UseShellWhenLaunchingFFmpeg { get; set; } = "useshellwhenlaunchingffmpeg";
+        public static string IsAutologinEnable { get; private set; } = "isautologinenable";
+        public static string AutoLoginMode { get; private set; } = "autologinmode";
 
     }
 }

--- a/Niconicome/Models/Domain/Local/Store/Types/Settings.cs
+++ b/Niconicome/Models/Domain/Local/Store/Types/Settings.cs
@@ -129,6 +129,7 @@ namespace Niconicome.Models.Domain.Local.Store.Types
         public static string UseShellWhenLaunchingFFmpeg { get; set; } = "useshellwhenlaunchingffmpeg";
         public static string IsAutologinEnable { get; private set; } = "isautologinenable";
         public static string AutoLoginMode { get; private set; } = "autologinmode";
-
+        public static string MaxParallelDownloadCount { get; private set; } = "maxparalleldownloadcount";
+        public static string MaxParallelSegmentDownloadCount { get; private set; } = "maxparallelsegmentdownloadcount";
     }
 }

--- a/Niconicome/Models/Domain/Local/Store/Types/Settings.cs
+++ b/Niconicome/Models/Domain/Local/Store/Types/Settings.cs
@@ -134,5 +134,6 @@ namespace Niconicome.Models.Domain.Local.Store.Types
         public static string DownloadAllWhenPushDLButton { get; private set; } = "downloadallwhenpushdlbutton";
         public static string AllowDupeOnStage { get; private set; } = "allowdupeonstage";
         public static string ReplaceSingleByteToMultiByte { get; private set; } = "replacesinglebytetomultibyte";
+        public static string OverideVideoFileDTToUploadedDT { get; private set; } = "overidevideofiledttouploadeddt";
     }
 }

--- a/Niconicome/Models/Domain/Local/Store/Types/Settings.cs
+++ b/Niconicome/Models/Domain/Local/Store/Types/Settings.cs
@@ -135,5 +135,7 @@ namespace Niconicome.Models.Domain.Local.Store.Types
         public static string AllowDupeOnStage { get; private set; } = "allowdupeonstage";
         public static string ReplaceSingleByteToMultiByte { get; private set; } = "replacesinglebytetomultibyte";
         public static string OverideVideoFileDTToUploadedDT { get; private set; } = "overidevideofiledttouploadeddt";
+        public static string LimitCommentCount { get; private set; } = "limitcommentcount";
+        public static string MaxCommentCount { get; set; } = "maxcommentcount";
     }
 }

--- a/Niconicome/Models/Domain/Local/Store/Types/Settings.cs
+++ b/Niconicome/Models/Domain/Local/Store/Types/Settings.cs
@@ -141,5 +141,6 @@ namespace Niconicome.Models.Domain.Local.Store.Types
         public static string IsDownloadingVideoInfoInJsonEnable { get; private set; } = "isdownloadingvideoinfoinjsonenable";
         public static string MaxParallelFetchCount { get; private set; } = "maxparallelfetchcount";
         public static string FetchSleepInterval { get; private set; } = "fetchsleepinterval";
+        public static string SkipSSLVerification { get; private set; } = "skipsslverification";
     }
 }

--- a/Niconicome/Models/Domain/Local/Store/Types/Settings.cs
+++ b/Niconicome/Models/Domain/Local/Store/Types/Settings.cs
@@ -139,5 +139,7 @@ namespace Niconicome.Models.Domain.Local.Store.Types
         public static string MaxCommentCount { get; private set; } = "maxcommentcount";
         public static string IsDownloadingVideoInfoEnable { get; private set; } = "isdownloadingvideoinfoenable";
         public static string IsDownloadingVideoInfoInJsonEnable { get; private set; } = "isdownloadingvideoinfoinjsonenable";
+        public static string MaxParallelFetchCount { get; private set; } = "maxparallelfetchcount";
+        public static string FetchSleepInterval { get; private set; } = "fetchsleepinterval";
     }
 }

--- a/Niconicome/Models/Domain/Local/Store/Types/Settings.cs
+++ b/Niconicome/Models/Domain/Local/Store/Types/Settings.cs
@@ -133,5 +133,6 @@ namespace Niconicome.Models.Domain.Local.Store.Types
         public static string MaxParallelSegmentDownloadCount { get; private set; } = "maxparallelsegmentdownloadcount";
         public static string DownloadAllWhenPushDLButton { get; private set; } = "downloadallwhenpushdlbutton";
         public static string AllowDupeOnStage { get; private set; } = "allowdupeonstage";
+        public static string ReplaceSingleByteToMultiByte { get; private set; } = "replacesinglebytetomultibyte";
     }
 }

--- a/Niconicome/Models/Domain/Local/Store/VideoStoreHandler.cs
+++ b/Niconicome/Models/Domain/Local/Store/VideoStoreHandler.cs
@@ -204,6 +204,12 @@ namespace Niconicome.Models.Domain.Local.Store
             dbVideo.FileName = videoData.FileName;
             dbVideo.Tags = videoData.Tags.ToList();
             dbVideo.ViewCount = videoData.ViewCount;
+            dbVideo.CommentCount = videoData.CommentCount;
+            dbVideo.MylistCount = videoData.MylistCount;
+            dbVideo.LikeCount = videoData.LikeCount;
+            dbVideo.Duration = videoData.Duration;
+            dbVideo.OwnerID = videoData.OwnerID;
+            dbVideo.OwnerName = videoData.OwnerName;
         }
 
         private void JustifyVideo(STypes::Video video)

--- a/Niconicome/Models/Domain/Niconico/Auth.cs
+++ b/Niconicome/Models/Domain/Niconico/Auth.cs
@@ -5,7 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 using CredentialManagement;
 
-namespace Niconicome.Models.Auth
+namespace Niconicome.Models.Domain.Niconico
 {
 
     public interface IUserCredential
@@ -19,7 +19,7 @@ namespace Niconicome.Models.Auth
         void Save(string username, string password);
         bool IsPasswordSaved { get; }
         IUserCredential GetUserCredential();
-        static IUserCredential GetUserCredential(string username,string password)
+        static IUserCredential GetUserCredential(string username, string password)
         {
             return new UserCredential(username, password);
         }
@@ -28,7 +28,7 @@ namespace Niconicome.Models.Auth
     /// <summary>
     /// ユーザーアカウントマネージャー
     /// </summary>
-    class AccountManager:IAccountManager
+    class AccountManager : IAccountManager
     {
         private readonly string siteName = "https://nicovideo.jp";
 

--- a/Niconicome/Models/Domain/Niconico/Download/Comment/CommentClient.cs
+++ b/Niconicome/Models/Domain/Niconico/Download/Comment/CommentClient.cs
@@ -28,6 +28,7 @@ namespace Niconicome.Models.Domain.Niconico.Download.Comment
         bool IsDownloadingLogEnable { get; }
         bool IsDownloadingOwnerCommentEnable { get; }
         bool IsDownloadingEasyCommentEnable { get; }
+        bool IsReplaceStrictedEnable { get; }
         int CommentOffset { get; }
     }
 
@@ -72,6 +73,9 @@ namespace Niconicome.Models.Domain.Niconico.Download.Comment
         public bool IsDownloadingOwnerCommentEnable { get; set; }
 
         public bool IsDownloadingEasyCommentEnable { get; set; }
+        
+        public bool IsReplaceStrictedEnable { get; set; }
+
         public int CommentOffset { get; set; }
 
     }

--- a/Niconicome/Models/Domain/Niconico/Download/Comment/CommentClient.cs
+++ b/Niconicome/Models/Domain/Niconico/Download/Comment/CommentClient.cs
@@ -1,16 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
 using System.Net.Http;
-using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Windows.Documents;
-using Niconicome.Extensions.System.List;
-using Niconicome.Models.Domain.Local.Store;
 using Niconicome.Models.Domain.Niconico.Net.Json;
-using Niconicome.Models.Domain.Niconico.Net.Json.API.Search;
 using Niconicome.Models.Domain.Niconico.Watch;
 using Niconicome.Models.Domain.Utils;
 using Response = Niconicome.Models.Domain.Niconico.Net.Json.API.Comment.Response;
@@ -30,25 +23,7 @@ namespace Niconicome.Models.Domain.Niconico.Download.Comment
         bool IsDownloadingEasyCommentEnable { get; }
         bool IsReplaceStrictedEnable { get; }
         int CommentOffset { get; }
-    }
-
-    public interface ICommentCollection
-    {
-        List<Response::Comment> Comments { get; }
-        Response::Thread? ThreadInfo { get; }
-        int Count { get; }
-        long Thread { get; }
-        int Fork { get; }
-        bool IsDefaultPostTarget { get; }
-        void Add(Response::Comment comment, bool sort = true);
-        void Add(List<Response::Comment> comments, bool addSafe = true);
-        void Clear();
-        void Distinct();
-        void Sort();
-        void Where(Func<Response::Comment, bool> predicate);
-        ICommentCollection Clone();
-        IEnumerable<Response::Chat> GetAllComments();
-        Response::Chat? GetFirstComment(bool includeOwnerComment = true);
+        int MaxcommentsCount { get; }
     }
 
     public interface ICommentClient
@@ -73,10 +48,13 @@ namespace Niconicome.Models.Domain.Niconico.Download.Comment
         public bool IsDownloadingOwnerCommentEnable { get; set; }
 
         public bool IsDownloadingEasyCommentEnable { get; set; }
-        
+
         public bool IsReplaceStrictedEnable { get; set; }
 
         public int CommentOffset { get; set; }
+
+        public int MaxcommentsCount { get; set; }
+
 
     }
 
@@ -144,6 +122,13 @@ namespace Niconicome.Models.Domain.Niconico.Download.Comment
                     lastNo = first?.No ?? 0;
                 }
 
+                if (settings.MaxcommentsCount > 0 && comments.Count > settings.MaxcommentsCount)
+                {
+                    var rmCount = comments.Count - settings.MaxcommentsCount;
+                    comments.RemoveFor(rmCount);
+                    break;
+                }
+
                 if (!settings.IsDownloadingLogEnable)
                 {
                     break;
@@ -207,393 +192,5 @@ namespace Niconicome.Models.Domain.Niconico.Download.Comment
         }
     }
 
-    /// <summary>
-    /// コメントのコレクション
-    /// </summary>
-    public class CommentCollection : ICommentCollection
-    {
-        public CommentCollection(ICommentCollection original)
-        {
-            this.commentsfield = new List<Response.Comment>();
-            this.commentsfield.AddRange(original.Comments);
-            this.ThreadInfo = original.ThreadInfo;
-        }
-
-        public CommentCollection(int cOffset, long defaultThread, int defaultFork)
-        {
-            this.comThroughSetting = cOffset;
-            this.isRoot = true;
-            this.defaultTread = defaultThread;
-            this.defaultFork = defaultFork;
-        }
-
-        public CommentCollection(long thread, int fork, bool isDefault)
-        {
-            this.Thread = thread;
-            this.Fork = fork;
-            this.IsDefaultPostTarget = isDefault;
-
-        }
-
-        public static ICommentCollection GetInstance(int cOffset, long defaultThread, int defaultFork)
-        {
-            return new CommentCollection(cOffset, defaultThread, defaultFork);
-        }
-
-        private readonly List<Response::Comment> commentsfield = new();
-
-        private readonly List<ICommentCollection> childCollections = new();
-
-        public const int NumberToThrough = 40;
-
-        private readonly int comThroughSetting;
-
-        private readonly bool isRoot;
-
-        private readonly long defaultTread;
-
-        private readonly int defaultFork;
-
-        /// <summary>
-        /// スレッド情報
-        /// </summary>
-        private Response::Thread? threadInfoField;
-
-        /// <summary>
-        /// スレッド番号
-        /// </summary>
-        public long Thread { get; init; }
-
-        /// <summary>
-        /// Fork
-        /// </summary>
-        public int Fork { get; init; }
-
-        /// <summary>
-        /// デフォルトフラグ
-        /// </summary>
-        public bool IsDefaultPostTarget { get; init; }
-
-        /// <summary>
-        /// コメント
-        /// </summary>
-        public List<Response::Comment> Comments
-        {
-            get
-            {
-                if (this.isRoot)
-                {
-
-                    List<Response::Comment> comments = new();
-                    foreach (var child in this.childCollections)
-                    {
-                        comments.AddRange(child.Comments);
-                    }
-
-                    return comments;
-                }
-                else
-                {
-                    this.commentsfield.Sort((a, b) => (int)(a.Chat!.No - b.Chat!.No));
-                    return this.commentsfield.Distinct(c => c.Chat!.No).ToList();
-                }
-
-            }
-        }
-
-
-        /// <summary>
-        /// 要素数
-        /// </summary>
-        public int Count { get => this.Comments.Count; }
-
-        /// <summary>
-        /// スレッド
-        /// </summary>
-        public Response::Thread? ThreadInfo
-        {
-            get
-            {
-                if (this.isRoot)
-                {
-                    return this.childCollections.FirstOrDefault()?.ThreadInfo;
-                }
-                else
-                {
-                    return this.threadInfoField;
-                }
-            }
-            private set => this.threadInfoField = value;
-        }
-
-        /// <summary>
-        /// コメントを追加
-        /// </summary>
-        /// <param name="comment"></param>
-        /// <param name="sort"></param>
-        public void Add(Response::Comment comment, bool sort = true)
-        {
-            if (this.isRoot)
-            {
-                long thread;
-                int fork;
-
-                if (comment.Thread is not null)
-                {
-                    thread = long.Parse(comment.Thread.ThreadThread);
-                    fork = (int)(comment.Thread.Fork ?? 0);
-                }
-                else if (comment.Chat is not null)
-                {
-                    thread = long.Parse(comment.Chat.Thread);
-                    fork = (int)(comment.Chat.Fork ?? 0);
-                }
-                else
-                {
-                    return;
-                }
-
-
-                if (!this.HasChild(thread, fork)) this.CreateChild(thread, fork);
-
-                var child = this.GetChild(thread, fork);
-
-                child.Add(comment);
-
-            }
-            else
-            {
-                if (comment.Thread is not null)
-                {
-                    if ((this.ThreadInfo?.LastRes ?? 0) < comment.Thread.LastRes)
-                    {
-                        this.ThreadInfo = comment.Thread;
-                    }
-                }
-                else if (comment.Chat is not null)
-                {
-                    //if (!this.commentsfield.Any(c => c.Chat!.No == comment.Chat.No))
-                    //{
-                    this.commentsfield.Add(comment);
-                    //}
-                }
-                else
-                {
-                    return;
-                }
-
-            }
-        }
-
-        /// <summary>
-        /// 複数のコメントを追加する
-        /// </summary>
-        /// <param name="comments"></param>
-        public void Add(List<Response::Comment> comments, bool addSafe = true)
-        {
-
-            ///if (addSafe && this.comThroughSetting > 0 && comments.Count > this.comThroughSetting)
-            ///{
-            ///    var filtered = comments.Copy().Where(c => c.Chat is not null).ToList();
-            ///    if (filtered.Count > this.comThroughSetting)
-            ///    {
-            ///        filtered.RemoveRange(0, this.comThroughSetting);
-            ///        comments.Clear();
-            ///        comments.AddRange(filtered);
-            ///    }
-            ///}
-
-            //bool chatStarted = false;
-            bool nicoruEnded = false;
-            int skipped = 0;
-            int cCounts = comments.Where(c => c.Chat is not null).Count();
-            var first = this.GetFirstComment();
-            bool isFirstIsOldEnough = first is null ? false : first.No < this.comThroughSetting + 10;
-
-            foreach (var item in comments)
-            {
-                if (item.Chat is not null)
-                {
-                    if (!nicoruEnded && item.Chat.Nicoru is not null)
-                    {
-                        continue;
-                    }
-                    else if (!nicoruEnded && item.Chat.Nicoru is null)
-                    {
-                        nicoruEnded = true;
-                    }
-                }
-
-                if (addSafe && !isFirstIsOldEnough && this.comThroughSetting > 0 && cCounts > this.comThroughSetting + 20 && item.Chat is not null)
-                {
-                    if (skipped < this.comThroughSetting)
-                    {
-                        ++skipped;
-                        continue;
-                    }
-                }
-                this.Add(item, false);
-            }
-        }
-
-        /// <summary>
-        /// 全てのコメントを削除
-        /// </summary>
-        public void Clear()
-        {
-            if (this.isRoot)
-            {
-                foreach (var child in this.childCollections)
-                {
-                    child.Clear();
-                }
-            }
-            else
-            {
-                this.commentsfield.Clear();
-            }
-        }
-
-        /// <summary>
-        /// ユニーク化する
-        /// </summary>
-        public void Distinct()
-        {
-            var copy = this.Clone();
-            this.commentsfield.Clear();
-            this.commentsfield.AddRange(copy.Comments.Distinct(c => c.Chat!.No));
-        }
-
-        /// <summary>
-        /// フィルターする
-        /// </summary>
-        /// <param name="predicate"></param>
-        public void Where(Func<Response::Comment, bool> predicate)
-        {
-            if (this.isRoot)
-            {
-                foreach (var child in this.childCollections)
-                {
-                    child.Where(predicate);
-                }
-            }
-            else
-            {
-                var copy = this.Comments.Copy();
-                this.commentsfield.Clear();
-                this.commentsfield.AddRange(copy.Where(predicate));
-            }
-        }
-
-        /// <summary>
-        /// 複製する
-        /// </summary>
-        /// <returns></returns>
-        public ICommentCollection Clone()
-        {
-            return new CommentCollection(this);
-        }
-
-        /// <summary>
-        /// 全てのコメントを取得
-        /// </summary>
-        /// <returns></returns>
-        public IEnumerable<Response::Chat> GetAllComments()
-        {
-            if (this.isRoot)
-            {
-
-                List<Response::Chat> comments = new();
-                foreach (var child in this.childCollections)
-                {
-                    comments.AddRange(child.GetAllComments());
-                }
-
-                return comments;
-            }
-            else
-            {
-                return this.Comments.Select(c => c.Chat ?? new Response::Chat() { No = -1 }).Where(c => c.No != -1);
-            }
-        }
-
-        /// <summary>
-        /// 最初のコメントを取得する
-        /// </summary>
-        /// <returns></returns>
-        public Response::Chat? GetFirstComment(bool includeOwnerComment = true)
-        {
-            if (this.isRoot)
-            {
-                //IEnumerable<Response::Chat?> GetFirstComents(IEnumerable<ICommentCollection> collection)
-                //{
-                //    return collection.Select(c => c.GetFirstComment()).Where(c => c is not null);
-                //}
-
-                var defaultThread = this.childCollections.FirstOrDefault(c => c.IsDefaultPostTarget);
-
-                return defaultThread?.Comments.FirstOrDefault()?.Chat;
-
-                ////デフォルトスレッドに1がある場合はリターン
-                //if (GetFirstComents(defaultThread).Any(c => c!.No == 1))
-                //{
-                //    return GetFirstComents(defaultThread).FirstOrDefault(c => c!.No == 1);
-                //}
-                //
-                //var children = GetFirstComents(this.childCollections);
-                //if (!children.Any()) return null;
-                //var max = children.Max(c => c!.No);
-                //return children.FirstOrDefault(c => c!.No == max);
-            }
-            else
-            {
-                return this.commentsfield.FirstOrDefault(c => includeOwnerComment || (c.Chat?.UserId != null || c.Chat?.Deleted != null))?.Chat;
-            }
-        }
-
-        /// <summary>
-        /// 並び替える
-        /// </summary>
-        public void Sort()
-        {
-            this.commentsfield.Sort((a, b) => (int)(a.Chat!.No - b.Chat!.No));
-        }
-
-        /// <summary>
-        /// 子コレクションを確認
-        /// </summary>
-        /// <param name="thread"></param>
-        /// <param name="fork"></param>
-        /// <returns></returns>
-        private bool HasChild(long thread, int fork)
-        {
-            return this.childCollections.Any(c => c.Thread == thread && c.Fork == fork);
-        }
-
-        /// <summary>
-        /// 子コレクションを追加
-        /// </summary>
-        /// <param name="thread"></param>
-        /// <param name="fork"></param>
-        private void CreateChild(long thread, int fork)
-        {
-            if (this.HasChild(thread, fork)) return;
-
-            var isDefault = thread == this.defaultTread && fork == this.defaultFork;
-
-            this.childCollections.Add(new CommentCollection(thread, fork, isDefault));
-        }
-
-        /// <summary>
-        /// 子コレクションを取得
-        /// </summary>
-        /// <param name="thread"></param>
-        /// <param name="fork"></param>
-        /// <returns></returns>
-        private ICommentCollection GetChild(long thread, int fork)
-        {
-            return this.childCollections.First(c => c.Thread == thread && c.Fork == fork);
-        }
-    }
 
 }

--- a/Niconicome/Models/Domain/Niconico/Download/Comment/CommentCollection.cs
+++ b/Niconicome/Models/Domain/Niconico/Download/Comment/CommentCollection.cs
@@ -1,0 +1,429 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Niconicome.Extensions.System.List;
+using Response = Niconicome.Models.Domain.Niconico.Net.Json.API.Comment.Response;
+
+namespace Niconicome.Models.Domain.Niconico.Download.Comment
+{
+
+
+    public interface ICommentCollection
+    {
+        List<Response::Comment> Comments { get; }
+        Response::Thread? ThreadInfo { get; }
+        int Count { get; }
+        long Thread { get; }
+        int Fork { get; }
+        bool IsDefaultPostTarget { get; }
+        void Add(Response::Comment comment, bool sort = true);
+        void Add(List<Response::Comment> comments, bool addSafe = true);
+        void Clear();
+        void Distinct();
+        void Sort();
+        void Where(Func<Response::Comment, bool> predicate);
+        int RemoveFor(int count);
+        ICommentCollection Clone();
+        IEnumerable<Response::Chat> GetAllComments();
+        Response::Chat? GetFirstComment(bool includeOwnerComment = true);
+    }
+
+
+    /// <summary>
+    /// コメントのコレクション
+    /// </summary>
+    public class CommentCollection : ICommentCollection
+    {
+        public CommentCollection(ICommentCollection original)
+        {
+            this.commentsfield = new List<Response::Comment>();
+            this.commentsfield.AddRange(original.Comments);
+            this.ThreadInfo = original.ThreadInfo;
+        }
+
+        public CommentCollection(int cOffset, long defaultThread, int defaultFork)
+        {
+            this.comThroughSetting = cOffset;
+            this.isRoot = true;
+            this.defaultTread = defaultThread;
+            this.defaultFork = defaultFork;
+        }
+
+        public CommentCollection(long thread, int fork, bool isDefault)
+        {
+            this.Thread = thread;
+            this.Fork = fork;
+            this.IsDefaultPostTarget = isDefault;
+
+        }
+
+        public static ICommentCollection GetInstance(int cOffset, long defaultThread, int defaultFork)
+        {
+            return new CommentCollection(cOffset, defaultThread, defaultFork);
+        }
+
+        private readonly List<Response::Comment> commentsfield = new();
+
+        private readonly List<ICommentCollection> childCollections = new();
+
+        public const int NumberToThrough = 40;
+
+        private readonly int comThroughSetting;
+
+        private readonly bool isRoot;
+
+        private readonly long defaultTread;
+
+        private readonly int defaultFork;
+
+        /// <summary>
+        /// スレッド情報
+        /// </summary>
+        private Response::Thread? threadInfoField;
+
+        /// <summary>
+        /// スレッド番号
+        /// </summary>
+        public long Thread { get; init; }
+
+        /// <summary>
+        /// Fork
+        /// </summary>
+        public int Fork { get; init; }
+
+        /// <summary>
+        /// デフォルトフラグ
+        /// </summary>
+        public bool IsDefaultPostTarget { get; init; }
+
+        /// <summary>
+        /// コメント
+        /// </summary>
+        public List<Response::Comment> Comments
+        {
+            get
+            {
+                if (this.isRoot)
+                {
+
+                    List<Response::Comment> comments = new();
+                    foreach (var child in this.childCollections)
+                    {
+                        comments.AddRange(child.Comments);
+                    }
+
+                    return comments;
+                }
+                else
+                {
+                    this.commentsfield.Sort((a, b) => (int)(a.Chat!.No - b.Chat!.No));
+                    return this.commentsfield.Distinct(c => c.Chat!.No).ToList();
+                }
+
+            }
+        }
+
+
+        /// <summary>
+        /// 要素数
+        /// </summary>
+        public int Count { get => this.Comments.Count; }
+
+        /// <summary>
+        /// スレッド
+        /// </summary>
+        public Response::Thread? ThreadInfo
+        {
+            get
+            {
+                if (this.isRoot)
+                {
+                    return this.GetDefaultThread()?.ThreadInfo;
+                }
+                else
+                {
+                    return this.threadInfoField;
+                }
+            }
+            private set => this.threadInfoField = value;
+        }
+
+        /// <summary>
+        /// コメントを追加
+        /// </summary>
+        /// <param name="comment"></param>
+        /// <param name="sort"></param>
+        public void Add(Response::Comment comment, bool sort = true)
+        {
+            if (this.isRoot)
+            {
+                long thread;
+                int fork;
+
+                if (comment.Thread is not null)
+                {
+                    thread = long.Parse(comment.Thread.ThreadThread);
+                    fork = (int)(comment.Thread.Fork ?? 0);
+                }
+                else if (comment.Chat is not null)
+                {
+                    thread = long.Parse(comment.Chat.Thread);
+                    fork = (int)(comment.Chat.Fork ?? 0);
+                }
+                else
+                {
+                    return;
+                }
+
+
+                if (!this.HasChild(thread, fork)) this.CreateChild(thread, fork);
+
+                var child = this.GetChild(thread, fork);
+
+                child.Add(comment);
+
+            }
+            else
+            {
+                if (comment.Thread is not null)
+                {
+                    if ((this.ThreadInfo?.LastRes ?? 0) < comment.Thread.LastRes)
+                    {
+                        this.ThreadInfo = comment.Thread;
+                    }
+                }
+                else if (comment.Chat is not null)
+                {
+                    this.commentsfield.Add(comment);
+                }
+                else
+                {
+                    return;
+                }
+
+            }
+        }
+
+        /// <summary>
+        /// 複数のコメントを追加する
+        /// </summary>
+        /// <param name="comments"></param>
+        public void Add(List<Response::Comment> comments, bool addSafe = true)
+        {
+            bool nicoruEnded = false;
+            int skipped = 0;
+            int cCounts = comments.Where(c => c.Chat is not null).Count();
+            var first = this.GetFirstComment();
+            bool isFirstIsOldEnough = first is null ? false : first.No < this.comThroughSetting + 10;
+
+            foreach (var item in comments)
+            {
+                if (item.Chat is not null)
+                {
+                    if (!nicoruEnded && item.Chat.Nicoru is not null)
+                    {
+                        continue;
+                    }
+                    else if (!nicoruEnded && item.Chat.Nicoru is null)
+                    {
+                        nicoruEnded = true;
+                    }
+                }
+
+                if (addSafe && !isFirstIsOldEnough && this.comThroughSetting > 0 && cCounts > this.comThroughSetting + 20 && item.Chat is not null)
+                {
+                    if (skipped < this.comThroughSetting)
+                    {
+                        ++skipped;
+                        continue;
+                    }
+                }
+                this.Add(item, false);
+            }
+        }
+
+        /// <summary>
+        /// 全てのコメントを削除
+        /// </summary>
+        public void Clear()
+        {
+            if (this.isRoot)
+            {
+                foreach (var child in this.childCollections)
+                {
+                    child.Clear();
+                }
+            }
+            else
+            {
+                this.commentsfield.Clear();
+            }
+        }
+
+        /// <summary>
+        /// ユニーク化する
+        /// </summary>
+        public void Distinct()
+        {
+            var copy = this.Clone();
+            this.commentsfield.Clear();
+            this.commentsfield.AddRange(copy.Comments.Distinct(c => c.Chat!.No));
+        }
+
+        /// <summary>
+        /// フィルターする
+        /// </summary>
+        /// <param name="predicate"></param>
+        public void Where(Func<Response::Comment, bool> predicate)
+        {
+            if (this.isRoot)
+            {
+                foreach (var child in this.childCollections)
+                {
+                    child.Where(predicate);
+                }
+            }
+            else
+            {
+                var copy = this.Comments.Copy();
+                this.commentsfield.Clear();
+                this.commentsfield.AddRange(copy.Where(predicate));
+            }
+        }
+
+        /// <summary>
+        /// 複製する
+        /// </summary>
+        /// <returns></returns>
+        public ICommentCollection Clone()
+        {
+            return new CommentCollection(this);
+        }
+
+        /// <summary>
+        /// 全てのコメントを取得
+        /// </summary>
+        /// <returns></returns>
+        public IEnumerable<Response::Chat> GetAllComments()
+        {
+            if (this.isRoot)
+            {
+
+                List<Response::Chat> comments = new();
+                foreach (var child in this.childCollections)
+                {
+                    comments.AddRange(child.GetAllComments());
+                }
+
+                return comments;
+            }
+            else
+            {
+                return this.Comments.Select(c => c.Chat ?? new Response::Chat() { No = -1 }).Where(c => c.No != -1);
+            }
+        }
+
+        /// <summary>
+        /// 最初のコメントを取得する
+        /// </summary>
+        /// <returns></returns>
+        public Response::Chat? GetFirstComment(bool includeOwnerComment = true)
+        {
+            if (this.isRoot)
+            {
+
+                var defaultThread = this.GetDefaultThread();
+
+                return defaultThread?.GetFirstComment();
+            }
+            else
+            {
+                return this.commentsfield.FirstOrDefault(c => includeOwnerComment || (c.Chat?.UserId != null || c.Chat?.Deleted != null))?.Chat;
+            }
+        }
+
+        /// <summary>
+        /// 並び替える
+        /// </summary>
+        public void Sort()
+        {
+            this.commentsfield.Sort((a, b) => (int)(a.Chat!.No - b.Chat!.No));
+        }
+
+        /// <summary>
+        /// 指定した数のコメント削除する
+        /// </summary>
+        /// <param name="count"></param>
+        /// <returns></returns>
+        public int RemoveFor(int count)
+        {
+            if (this.isRoot)
+            {
+                var defaultThread = this.GetDefaultThread()?.RemoveFor(count) ?? 0;
+                return defaultThread;
+            }
+            else
+            {
+                if (count > this.commentsfield.Count)
+                {
+                    count = this.commentsfield.Count;
+                }
+                this.commentsfield.RemoveRange(0, count);
+
+                return count;
+            }
+        }
+
+        #region private
+
+        /// <summary>
+        /// 子コレクションを確認
+        /// </summary>
+        /// <param name="thread"></param>
+        /// <param name="fork"></param>
+        /// <returns></returns>
+        private bool HasChild(long thread, int fork)
+        {
+            return this.childCollections.Any(c => c.Thread == thread && c.Fork == fork);
+        }
+
+        /// <summary>
+        /// 子コレクションを追加
+        /// </summary>
+        /// <param name="thread"></param>
+        /// <param name="fork"></param>
+        private void CreateChild(long thread, int fork)
+        {
+            if (this.HasChild(thread, fork)) return;
+
+            var isDefault = thread == this.defaultTread && fork == this.defaultFork;
+
+            this.childCollections.Add(new CommentCollection(thread, fork, isDefault));
+        }
+
+        /// <summary>
+        /// 子コレクションを取得
+        /// </summary>
+        /// <param name="thread"></param>
+        /// <param name="fork"></param>
+        /// <returns></returns>
+        private ICommentCollection GetChild(long thread, int fork)
+        {
+            return this.childCollections.First(c => c.Thread == thread && c.Fork == fork);
+        }
+
+        /// <summary>
+        /// デフォルトスレッドを取得する
+        /// </summary>
+        /// <returns></returns>
+        private ICommentCollection? GetDefaultThread()
+        {
+            if (!this.isRoot) throw new InvalidOperationException("このコレクションはルートではないためデフォルトスレッドを取得できません。");
+
+            return this.childCollections.FirstOrDefault(c => c.IsDefaultPostTarget);
+        }
+
+        #endregion
+    }
+
+}

--- a/Niconicome/Models/Domain/Niconico/Download/Comment/CommentConverter.cs
+++ b/Niconicome/Models/Domain/Niconico/Download/Comment/CommentConverter.cs
@@ -118,6 +118,7 @@ namespace Niconicome.Models.Domain.Niconico.Download.Comment
                      UserId = c.UserId,
                      Mail = c.Mail,
                      Text = Utils::XmlUtils.RemoveSymbols(c.Content),
+                     Premium = (int)(c.Premium ?? 1),
                  }
             ).ToList(),
                 Thread = new Xml::PacketThread()

--- a/Niconicome/Models/Domain/Niconico/Download/Comment/CommentDownloader.cs
+++ b/Niconicome/Models/Domain/Niconico/Download/Comment/CommentDownloader.cs
@@ -55,8 +55,8 @@ namespace Niconicome.Models.Domain.Niconico.Download.Comment
                 throw new InvalidOperationException("動画情報が未取得です。");
             }
 
-            string fileName = this.utils.GetFileName(settings.FileNameFormat, session.Video!.DmcInfo, ".xml");
-            string ownerFileName = this.utils.GetFileName(settings.FileNameFormat, session.Video!.DmcInfo, ".xml", "[owner]");
+            string fileName = this.utils.GetFileName(settings.FileNameFormat, session.Video!.DmcInfo, ".xml",settings.IsReplaceStrictedEnable);
+            string ownerFileName = this.utils.GetFileName(settings.FileNameFormat, session.Video!.DmcInfo, ".xml",settings.IsReplaceStrictedEnable, "[owner]");
 
             if (token.IsCancellationRequested)
             {

--- a/Niconicome/Models/Domain/Niconico/Download/Comment/CommentWriter.cs
+++ b/Niconicome/Models/Domain/Niconico/Download/Comment/CommentWriter.cs
@@ -28,6 +28,7 @@ namespace Niconicome.Models.Domain.Niconico.Download.Comment
         /// <param name="folderPath"></param>
         public void Write(IStoreCommentsData comments, string folderPath, bool overwrite)
         {
+            IOUtils.CreateDirectoryIfNotExist(folderPath, comments.Filename);
             string targetPath = this.GetFilePath(folderPath, comments.Filename, overwrite);
             this.WriteComments(comments.Chats, targetPath);
 

--- a/Niconicome/Models/Domain/Niconico/Download/Description/DescriptionDownloader.cs
+++ b/Niconicome/Models/Domain/Niconico/Download/Description/DescriptionDownloader.cs
@@ -1,0 +1,249 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.InteropServices.ComTypes;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using System.Text.Unicode;
+using Niconicome.Extensions.System;
+using Niconicome.Models.Domain.Niconico.Net.Json;
+using Niconicome.Models.Domain.Niconico.Watch;
+using Niconicome.Models.Domain.Utils;
+
+namespace Niconicome.Models.Domain.Niconico.Download.Description
+{
+    public interface IDescriptionSetting
+    {
+        string FolderName { get; set; }
+        string Format { get; set; }
+        bool IsOverwriteEnable { get; set; }
+        bool IsReplaceRestrictedEnable { get; set; }
+        bool IsSaveInJsonEnabled { get; set; }
+    }
+
+    interface IDescriptionDownloader
+    {
+        IDownloadResult DownloadVideoInfo(IDescriptionSetting setting, IWatchSession session, Action<string> onMessage);
+    }
+    public interface IVideoInfoContentProducer
+    {
+        string GetContent(IDmcInfo info);
+        string GetJsonContent(IDmcInfo info);
+    }
+
+    public class DescriptionSetting : IDescriptionSetting
+    {
+        public string FolderName { get; set; } = string.Empty;
+
+        public string Format { get; set; } = string.Empty;
+
+        public bool IsOverwriteEnable { get; set; }
+
+        public bool IsReplaceRestrictedEnable { get; set; }
+
+        public bool IsSaveInJsonEnabled { get; set; }
+    }
+
+    class DescriptionDownloader : IDescriptionDownloader
+    {
+        public DescriptionDownloader(INiconicoUtils niconicoUtils, ILogger logger, IDownloadMessenger messenger, IVideoInfoContentProducer producer)
+        {
+            this.utils = niconicoUtils;
+            this.logger = logger;
+            this.messenger = messenger;
+            this.producer = producer;
+        }
+
+        private readonly INiconicoUtils utils;
+
+        private readonly ILogger logger;
+
+        private readonly IDownloadMessenger messenger;
+
+        private readonly IVideoInfoContentProducer producer;
+
+        /// <summary>
+        /// 動画情報ファイルを保存する
+        /// </summary>
+        /// <param name="setting"></param>
+        /// <param name="dmcInfo"></param>
+        /// <returns></returns>
+        public IDownloadResult DownloadVideoInfo(IDescriptionSetting setting, IWatchSession session, Action<string> onMessage)
+        {
+            this.messenger.AddHandler(onMessage);
+
+            if (session.Video is null)
+            {
+                this.messenger.RemoveHandler(onMessage);
+                throw new InvalidOperationException("動画情報が未取得です。");
+            }
+
+            this.messenger.SendMessage($"動画情報の保存を開始します。");
+            this.logger.Log($"{session.Video.Id}の動画情報保存を開始");
+
+            string fileName;
+
+            if (setting.IsSaveInJsonEnabled)
+            {
+                fileName = this.utils.GetFileName(setting.Format, session.Video.DmcInfo, ".json", setting.IsReplaceRestrictedEnable);
+            }
+            else
+            {
+                fileName = this.utils.GetFileName(setting.Format, session.Video.DmcInfo, ".txt", setting.IsReplaceRestrictedEnable);
+            }
+
+            var filePath = Path.Combine(setting.FolderName, fileName);
+            var folderpath = Path.GetDirectoryName(filePath);
+
+            if (folderpath is null)
+            {
+                this.messenger.SendMessage($"動画情報ファイルの保存フォルダー取得に失敗しました。");
+                this.messenger.RemoveHandler(onMessage);
+                return new DownloadResult() { Message = "動画情報ファイルの保存フォルダー取得に失敗しました。" };
+            }
+
+            string content;
+
+            if (setting.IsSaveInJsonEnabled)
+            {
+                content = this.producer.GetJsonContent(session.Video.DmcInfo);
+            }
+            else
+            {
+                content = this.producer.GetContent(session.Video.DmcInfo);
+            }
+
+            try
+            {
+                using var fs = new StreamWriter(filePath);
+                fs.Write(content);
+            }
+            catch (Exception e)
+            {
+                this.messenger.SendMessage("動画情報ファイルの書き込みに失敗しました。");
+                this.logger.Error("動画情報ファイルの書き込みに失敗しました。", e);
+                this.messenger.RemoveHandler(onMessage);
+                return new DownloadResult() { Message = $"動画情報ファイルの書き込みに失敗しました。(詳細:{e.Message})" };
+            }
+
+            this.messenger.SendMessage($"動画情報ファイルを保存しました。");
+            this.messenger.RemoveHandler(onMessage);
+            return new DownloadResult() { Issucceeded = true };
+        }
+
+
+
+    }
+
+
+    public class VideoInfoContentProducer : IVideoInfoContentProducer
+    {
+        /// <summary>
+        /// 動画情報本文を取得する
+        /// </summary>
+        /// <param name="info"></param>
+        /// <returns></returns>
+        public string GetContent(IDmcInfo info)
+        {
+            var ownerNameTitle = info.ChannelName.IsNullOrEmpty() ? "[owner_nickname]" : "[channel_name]";
+            var ownerIDTitle = info.ChannelName.IsNullOrEmpty() ? "[owner_id]" : "[channel_id]";
+            var ownerName = info.ChannelName.IsNullOrEmpty() ? info.Owner : info.ChannelName;
+            var ownerID = info.ChannelName.IsNullOrEmpty() ? info.OwnerID.ToString() : info.ChannelID;
+
+            var list = new List<string>()
+            {
+                "[name]",
+                info.Id+Environment.NewLine,
+                "[post]",
+                info.UploadedOn.ToString("yyyy/MM/dd HH:mm:ss")+Environment.NewLine,
+                "[title]",
+                info.Title+Environment.NewLine,
+                "[comment]",
+                info.Description+Environment.NewLine,
+                "[tags]",
+                String.Join(Environment.NewLine,info.Tags)+Environment.NewLine,
+                "[view_counter]",
+                info.ViewCount.ToString()+Environment.NewLine,
+                "[comment_num]",
+                info.CommentCount.ToString()+Environment.NewLine,
+                "[mylist_counter]",
+                info.MylistCount.ToString()+Environment.NewLine,
+                "[length]",
+                $"{Math.Floor((double)(info.Duration/60))}分{info.Duration%60}秒"+Environment.NewLine,
+                ownerIDTitle,
+                ownerID+Environment.NewLine,
+                ownerNameTitle,
+                ownerName
+            };
+
+            return string.Join(Environment.NewLine, list);
+        }
+
+        /// <summary>
+        /// JSON文字列を取得する
+        /// </summary>
+        /// <param name="info"></param>
+        /// <returns></returns>
+        public string GetJsonContent(IDmcInfo info)
+        {
+            var data = new VideoInfoJson(info);
+            var options = new JsonSerializerOptions()
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                PropertyNameCaseInsensitive = false,
+                IgnoreNullValues = true,
+                Encoder = JavaScriptEncoder.Create(UnicodeRanges.All),
+                WriteIndented = true
+            };
+
+            return JsonParser.Serialize(data, options);
+        }
+
+        class VideoInfoJson
+        {
+            public VideoInfoJson(IDmcInfo info)
+            {
+                this.Title = info.Title;
+                this.Post = info.UploadedOn.ToString("yyyy/MM/ddTHH:mm:ss");
+                this.ID = info.Id;
+                this.Description = info.Description;
+                this.Tags = new List<string>();
+                this.Tags.AddRange(info.Tags);
+                this.ViewCount = info.ViewCount;
+                this.MylistCount = info.MylistCount;
+                this.CommentCount = info.CommentCount;
+                this.LikeCount = info.LikeCount;
+                this.Owner = info.ChannelName.IsNullOrEmpty() ? info.Owner : null;
+                this.OwnerID = info.ChannelName.IsNullOrEmpty() ? info.OwnerID.ToString() : null;
+                this.ChannelName = info.ChannelName.IsNullOrEmpty() ? null : info.ChannelName;
+                this.ChannelID = info.ChannelName.IsNullOrEmpty() ? null : info.ChannelID;
+            }
+
+            public string Title { get; init; }
+
+            public string Post { get; init; }
+
+            public string ID { get; init; }
+
+            public string Description { get; init; }
+
+            public List<string> Tags { get; init; }
+
+            public int ViewCount { get; init; }
+
+            public int CommentCount { get; init; }
+
+            public int MylistCount { get; init; }
+
+            public int LikeCount { get; init; }
+
+            public string? Owner { get; init; }
+
+            public string? OwnerID { get; init; }
+
+            public string? ChannelName { get; init; }
+
+            public string? ChannelID { get; init; }
+        }
+    }
+}

--- a/Niconicome/Models/Domain/Niconico/Download/DownloadContext.cs
+++ b/Niconicome/Models/Domain/Niconico/Download/DownloadContext.cs
@@ -11,6 +11,7 @@ namespace Niconicome.Models.Domain.Niconico.Download
     {
         string NiconicoId { get; }
         string Id { get; }
+        uint ActualVerticalResolution { get; set; }
 
         string GetLogContent();
     }
@@ -32,6 +33,12 @@ namespace Niconicome.Models.Domain.Niconico.Download
         /// ユニークなID
         /// </summary>
         public string Id { get; init; }
+
+        /// <summary>
+        /// 実際の垂直解像度
+        /// </summary>
+        public uint ActualVerticalResolution { get; set; }
+
 
         /// <summary>
         /// ログ出力可能な文字列を取得する

--- a/Niconicome/Models/Domain/Niconico/Download/Thumbnail/ThumbDownloader.cs
+++ b/Niconicome/Models/Domain/Niconico/Download/Thumbnail/ThumbDownloader.cs
@@ -29,6 +29,7 @@ namespace Niconicome.Models.Domain.Niconico.Download.Thumbnail
         string FolderName { get; }
         string FileNameFormat { get; }
         bool IsOverwriteEnable { get; }
+        bool IsReplaceStrictedEnable { get; }
     }
 
     /// <summary>
@@ -54,18 +55,22 @@ namespace Niconicome.Models.Domain.Niconico.Download.Thumbnail
             }
 
 
-            var generatedFIlename = this.niconicoUtils.GetFileName(settings.FileNameFormat, session.Video!.DmcInfo, ".jpg");
+            var generatedFIlename = this.niconicoUtils.GetFileName(settings.FileNameFormat, session.Video!.DmcInfo, ".jpg",settings.IsReplaceStrictedEnable);
             string fileName = generatedFIlename.IsNullOrEmpty() ? $"[{session.Video!.Id}]{session.Video!.Title}.jpg" : generatedFIlename;
+
+            IOUtils.CreateDirectoryIfNotExist(settings.FolderName, fileName);
 
 
             string? thumbUrl;
             if (!(session.Video!.DmcInfo.ThumbInfo.Large?.IsNullOrEmpty() ?? true))
             {
                 thumbUrl = session.Video!.DmcInfo.ThumbInfo.Large;
-            } else if (!(session.Video!.DmcInfo.ThumbInfo.Normal?.IsNullOrEmpty() ?? true))
+            }
+            else if (!(session.Video!.DmcInfo.ThumbInfo.Normal?.IsNullOrEmpty() ?? true))
             {
                 thumbUrl = session.Video!.DmcInfo.ThumbInfo.Normal;
-            } else
+            }
+            else
             {
                 return new DownloadResult() { Issucceeded = false, Message = "サムネイルのURLを取得できませんでした。" };
             }
@@ -190,6 +195,9 @@ namespace Niconicome.Models.Domain.Niconico.Download.Thumbnail
         public string FileNameFormat { get; set; } = string.Empty;
 
         public bool IsOverwriteEnable { get; set; }
+
+        public bool IsReplaceStrictedEnable { get; set; }
+
 
     }
 

--- a/Niconicome/Models/Domain/Niconico/Download/Video/VideoDownloader.cs
+++ b/Niconicome/Models/Domain/Niconico/Download/Video/VideoDownloader.cs
@@ -58,6 +58,7 @@ namespace Niconicome.Models.Domain.Niconico.Download.Video
         string FileNameFormat { get; }
         bool IsOverwriteEnable { get; }
         bool IsAutoDisposingEnable { get; }
+        bool IsReplaceStrictedEnable { get; }
         uint VerticalResolution { get; }
         int MaxParallelDownloadCount { get; }
     }
@@ -125,7 +126,7 @@ namespace Niconicome.Models.Domain.Niconico.Download.Video
             }
 
 
-            string fileName = !settings.FileNameFormat.IsNullOrEmpty() ? this.utils.GetFileName(settings.FileNameFormat, session.Video!.DmcInfo, ".mp4")
+            string fileName = !settings.FileNameFormat.IsNullOrEmpty() ? this.utils.GetFileName(settings.FileNameFormat, session.Video!.DmcInfo, ".mp4", settings.IsReplaceStrictedEnable)
                 : $"[{session.Video!.Id}]{session.Video!.Title}.mp4"
                 ;
 
@@ -459,6 +460,7 @@ namespace Niconicome.Models.Domain.Niconico.Download.Video
         public bool IsOverwriteEnable { get; set; }
 
         public bool IsAutoDisposingEnable { get; set; }
+        public bool IsReplaceStrictedEnable { get; set; }
 
         public uint VerticalResolution { get; set; }
 

--- a/Niconicome/Models/Domain/Niconico/Download/Video/VideoDownloader.cs
+++ b/Niconicome/Models/Domain/Niconico/Download/Video/VideoDownloader.cs
@@ -59,6 +59,7 @@ namespace Niconicome.Models.Domain.Niconico.Download.Video
         bool IsOverwriteEnable { get; }
         bool IsAutoDisposingEnable { get; }
         bool IsReplaceStrictedEnable { get; }
+        bool IsOvwrridingFileDTEnable { get; }
         uint VerticalResolution { get; }
         int MaxParallelDownloadCount { get; }
     }
@@ -183,7 +184,9 @@ namespace Niconicome.Models.Domain.Niconico.Download.Video
                 FileName = fileName,
                 FolderName = settings.FolderName,
                 TsFilePaths = this.videoDownloadHelper.GetAllFileAbsPaths(),
-                IsOverwriteEnable = settings.IsOverwriteEnable
+                IsOverwriteEnable = settings.IsOverwriteEnable,
+                IsOverrideDTEnable = settings.IsOvwrridingFileDTEnable,
+                UploadedOn = session.Video.DmcInfo.UploadedOn,
             };
 
             try
@@ -460,7 +463,11 @@ namespace Niconicome.Models.Domain.Niconico.Download.Video
         public bool IsOverwriteEnable { get; set; }
 
         public bool IsAutoDisposingEnable { get; set; }
+
         public bool IsReplaceStrictedEnable { get; set; }
+
+        public bool IsOvwrridingFileDTEnable { get; set; }
+
 
         public uint VerticalResolution { get; set; }
 

--- a/Niconicome/Models/Domain/Niconico/Download/Video/VideoDownloader.cs
+++ b/Niconicome/Models/Domain/Niconico/Download/Video/VideoDownloader.cs
@@ -305,7 +305,7 @@ namespace Niconicome.Models.Domain.Niconico.Download.Video
             var resolution = context.ActualVerticalResolution == 0 ? string.Empty : $"（{context.ActualVerticalResolution}px）";
             Exception? ex = null;
 
-            var tasks = stream.StreamUrls.Select(url => new ParallelDownloadTask(async self =>
+            var tasks = stream.StreamUrls.Select(url => new ParallelDownloadTask(async (self, _) =>
             {
                 if (token.IsCancellationRequested || ex is not null) return;
 
@@ -417,7 +417,7 @@ namespace Niconicome.Models.Domain.Niconico.Download.Video
     /// </summary>
     public class ParallelDownloadTask : IParallelDownloadTask
     {
-        public ParallelDownloadTask(Func<IParallelDownloadTask, Task> taskFunc, IDownloadContext context, string url, int sequenceZero, string filename)
+        public ParallelDownloadTask(Func<IParallelDownloadTask, object, Task> taskFunc, IDownloadContext context, string url, int sequenceZero, string filename)
         {
             this.TaskFunction = taskFunc;
             this.TaskId = Guid.NewGuid();
@@ -444,7 +444,7 @@ namespace Niconicome.Models.Domain.Niconico.Download.Video
 
         public Guid TaskId { get; init; }
 
-        public Func<IParallelDownloadTask, Task> TaskFunction { get; init; }
+        public Func<IParallelDownloadTask, object, Task> TaskFunction { get; init; }
 
         public Action<int> OnWait { get; init; }
     }

--- a/Niconicome/Models/Domain/Niconico/Download/Video/VideoEncoader.cs
+++ b/Niconicome/Models/Domain/Niconico/Download/Video/VideoEncoader.cs
@@ -63,10 +63,7 @@ namespace Niconicome.Models.Domain.Niconico.Download.Video
             string mp4Foldername = this.GetFolderPath(settings.FolderName);
             string mp4Filename = this.GetFilePath(settings.FileName, mp4Foldername, settings.IsOverwriteEnable);
 
-            if (!Directory.Exists(mp4Foldername))
-            {
-                Directory.CreateDirectory(mp4Foldername);
-            }
+            IOUtils.CreateDirectoryIfNotExist(mp4Foldername, mp4Filename);
 
             this.Mp4FilePath = mp4Filename;
 

--- a/Niconicome/Models/Domain/Niconico/Download/Video/VideoEncoader.cs
+++ b/Niconicome/Models/Domain/Niconico/Download/Video/VideoEncoader.cs
@@ -28,6 +28,8 @@ namespace Niconicome.Models.Domain.Niconico.Download.Video
         string FileName { get; }
         string FolderName { get; }
         bool IsOverwriteEnable { get; }
+        bool IsOverrideDTEnable { get; }
+        DateTime UploadedOn { get; }
         IEnumerable<string> TsFilePaths { get; }
     }
 
@@ -96,6 +98,18 @@ namespace Niconicome.Models.Domain.Niconico.Download.Video
             messenger.SendMessage("ffmpegで変換を開始(.ts=>.mp4)");
             await this.encodeutility.EncodeAsync(targetFilePath, mp4Filename, token, LocalFile::EncodeOptions.Copy);
             messenger.SendMessage("ffmpegの変換が完了");
+
+            if (settings.IsOverrideDTEnable)
+            {
+                try
+                {
+                    File.SetLastWriteTime(mp4Filename, settings.UploadedOn);
+                }
+                catch (Exception ex)
+                {
+                    throw new IOException($"動画ファイルの更新日時書き換え中にエラーが発生しました。(詳細:{ex.Message})");
+                }
+            }
         }
 
         /// <summary>
@@ -163,6 +177,10 @@ namespace Niconicome.Models.Domain.Niconico.Download.Video
         public string FolderName { get; set; } = string.Empty;
 
         public bool IsOverwriteEnable { get; set; }
+
+        public bool IsOverrideDTEnable { get; set; }
+
+        public DateTime UploadedOn { get; set; }
 
         public IEnumerable<string> TsFilePaths { get; set; } = new List<string>();
     }

--- a/Niconicome/Models/Domain/Niconico/Net/Json/JsonParser.cs
+++ b/Niconicome/Models/Domain/Niconico/Net/Json/JsonParser.cs
@@ -29,8 +29,8 @@ namespace Niconicome.Models.Domain.Niconico.Net.Json
                 PropertyNameCaseInsensitive = false,
                 IgnoreNullValues = true,
                 Encoder = JavaScriptEncoder.Create(UnicodeRanges.All),
-            //DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault,
-        };
+                //DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault,
+            };
 
             T? instance = JsonSerializer.Deserialize<T>(source, options);
             //nullチェック
@@ -45,17 +45,20 @@ namespace Niconicome.Models.Domain.Niconico.Net.Json
         /// <typeparam name="T"></typeparam>
         /// <param name="source"></param>
         /// <returns></returns>
-        public static string Serialize<T>(T source)
+        public static string Serialize<T>(T source, JsonSerializerOptions? options = null)
         {
 
-            var options = new JsonSerializerOptions()
+            if (options is null)
             {
-                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-                PropertyNameCaseInsensitive = false,
-                IgnoreNullValues = true,
-                Encoder = JavaScriptEncoder.Create(UnicodeRanges.All),
-                //DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault,
-            };
+                options = new JsonSerializerOptions()
+                {
+                    PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                    PropertyNameCaseInsensitive = false,
+                    IgnoreNullValues = true,
+                    Encoder = JavaScriptEncoder.Create(UnicodeRanges.All),
+                    //DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault,
+                };
+            }
 
             string json = JsonSerializer.Serialize<T>(source, options);
 

--- a/Niconicome/Models/Domain/Niconico/Net/Json/WatchPage/DataApiData.cs
+++ b/Niconicome/Models/Domain/Niconico/Net/Json/WatchPage/DataApiData.cs
@@ -19,6 +19,9 @@ namespace Niconicome.Models.Domain.Niconico.Net.Json.WatchPage
 
         [JsonPropertyName("context")]
         public Context Context { get; set; } = new();
+
+        [JsonPropertyName("channel")]
+        public Channel? Channel { get; set; }
     }
 
     public partial class CommentComposite
@@ -207,6 +210,12 @@ namespace Niconicome.Models.Domain.Niconico.Net.Json.WatchPage
 
         [JsonPropertyName("nickname")]
         public string? Nickname { get; set; }
+    }
+
+    public class Channel
+    {
+        [JsonPropertyName("name")]
+        public string? Name { get; set; }
     }
 
 }

--- a/Niconicome/Models/Domain/Niconico/Net/Json/WatchPage/V2/DataApiData.cs
+++ b/Niconicome/Models/Domain/Niconico/Net/Json/WatchPage/V2/DataApiData.cs
@@ -223,6 +223,9 @@ namespace Niconicome.Models.Domain.Niconico.Net.Json.WatchPage.V2
 
         [JsonPropertyName("isAuthenticationRequired")]
         public bool IsAuthenticationRequired { get; set; }
+
+        [JsonPropertyName("description")]
+        public string Description { get; set; } = string.Empty;
     }
     public class Owner
     {

--- a/Niconicome/Models/Domain/Niconico/NiconicoContext.cs
+++ b/Niconicome/Models/Domain/Niconico/NiconicoContext.cs
@@ -90,7 +90,7 @@ namespace Niconicome.Models.Domain.Niconico
         public CookieManager(IDbUrlHandler urlHandler)
         {
             this.urlHandler = urlHandler;
-            this.niconicoBaseUri = this.urlHandler.GetUriFromDB("NiconicoBaseUri", "https://nicovideo.jp");
+            this.niconicoBaseUri = new Uri("http://nicovideo.jp"); //this.urlHandler.GetUriFromDB("NiconicoBaseUri", "https://nicovideo.jp");
         }
 
         private readonly IDbUrlHandler urlHandler;
@@ -335,6 +335,8 @@ namespace Niconicome.Models.Domain.Niconico
         {
             if (this.IsLogin) return true;
 
+            this.cookieManager.DeleteAllCookies();
+
             var data = new Dictionary<string, string>()
             {
                 {"mail_tel",username },
@@ -372,6 +374,7 @@ namespace Niconicome.Models.Domain.Niconico
         {
             if (!this.IsLogin) return;
             await this.http.GetAsync(this.niconicoLogoutUri);
+            this.cookieManager.DeleteAllCookies();
         }
 
         /// <summary>

--- a/Niconicome/Models/Domain/Niconico/NiconicoContext.cs
+++ b/Niconicome/Models/Domain/Niconico/NiconicoContext.cs
@@ -88,13 +88,10 @@ namespace Niconicome.Models.Domain.Niconico
     public class CookieManager : ICookieManager
     {
 
-        public CookieManager(IDbUrlHandler urlHandler)
+        public CookieManager()
         {
-            this.urlHandler = urlHandler;
             this.niconicoBaseUri = new Uri("http://nicovideo.jp"); 
         }
-
-        private readonly IDbUrlHandler urlHandler;
 
         private readonly Uri niconicoBaseUri;
 

--- a/Niconicome/Models/Domain/Niconico/NiconicoContext.cs
+++ b/Niconicome/Models/Domain/Niconico/NiconicoContext.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Net;
 using System.Net.Http;
+using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Niconicome.Models.Domain.Local;
@@ -90,7 +91,7 @@ namespace Niconicome.Models.Domain.Niconico
         public CookieManager(IDbUrlHandler urlHandler)
         {
             this.urlHandler = urlHandler;
-            this.niconicoBaseUri = new Uri("http://nicovideo.jp"); //this.urlHandler.GetUriFromDB("NiconicoBaseUri", "https://nicovideo.jp");
+            this.niconicoBaseUri = new Uri("http://nicovideo.jp"); 
         }
 
         private readonly IDbUrlHandler urlHandler;
@@ -184,15 +185,15 @@ namespace Niconicome.Models.Domain.Niconico
     {
         public NicoHttp(HttpClient client, IDbUrlHandler dbUrlHandler)
         {
-
-
             //ニコニコのアドレスを設定
             this.NiconicoBaseUri = dbUrlHandler.GetUriFromDB(nameof(this.NiconicoBaseUri), "https://nicovideo.jp");
             this.NiconicoLoginUri = dbUrlHandler.GetUriFromDB(nameof(this.NiconicoLoginUri), "https://secure.nicovideo.jp/secure/login?site=niconico");
             this.NiconicoLogoutUri = dbUrlHandler.GetUriFromDB(nameof(this.NiconicoLogoutUri), "https://account.nicovideo.jp/logout");
 
+            var version = Assembly.GetExecutingAssembly().GetName().Version;
+
             client.DefaultRequestHeaders.Referrer = this.NiconicoBaseUri;
-            client.DefaultRequestHeaders.UserAgent.ParseAdd("Mozilla/5.0 (Niconicome/0.0.0.0)");
+            client.DefaultRequestHeaders.UserAgent.ParseAdd($"Mozilla/5.0 (Niconicome/{version?.Major}.{version?.Minor}.{version?.Build})");
             client.DefaultRequestHeaders.Add("X-Frontend-Id", "6");
             client.DefaultRequestHeaders.Add("X-Frontend-Version", "0");
 

--- a/Niconicome/Models/Domain/Niconico/Watch/WatchInfohandler.cs
+++ b/Niconicome/Models/Domain/Niconico/Watch/WatchInfohandler.cs
@@ -23,6 +23,7 @@ namespace Niconicome.Models.Domain.Niconico.Watch
     {
         string Title { get; set; }
         string Id { get; set; }
+        string ChannelID { get; set; }
         int ViewCount { get; }
         IEnumerable<string> Tags { get; set; }
         IDmcInfo DmcInfo { get; set; }
@@ -35,6 +36,7 @@ namespace Niconicome.Models.Domain.Niconico.Watch
         string Owner { get; set; }
         string Userkey { get; }
         string UserId { get; }
+        string ChannelID { get; }
         int ViewCount { get; }
         int Duration { get; }
         IEnumerable<string> Tags { get; set; }
@@ -156,7 +158,7 @@ namespace Niconicome.Models.Domain.Niconico.Watch
             }
 
             this.State = WatchInfoHandlerState.OK;
-            return new DomainVideoInfo() { Id = info.Id, Title = info.Title, Tags = info.Tags, DmcInfo = info, ViewCount = info.ViewCount };
+            return new DomainVideoInfo() { Id = info.Id, Title = info.Title, Tags = info.Tags, DmcInfo = info, ViewCount = info.ViewCount,ChannelID = info.ChannelID };
         }
     }
 
@@ -254,6 +256,9 @@ namespace Niconicome.Models.Domain.Niconico.Watch
 
             //時間
             info.Duration = original?.Video?.Duration ?? 0;
+
+            //チャンネルID
+            info.ChannelID = original?.Channel?.Name ?? string.Empty;
 
             //Session情報
             if (!options.HasFlag(WatchInfoOptions.NoDmcData) && original?.Media?.Delivery is not null)
@@ -356,6 +361,11 @@ namespace Niconicome.Models.Domain.Niconico.Watch
         /// </summary>
         public string FileName { get; set; } = string.Empty;
 
+        /// <summary>
+        /// チャンネルID
+        /// </summary>
+        public string ChannelID { get; set; } = string.Empty;
+
 
         /// <summary>
         /// 再生回数
@@ -389,6 +399,8 @@ namespace Niconicome.Models.Domain.Niconico.Watch
         public string Userkey { get; set; } = string.Empty;
 
         public string UserId { get; set; } = string.Empty;
+
+        public string ChannelID { get; set; } = string.Empty;
 
         public int ViewCount { get; set; }
 

--- a/Niconicome/Models/Domain/Niconico/Watch/WatchInfohandler.cs
+++ b/Niconicome/Models/Domain/Niconico/Watch/WatchInfohandler.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net.Http;
 using System.Threading.Tasks;
 using AngleSharp.Html.Dom;
 using Niconicome.Extensions.System;
@@ -46,6 +47,7 @@ namespace Niconicome.Models.Domain.Niconico.Watch
         bool IsEncrypted { get; set; }
         bool IsOfficial { get; set; }
         DateTime UploadedOn { get; set; }
+        DateTime DownloadStartedOn { get; set; }
         IThumbInfo ThumbInfo { get; }
         ISessionInfo SessionInfo { get; }
         List<WatchJson::Thread> CommentThreads { get; }
@@ -124,18 +126,17 @@ namespace Niconicome.Models.Domain.Niconico.Watch
             Uri url = NiconicoContext.Context.GetPageUri(id);
 
             var res = await this.http.GetAsync(url);
-            source = await res.Content.ReadAsStringAsync();
 
-            //try
-            //{
-            //    source = await this.http.GetStringAsync(url);
-            //}
-            //catch (Exception e)
-            //{
-            //    this.logger.Error($"動画情報の取得に失敗しました(url: {url.AbsoluteUri})", e);
-            //    this.State = WatchInfoHandlerState.HttpRequestFailure;
-            //    throw new HttpRequestException();
-            //}
+            try
+            {
+                source = await this.http.GetStringAsync(url);
+            }
+            catch (Exception e)
+            {
+                this.logger.Error($"動画情報の取得に失敗しました(url: {url.AbsoluteUri})", e);
+                this.State = WatchInfoHandlerState.HttpRequestFailure;
+                throw new HttpRequestException();
+            }
 
             IDmcInfo info;
 
@@ -437,6 +438,12 @@ namespace Niconicome.Models.Domain.Niconico.Watch
         /// 投稿日時
         /// </summary>
         public DateTime UploadedOn { get; set; }
+
+        /// <summary>
+        /// DL開始日時
+        /// </summary>
+        public DateTime DownloadStartedOn { get; set; }
+
 
         /// <summary>
         /// サムネイル

--- a/Niconicome/Models/Domain/Niconico/Watch/WatchInfohandler.cs
+++ b/Niconicome/Models/Domain/Niconico/Watch/WatchInfohandler.cs
@@ -24,6 +24,7 @@ namespace Niconicome.Models.Domain.Niconico.Watch
         string Title { get; set; }
         string Id { get; set; }
         string ChannelID { get; set; }
+        string ChannelName { get; set; }
         int ViewCount { get; }
         IEnumerable<string> Tags { get; set; }
         IDmcInfo DmcInfo { get; set; }
@@ -37,6 +38,7 @@ namespace Niconicome.Models.Domain.Niconico.Watch
         string Userkey { get; }
         string UserId { get; }
         string ChannelID { get; }
+        string ChannelName { get; }
         int ViewCount { get; }
         int Duration { get; }
         IEnumerable<string> Tags { get; set; }
@@ -158,7 +160,7 @@ namespace Niconicome.Models.Domain.Niconico.Watch
             }
 
             this.State = WatchInfoHandlerState.OK;
-            return new DomainVideoInfo() { Id = info.Id, Title = info.Title, Tags = info.Tags, DmcInfo = info, ViewCount = info.ViewCount,ChannelID = info.ChannelID };
+            return new DomainVideoInfo() { Id = info.Id, Title = info.Title, Tags = info.Tags, DmcInfo = info, ViewCount = info.ViewCount,ChannelID = info.ChannelID,ChannelName = info.ChannelName };
         }
     }
 
@@ -257,8 +259,9 @@ namespace Niconicome.Models.Domain.Niconico.Watch
             //時間
             info.Duration = original?.Video?.Duration ?? 0;
 
-            //チャンネルID
-            info.ChannelID = original?.Channel?.Name ?? string.Empty;
+            //チャンネル情報
+            info.ChannelID = original?.Channel?.Id ?? string.Empty;
+            info.ChannelName = original?.Channel?.Name ?? string.Empty;
 
             //Session情報
             if (!options.HasFlag(WatchInfoOptions.NoDmcData) && original?.Media?.Delivery is not null)
@@ -366,6 +369,10 @@ namespace Niconicome.Models.Domain.Niconico.Watch
         /// </summary>
         public string ChannelID { get; set; } = string.Empty;
 
+        /// <summary>
+        /// チャンネル名
+        /// </summary>
+        public string ChannelName { get; set; } = string.Empty;
 
         /// <summary>
         /// 再生回数
@@ -401,6 +408,8 @@ namespace Niconicome.Models.Domain.Niconico.Watch
         public string UserId { get; set; } = string.Empty;
 
         public string ChannelID { get; set; } = string.Empty;
+
+        public string ChannelName { get; set; } = string.Empty;
 
         public int ViewCount { get; set; }
 

--- a/Niconicome/Models/Domain/Utils/DIFactory.cs
+++ b/Niconicome/Models/Domain/Utils/DIFactory.cs
@@ -26,6 +26,8 @@ using UVideo = Niconicome.Models.Domain.Niconico.Video;
 using DomainXeno = Niconicome.Models.Domain.Local.External.Import.Xeno;
 using Import = Niconicome.Models.Local.External.Import;
 using Handlers = Niconicome.Models.Domain.Local.Handlers;
+using SQlite = Niconicome.Models.Domain.Local.SQLite;
+using Cookies = Niconicome.Models.Domain.Local.Cookies;
 
 namespace Niconicome.Models.Domain.Utils
 {
@@ -70,7 +72,7 @@ namespace Niconicome.Models.Domain.Utils
             services.AddTransient<DomainNet::ICacheStraem, DomainNet::CacheStream>();
             services.AddTransient<Net::INetworkVideoHandler, Net::NetworkVideoHandler>();
             services.AddSingleton<State::IMessageHandler, State::MessageHandler>();
-            services.AddTransient<Auth::IAccountManager, Auth::AccountManager>();
+            services.AddTransient<Niconico::IAccountManager, Niconico::AccountManager>();
             services.AddTransient<DomainWatch::IDmcDataHandler, DomainWatch::DmcDataHandler>();
             services.AddTransient<DomainWatch::IWatchSession, DomainWatch::WatchSession>();
             services.AddTransient<DomainWatch::IWatchPlaylisthandler, DomainWatch::WatchPlaylistHandler>();
@@ -88,7 +90,7 @@ namespace Niconicome.Models.Domain.Utils
             services.AddTransient<Search::ISearch, Search::Search>();
             services.AddTransient<Search::ISearchClient, Search::SearchClient>();
             services.AddSingleton<State::IErrorMessanger, State::ErrorMessenger>();
-            services.AddTransient<MyApplication::IStartUp, MyApplication::StartUp>();
+            services.AddSingleton<MyApplication::IStartUp, MyApplication::StartUp>();
             services.AddTransient<Store::ISettingHandler, Store::SettingHandler>();
             services.AddTransient<Local::ILocalSettingHandler, Local::LocalSettingHandler>();
             services.AddTransient<INiconicoUtils, NiconicoUtils>();
@@ -117,6 +119,14 @@ namespace Niconicome.Models.Domain.Utils
             services.AddTransient<Store::IVideoDirectoryStoreHandler, Store::VideoDirectoryStoreHandler>();
             services.AddTransient<Net::ILocalContentHandler, Net::LocalContentHandler>();
             services.AddTransient<Handlers::ICoreWebview2Handler, Handlers::CoreWebview2Handler>();
+            services.AddTransient<Auth::IAutoLogin, Auth::AutoLogin>();
+            services.AddSingleton<State::ISnackbarHandler, State::SnackbarHandler>();
+            services.AddTransient<SQlite::ISQliteLoader, SQlite::SQliteLoader>();
+            services.AddTransient<SQlite::ISqliteCookieLoader, SQlite::SqliteCookieLoader>();
+            services.AddTransient<Cookies::IChromeCookieDecryptor, Cookies::ChromeCookieDecryptor>();
+            services.AddTransient<LocalFile::ICookieJsonLoader, LocalFile::CookieJsonLoader>();
+            services.AddTransient<Cookies::IWebview2LocalCookieManager, Cookies::Webview2LocalCookieManager>();
+            services.AddTransient<Auth::IWebview2SharedLogin, Auth::Webview2SharedLogin>();
 
             return services.BuildServiceProvider();
         }

--- a/Niconicome/Models/Domain/Utils/DIFactory.cs
+++ b/Niconicome/Models/Domain/Utils/DIFactory.cs
@@ -70,7 +70,7 @@ namespace Niconicome.Models.Domain.Utils
             services.AddTransient<State::ILocalInfo, State::LocalInfo>();
             services.AddTransient<DomainNet::ICacheHandler, DomainNet::CacheHandler>();
             services.AddTransient<DomainNet::ICacheStraem, DomainNet::CacheStream>();
-            services.AddTransient<Net::INetworkVideoHandler, Net::NetworkVideoHandler>();
+            services.AddSingleton<Net::INetworkVideoHandler, Net::NetworkVideoHandler>();
             services.AddSingleton<State::IMessageHandler, State::MessageHandler>();
             services.AddTransient<Niconico::IAccountManager, Niconico::AccountManager>();
             services.AddTransient<DomainWatch::IDmcDataHandler, DomainWatch::DmcDataHandler>();
@@ -127,6 +127,8 @@ namespace Niconicome.Models.Domain.Utils
             services.AddTransient<LocalFile::ICookieJsonLoader, LocalFile::CookieJsonLoader>();
             services.AddTransient<Cookies::IWebview2LocalCookieManager, Cookies::Webview2LocalCookieManager>();
             services.AddTransient<Auth::IWebview2SharedLogin, Auth::Webview2SharedLogin>();
+            services.AddTransient<LocalFile::ILocalDirectoryHandler, LocalFile::LocalDirectoryHandler>();
+            services.AddTransient<Net::IVideoIDHandler, Net::VideoIDHandler>();
 
             return services.BuildServiceProvider();
         }

--- a/Niconicome/Models/Domain/Utils/DIFactory.cs
+++ b/Niconicome/Models/Domain/Utils/DIFactory.cs
@@ -2,32 +2,33 @@
 using Microsoft.Extensions.DependencyInjection;
 using Auth = Niconicome.Models.Auth;
 using Channel = Niconicome.Models.Domain.Niconico.Video.Channel;
+using Cookies = Niconicome.Models.Domain.Local.Cookies;
 using DataBase = Niconicome.Models.Domain.Local;
 using DlComment = Niconicome.Models.Domain.Niconico.Download.Comment;
 using DlThumb = Niconicome.Models.Domain.Niconico.Download.Thumbnail;
 using DlVideo = Niconicome.Models.Domain.Niconico.Download.Video;
 using Dmc = Niconicome.Models.Domain.Niconico.Dmc;
+using DomainDownload = Niconicome.Models.Domain.Niconico.Download;
 using DomainNet = Niconicome.Models.Domain.Network;
 using DomainPlaylist = Niconicome.Models.Domain.Local.Playlist;
 using DomainWatch = Niconicome.Models.Domain.Niconico.Watch;
-using Download = Niconicome.Models.Domain.Niconico.Download;
-using LocalFile = Niconicome.Models.Domain.Local.LocalFile;
+using DomainXeno = Niconicome.Models.Domain.Local.External.Import.Xeno;
+using Download = Niconicome.Models.Network.Download;
+using Handlers = Niconicome.Models.Domain.Local.Handlers;
+using Import = Niconicome.Models.Local.External.Import;
 using Local = Niconicome.Models.Local;
+using LocalFile = Niconicome.Models.Domain.Local.LocalFile;
 using MyApplication = Niconicome.Models.Local.Application;
 using Mylist = Niconicome.Models.Domain.Niconico.Mylist;
 using Net = Niconicome.Models.Network;
 using Niconico = Niconicome.Models.Domain.Niconico;
 using Playlist = Niconicome.Models.Playlist;
 using Search = Niconicome.Models.Domain.Niconico.Search;
+using SQlite = Niconicome.Models.Domain.Local.SQLite;
 using State = Niconicome.Models.Local.State;
 using Store = Niconicome.Models.Domain.Local.Store;
 using Utils = Niconicome.Models.Domain.Utils;
 using UVideo = Niconicome.Models.Domain.Niconico.Video;
-using DomainXeno = Niconicome.Models.Domain.Local.External.Import.Xeno;
-using Import = Niconicome.Models.Local.External.Import;
-using Handlers = Niconicome.Models.Domain.Local.Handlers;
-using SQlite = Niconicome.Models.Domain.Local.SQLite;
-using Cookies = Niconicome.Models.Domain.Local.Cookies;
 
 namespace Niconicome.Models.Domain.Utils
 {
@@ -81,10 +82,10 @@ namespace Niconicome.Models.Domain.Utils
             services.AddTransient<DlVideo::IVideoDownloadHelper, DlVideo::VideoDownloadHelper>();
             services.AddTransient<DlVideo::IVideoDownloader, DlVideo::VideoDownloader>();
             services.AddTransient<DlVideo::ISegmentWriter, DlVideo::SegmentWriter>();
-            services.AddTransient<Download::IDownloadMessenger, Download::DownloadMessanger>();
+            services.AddTransient<DomainDownload::IDownloadMessenger, DomainDownload::DownloadMessanger>();
             services.AddTransient<DlVideo::IVideoEncoader, DlVideo::VideoEncoader>();
             services.AddTransient<DlVideo::ITsMerge, DlVideo::TsMerge>();
-            services.AddTransient<Net::IContentDownloader, Net::ContentDownloader>();
+            services.AddSingleton<Download::IContentDownloader, Download::ContentDownloader>();
             services.AddTransient<DlThumb::IThumbDownloader, DlThumb::ThumbDownloader>();
             services.AddTransient<Playlist::IVideoFilter, Playlist::VideoFilter>();
             services.AddTransient<Search::ISearch, Search::Search>();
@@ -117,7 +118,9 @@ namespace Niconicome.Models.Domain.Utils
             services.AddTransient<DomainXeno::IXenoPlaylistConverter, DomainXeno::XenoPlaylistConverter>();
             services.AddTransient<Import::IXenoImportGeneralManager, Import::XenoImportGeneralManager>();
             services.AddTransient<Store::IVideoDirectoryStoreHandler, Store::VideoDirectoryStoreHandler>();
-            services.AddTransient<Net::ILocalContentHandler, Net::LocalContentHandler>();
+            services.AddTransient<Download::ILocalContentHandler, Download::LocalContentHandler>();
+            services.AddTransient<Download::IDownloadTaskPool, Download::DownloadTaskPool>();
+            services.AddSingleton<Download::IDownloadTasksHandler, Download::DownloadTasksHandler>();
             services.AddTransient<Handlers::ICoreWebview2Handler, Handlers::CoreWebview2Handler>();
             services.AddTransient<Auth::IAutoLogin, Auth::AutoLogin>();
             services.AddSingleton<State::ISnackbarHandler, State::SnackbarHandler>();

--- a/Niconicome/Models/Domain/Utils/DIFactory.cs
+++ b/Niconicome/Models/Domain/Utils/DIFactory.cs
@@ -5,6 +5,7 @@ using Channel = Niconicome.Models.Domain.Niconico.Video.Channel;
 using Cookies = Niconicome.Models.Domain.Local.Cookies;
 using DataBase = Niconicome.Models.Domain.Local;
 using DlComment = Niconicome.Models.Domain.Niconico.Download.Comment;
+using DlDescription = Niconicome.Models.Domain.Niconico.Download.Description;
 using DlThumb = Niconicome.Models.Domain.Niconico.Download.Thumbnail;
 using DlVideo = Niconicome.Models.Domain.Niconico.Download.Video;
 using Dmc = Niconicome.Models.Domain.Niconico.Dmc;
@@ -132,6 +133,8 @@ namespace Niconicome.Models.Domain.Utils
             services.AddTransient<Auth::IWebview2SharedLogin, Auth::Webview2SharedLogin>();
             services.AddTransient<LocalFile::ILocalDirectoryHandler, LocalFile::LocalDirectoryHandler>();
             services.AddTransient<Net::IVideoIDHandler, Net::VideoIDHandler>();
+            services.AddTransient<DlDescription::IDescriptionDownloader, DlDescription::DescriptionDownloader>();
+            services.AddTransient<DlDescription::IVideoInfoContentProducer, DlDescription::VideoInfoContentProducer>();
 
             return services.BuildServiceProvider();
         }

--- a/Niconicome/Models/Domain/Utils/IOUtils.cs
+++ b/Niconicome/Models/Domain/Utils/IOUtils.cs
@@ -37,5 +37,20 @@ namespace Niconicome.Models.Domain.Utils
                 return filepath;
             }
         }
+
+        /// <summary>
+        /// パスが存在しない場合作成する
+        /// </summary>
+        /// <param name="folderPath"></param>
+        /// <param name="fileName"></param>
+        public static void CreateDirectoryIfNotExist(string folderPath,string fileName)
+        {
+            var path = Path.Combine(folderPath, fileName);
+            var dirname = Path.GetDirectoryName(path);
+            if (dirname is not null&&!Directory.Exists(dirname))
+            {
+                Directory.CreateDirectory(dirname);
+            }
+        }
     }
 }

--- a/Niconicome/Models/Domain/Utils/NiconicoUtils.cs
+++ b/Niconicome/Models/Domain/Utils/NiconicoUtils.cs
@@ -8,6 +8,7 @@ using Watch = Niconicome.Models.Domain.Niconico.Watch;
 using System.IO;
 using Niconicome.Models.Playlist;
 using Niconicome.Extensions.System;
+using Niconicome.Models.Domain.Niconico.Watch;
 
 namespace Niconicome.Models.Domain.Utils
 {
@@ -45,10 +46,12 @@ namespace Niconicome.Models.Domain.Utils
         {
             string filename = format.Replace("<id>", dmcInfo.Id)
                          .Replace("<title>", dmcInfo.Title)
-                         .Replace("<uploadedon>", dmcInfo.UploadedOn.ToString("yyyy/MM/dd HH:mm.ss"))
                          .Replace("<owner>", dmcInfo.Owner)
                          + suffix
                          + extension;
+
+            filename = this.GetDateReplacedString(filename, dmcInfo);
+
             if (replaceStricted)
             {
                 filename = filename
@@ -64,7 +67,38 @@ namespace Niconicome.Models.Domain.Utils
             {
                 filename = Regex.Replace(filename, @"[/:\*\?\<\>\|""]", "");
             }
+
+
             return filename;
+        }
+
+        /// <summary>
+        /// 日付情報を取得する
+        /// </summary>
+        /// <param name="format"></param>
+        /// <param name="dt"></param>
+        /// <returns></returns>
+        private string GetDateReplacedString(string format,IDmcInfo info)
+        {
+            if (Regex.IsMatch(format, "^.*<uploadedon:.+>.*$"))
+            {
+                var match = Regex.Match(format, "<uploadedon:.+>");
+                var customFormat = match.Value[12..^1];
+                return format.Replace(match.Value, info.UploadedOn.ToString(customFormat));
+
+            } else if (Regex.IsMatch(format, "^.*<downloadon:.+>.*$"))
+            {
+                var match = Regex.Match(format, "<downloadon:.+>");
+                var customFormat = match.Value[12..^1];
+                return format.Replace(match.Value, info.DownloadStartedOn.ToString(customFormat));
+
+            }
+            else
+            {
+                return format.Replace("<uploadedon>", info.UploadedOn.ToString("yyyy-MM-dd HH-mm-ss"))
+                    .Replace("<downloadon>",info.DownloadStartedOn.ToString("yyyy-MM-dd HH-mm-ss"))
+                    ;
+            }
         }
 
         /// <summary>

--- a/Niconicome/Models/Domain/Utils/NiconicoUtils.cs
+++ b/Niconicome/Models/Domain/Utils/NiconicoUtils.cs
@@ -6,6 +6,8 @@ using System.Threading.Tasks;
 using System.Text.RegularExpressions;
 using Watch = Niconicome.Models.Domain.Niconico.Watch;
 using System.IO;
+using Niconicome.Models.Playlist;
+using Niconicome.Extensions.System;
 
 namespace Niconicome.Models.Domain.Utils
 {
@@ -14,7 +16,10 @@ namespace Niconicome.Models.Domain.Utils
         List<string> GetNiconicoIdsFromText(string source);
         string GetFileName(string format, Watch::IDmcInfo dmcInfo, string extension, string? suffix = null);
         string GetIdFromFIleName(string format, string filenameWithExt);
-
+        string GetIdFromFIleName(string filenameWithExt);
+        bool IsNiconicoID(string testString);
+        RemoteType GetRemoteType(string url);
+        string GetID(string url,RemoteType type);
     }
 
     public class NiconicoUtils : INiconicoUtils
@@ -64,6 +69,101 @@ namespace Niconicome.Models.Domain.Utils
             int endPoint = filename.IndexOf("]");
             if (startPoint == -1 || endPoint == -1) throw new InvalidOperationException("[id]を含まないファイル名です。");
             return filename[startPoint..endPoint];
+        }
+
+        /// <summary>
+        /// ファイル名からIDを取得する
+        /// </summary>
+        /// <param name="filenameWithExt"></param>
+        /// <returns></returns>
+        public string GetIdFromFIleName( string filenameWithExt)
+        {
+            string filename = Path.GetFileNameWithoutExtension(filenameWithExt) ?? string.Empty;
+            if (filename == string.Empty) throw new InvalidOperationException("ファイル名が空です。");
+
+            var match = Regex.Match(filenameWithExt, "(sm|nm|so)?[0-9]+");
+            return match.Value;
+        }
+
+        /// <summary>
+        /// 入力した文字列がニコニコのIDとして正しいかどうかを取得する
+        /// </summary>
+        /// <param name="testString"></param>
+        /// <returns></returns>
+        public bool IsNiconicoID(string testString)
+        {
+            return Regex.IsMatch(testString, "^(sm|nm|so)?[0-9]+$");
+        }
+
+        /// <summary>
+        /// リモートプレイリストの種別を取得する
+        /// </summary>
+        /// <param name="url"></param>
+        /// <returns></returns>
+        public RemoteType GetRemoteType(string url)
+        {
+            if (Regex.IsMatch(url, @"^https?://(www\.)?ch\.nicovideo\.jp.*"))
+            {
+                return RemoteType.Channel;
+            }
+            else if (Regex.IsMatch(url, @"^https?://(www\.)?nicovideo\.jp/user/\d+/mylist/\d+.*"))
+            {
+                return RemoteType.Mylist;
+            }
+            else if (Regex.IsMatch(url, @"^https?://(www\.)?nicovideo\.jp/my/watchlater.*"))
+            {
+                return RemoteType.WatchLater;
+            }
+            else if (Regex.IsMatch(url, @"^https?://(www\.)?nicovideo\.jp/user/\d+/video.*"))
+            {
+                return RemoteType.UserVideos;
+            } else if (Regex.IsMatch(url, @"^https?://(www\.)?nicovideo\.jp/watch/(sm|nm|so)\d+.*"))
+            {
+                return RemoteType.WatchPage;
+            }
+
+            throw new InvalidOperationException("ニコニコ動画のURLではありません。");
+        }
+
+        /// <summary>
+        /// IDを取得する
+        /// </summary>
+        /// <param name="url"></param>
+        /// <returns></returns>
+        public string GetID(string url,RemoteType type)
+        {
+            var li = url.LastIndexOf("?");
+            if (li != -1)
+            {
+                url = url[0..li];
+            }
+
+            if (type is RemoteType.Channel or RemoteType.Mylist or RemoteType.WatchPage)
+            {
+                var splited = url.Split("/");
+                if (!splited[^1].IsNullOrEmpty())
+                {
+                    return splited[^1];
+                } else
+                {
+                    return splited[^2];
+                }
+            } else if (type is RemoteType.UserVideos)
+            {
+
+                var splited = url.Split("/");
+                if (!splited[^1].IsNullOrEmpty())
+                {
+                    return splited[^2];
+                } else
+                {
+                    return splited[^3];
+                }
+            }
+            else
+            {
+                throw new InvalidOperationException($"RemoteType:{type}は不正です。");
+            }
         }
 
 

--- a/Niconicome/Models/Local/LocalSettingHandler.cs
+++ b/Niconicome/Models/Local/LocalSettingHandler.cs
@@ -145,6 +145,7 @@ namespace Niconicome.Models.Local
                 Settings.DLAllFromQueue => STypes::SettingNames.DownloadAllWhenPushDLButton,
                 Settings.AllowDupeOnStage => STypes::SettingNames.AllowDupeOnStage,
                 Settings.ReplaceSBToMB => STypes::SettingNames.ReplaceSingleByteToMultiByte,
+                Settings.OverrideVideoFileDTToUploadedDT => STypes::SettingNames.OverideVideoFileDTToUploadedDT,
                 _ => null
             };
         }
@@ -180,5 +181,6 @@ namespace Niconicome.Models.Local
         DLAllFromQueue,
         AllowDupeOnStage,
         ReplaceSBToMB,
+        OverrideVideoFileDTToUploadedDT,
     }
 }

--- a/Niconicome/Models/Local/LocalSettingHandler.cs
+++ b/Niconicome/Models/Local/LocalSettingHandler.cs
@@ -144,6 +144,7 @@ namespace Niconicome.Models.Local
                 Settings.MaxParallelSegDl => STypes::SettingNames.MaxParallelSegmentDownloadCount,
                 Settings.DLAllFromQueue => STypes::SettingNames.DownloadAllWhenPushDLButton,
                 Settings.AllowDupeOnStage => STypes::SettingNames.AllowDupeOnStage,
+                Settings.ReplaceSBToMB => STypes::SettingNames.ReplaceSingleByteToMultiByte,
                 _ => null
             };
         }
@@ -178,5 +179,6 @@ namespace Niconicome.Models.Local
         MaxParallelSegDl,
         DLAllFromQueue,
         AllowDupeOnStage,
+        ReplaceSBToMB,
     }
 }

--- a/Niconicome/Models/Local/LocalSettingHandler.cs
+++ b/Niconicome/Models/Local/LocalSettingHandler.cs
@@ -144,6 +144,8 @@ namespace Niconicome.Models.Local
                 Settings.FFmpegShell=>STypes::SettingNames.UseShellWhenLaunchingFFmpeg,
                 Settings.AutologinEnable => STypes::SettingNames.IsAutologinEnable,
                 Settings.AutologinMode => STypes::SettingNames.AutoLoginMode,
+                Settings.MaxParallelDL=>STypes::SettingNames.MaxParallelDownloadCount,
+                Settings.MaxParallelSegDl=>STypes::SettingNames.MaxParallelSegmentDownloadCount,
                 _ => null
             };
         }
@@ -174,5 +176,7 @@ namespace Niconicome.Models.Local
         FFmpegShell,
         AutologinEnable,
         AutologinMode,
+        MaxParallelDL,
+        MaxParallelSegDl,
     }
 }

--- a/Niconicome/Models/Local/LocalSettingHandler.cs
+++ b/Niconicome/Models/Local/LocalSettingHandler.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Niconicome.Models.Domain.Local.Store;
+﻿using Niconicome.Models.Domain.Local.Store;
 using STypes = Niconicome.Models.Domain.Local.Store.Types;
 
 namespace Niconicome.Models.Local
@@ -106,10 +101,11 @@ namespace Niconicome.Models.Local
             else if (data is string stringData)
             {
                 this.settingHandler.SaveStringSetting(settingname, stringData);
-            } else if (data is int intData)
+            }
+            else if (data is int intData)
             {
                 this.settingHandler.SaveIntSetting(settingname, intData);
-            } 
+            }
         }
 
         /// <summary>
@@ -131,21 +127,23 @@ namespace Niconicome.Models.Local
                 Settings.FfmpegPath => STypes::SettingNames.FFmpegPath,
                 Settings.DefaultFolder => STypes::SettingNames.DefaultFolder,
                 Settings.CommentOffset => STypes::SettingNames.CommentOffset,
-                Settings.DLVideo=>STypes::SettingNames.IsDownloadingVideoEnable,
-                Settings.DLComment=> STypes::SettingNames.IsDownloadingCommentEnable,
-                Settings.DLKako=> STypes::SettingNames.IsDownloadingKakoroguEnable,
-                Settings.DLEasy=> STypes::SettingNames.IsDownloadingEasyEnable,
-                Settings.DLThumb=> STypes::SettingNames.IsDownloadingThumbEnable,
-                Settings.DLOwner=> STypes::SettingNames.IsDownloadingOwnerEnable,
-                Settings.DLSkip=> STypes::SettingNames.IsSkipEnable,
-                Settings.DLCopy=> STypes::SettingNames.IsCopyEnable,
-                Settings.DLOverwrite=> STypes::SettingNames.IsOverwriteEnable,
-                Settings.SwitchOffset=>STypes::SettingNames.IsAutoSwitchOffsetEnable,
-                Settings.FFmpegShell=>STypes::SettingNames.UseShellWhenLaunchingFFmpeg,
+                Settings.DLVideo => STypes::SettingNames.IsDownloadingVideoEnable,
+                Settings.DLComment => STypes::SettingNames.IsDownloadingCommentEnable,
+                Settings.DLKako => STypes::SettingNames.IsDownloadingKakoroguEnable,
+                Settings.DLEasy => STypes::SettingNames.IsDownloadingEasyEnable,
+                Settings.DLThumb => STypes::SettingNames.IsDownloadingThumbEnable,
+                Settings.DLOwner => STypes::SettingNames.IsDownloadingOwnerEnable,
+                Settings.DLSkip => STypes::SettingNames.IsSkipEnable,
+                Settings.DLCopy => STypes::SettingNames.IsCopyEnable,
+                Settings.DLOverwrite => STypes::SettingNames.IsOverwriteEnable,
+                Settings.SwitchOffset => STypes::SettingNames.IsAutoSwitchOffsetEnable,
+                Settings.FFmpegShell => STypes::SettingNames.UseShellWhenLaunchingFFmpeg,
                 Settings.AutologinEnable => STypes::SettingNames.IsAutologinEnable,
                 Settings.AutologinMode => STypes::SettingNames.AutoLoginMode,
-                Settings.MaxParallelDL=>STypes::SettingNames.MaxParallelDownloadCount,
-                Settings.MaxParallelSegDl=>STypes::SettingNames.MaxParallelSegmentDownloadCount,
+                Settings.MaxParallelDL => STypes::SettingNames.MaxParallelDownloadCount,
+                Settings.MaxParallelSegDl => STypes::SettingNames.MaxParallelSegmentDownloadCount,
+                Settings.DLAllFromQueue => STypes::SettingNames.DownloadAllWhenPushDLButton,
+                Settings.AllowDupeOnStage => STypes::SettingNames.AllowDupeOnStage,
                 _ => null
             };
         }
@@ -178,5 +176,7 @@ namespace Niconicome.Models.Local
         AutologinMode,
         MaxParallelDL,
         MaxParallelSegDl,
+        DLAllFromQueue,
+        AllowDupeOnStage,
     }
 }

--- a/Niconicome/Models/Local/LocalSettingHandler.cs
+++ b/Niconicome/Models/Local/LocalSettingHandler.cs
@@ -148,6 +148,8 @@ namespace Niconicome.Models.Local
                 Settings.OverrideVideoFileDTToUploadedDT => STypes::SettingNames.OverideVideoFileDTToUploadedDT,
                 Settings.MaxCommentsCount => STypes::SettingNames.MaxCommentCount,
                 Settings.LimitCommentsCount => STypes::SettingNames.LimitCommentCount,
+                Settings.DLVideoInfo => STypes::SettingNames.IsDownloadingVideoInfoEnable,
+                Settings.VideoInfoInJson => STypes::SettingNames.IsDownloadingVideoInfoInJsonEnable,
                 _ => null
             };
         }
@@ -186,5 +188,7 @@ namespace Niconicome.Models.Local
         OverrideVideoFileDTToUploadedDT,
         LimitCommentsCount,
         MaxCommentsCount,
+        DLVideoInfo,
+        VideoInfoInJson,
     }
 }

--- a/Niconicome/Models/Local/LocalSettingHandler.cs
+++ b/Niconicome/Models/Local/LocalSettingHandler.cs
@@ -142,6 +142,8 @@ namespace Niconicome.Models.Local
                 Settings.DLOverwrite=> STypes::SettingNames.IsOverwriteEnable,
                 Settings.SwitchOffset=>STypes::SettingNames.IsAutoSwitchOffsetEnable,
                 Settings.FFmpegShell=>STypes::SettingNames.UseShellWhenLaunchingFFmpeg,
+                Settings.AutologinEnable => STypes::SettingNames.IsAutologinEnable,
+                Settings.AutologinMode => STypes::SettingNames.AutoLoginMode,
                 _ => null
             };
         }
@@ -170,5 +172,7 @@ namespace Niconicome.Models.Local
         DLOverwrite,
         SwitchOffset,
         FFmpegShell,
+        AutologinEnable,
+        AutologinMode,
     }
 }

--- a/Niconicome/Models/Local/LocalSettingHandler.cs
+++ b/Niconicome/Models/Local/LocalSettingHandler.cs
@@ -146,6 +146,8 @@ namespace Niconicome.Models.Local
                 Settings.AllowDupeOnStage => STypes::SettingNames.AllowDupeOnStage,
                 Settings.ReplaceSBToMB => STypes::SettingNames.ReplaceSingleByteToMultiByte,
                 Settings.OverrideVideoFileDTToUploadedDT => STypes::SettingNames.OverideVideoFileDTToUploadedDT,
+                Settings.MaxCommentsCount => STypes::SettingNames.MaxCommentCount,
+                Settings.LimitCommentsCount => STypes::SettingNames.LimitCommentCount,
                 _ => null
             };
         }
@@ -182,5 +184,7 @@ namespace Niconicome.Models.Local
         AllowDupeOnStage,
         ReplaceSBToMB,
         OverrideVideoFileDTToUploadedDT,
+        LimitCommentsCount,
+        MaxCommentsCount,
     }
 }

--- a/Niconicome/Models/Local/LocalSettingHandler.cs
+++ b/Niconicome/Models/Local/LocalSettingHandler.cs
@@ -150,6 +150,8 @@ namespace Niconicome.Models.Local
                 Settings.LimitCommentsCount => STypes::SettingNames.LimitCommentCount,
                 Settings.DLVideoInfo => STypes::SettingNames.IsDownloadingVideoInfoEnable,
                 Settings.VideoInfoInJson => STypes::SettingNames.IsDownloadingVideoInfoInJsonEnable,
+                Settings.MaxFetchCount => STypes::SettingNames.MaxParallelFetchCount,
+                Settings.FetchSleepInterval => STypes::SettingNames.FetchSleepInterval,
                 _ => null
             };
         }
@@ -190,5 +192,7 @@ namespace Niconicome.Models.Local
         MaxCommentsCount,
         DLVideoInfo,
         VideoInfoInJson,
+        MaxFetchCount,
+        FetchSleepInterval,
     }
 }

--- a/Niconicome/Models/Local/LocalSettingHandler.cs
+++ b/Niconicome/Models/Local/LocalSettingHandler.cs
@@ -152,6 +152,7 @@ namespace Niconicome.Models.Local
                 Settings.VideoInfoInJson => STypes::SettingNames.IsDownloadingVideoInfoInJsonEnable,
                 Settings.MaxFetchCount => STypes::SettingNames.MaxParallelFetchCount,
                 Settings.FetchSleepInterval => STypes::SettingNames.FetchSleepInterval,
+                Settings.SkipSSLVerification => STypes::SettingNames.SkipSSLVerification,
                 _ => null
             };
         }
@@ -194,5 +195,6 @@ namespace Niconicome.Models.Local
         VideoInfoInJson,
         MaxFetchCount,
         FetchSleepInterval,
+        SkipSSLVerification,
     }
 }

--- a/Niconicome/Models/Local/State/ErrorMessenger.cs
+++ b/Niconicome/Models/Local/State/ErrorMessenger.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Threading.Tasks;
 using System.Windows;
+using Niconicome.ViewModels.Controls;
 
 namespace Niconicome.Models.Local.State
 {
@@ -20,20 +22,20 @@ namespace Niconicome.Models.Local.State
     class ErrorMessenger : IErrorMessanger
     {
 
-        public ErrorMessenger(Func<string, MessageBoxResult> showMessageBoxFunc)
+        public ErrorMessenger(Func<string, Task<MaterialMessageBoxResult>> showMessageBoxFunc)
         {
             this.showMessageBox = showMessageBoxFunc;
             this.Error += this.OnError;
         }
 
-        public ErrorMessenger() : this((message) => MessageBox.Show(message, "エラーが発生しました", MessageBoxButton.OK, MessageBoxImage.Error)) { }
+        public ErrorMessenger() : this((message) => MaterialMessageBox.Show(message, MessageBoxButtons.OK, MessageBoxIcons.Error)) { }
 
         public event EventHandler<IErrorEventArgs> Error;
 
         /// <summary>
         /// メッセージボックス(DI)
         /// </summary>
-        private readonly Func<string, MessageBoxResult> showMessageBox;
+        private readonly Func<string, Task<MaterialMessageBoxResult>> showMessageBox;
 
         /// <summary>
         /// エラーを通知する

--- a/Niconicome/Models/Local/State/SnackbarHandler.cs
+++ b/Niconicome/Models/Local/State/SnackbarHandler.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using MaterialDesign = MaterialDesignThemes.Wpf;
+
+namespace Niconicome.Models.Local.State
+{
+    interface ISnackbarHandler
+    {
+        MaterialDesign.ISnackbarMessageQueue Queue { get;}
+
+        void Enqueue(string message);
+    }
+
+    class SnackbarHandler : ISnackbarHandler
+    {
+        public MaterialDesign::ISnackbarMessageQueue Queue { get; init; } = new MaterialDesign::SnackbarMessageQueue();
+
+        /// <summary>
+        /// キューに追加する
+        /// </summary>
+        /// <param name="message"></param>
+        public void Enqueue(string message)
+        {
+            this.Queue.Enqueue(message);
+        }
+    }
+}

--- a/Niconicome/Models/Local/State/SnackbarHandler.cs
+++ b/Niconicome/Models/Local/State/SnackbarHandler.cs
@@ -12,6 +12,7 @@ namespace Niconicome.Models.Local.State
         MaterialDesign.ISnackbarMessageQueue Queue { get;}
 
         void Enqueue(string message);
+        void Enqueue(string message, string action, Action actionFunc);
     }
 
     class SnackbarHandler : ISnackbarHandler
@@ -26,5 +27,17 @@ namespace Niconicome.Models.Local.State
         {
             this.Queue.Enqueue(message);
         }
+
+        /// <summary>
+        /// アクション付きでキューに追加する
+        /// </summary>
+        /// <param name="message"></param>
+        /// <param name="action"></param>
+        /// <param name="actionFunc"></param>
+        public void Enqueue(string message, string action, Action actionFunc)
+        {
+            this.Queue.Enqueue(message, action, actionFunc);
+        }
+
     }
 }

--- a/Niconicome/Models/Network/Download/ContentDownloader.cs
+++ b/Niconicome/Models/Network/Download/ContentDownloader.cs
@@ -46,6 +46,7 @@ namespace Niconicome.Models.Network.Download
         string FolderPath { get; }
         uint VerticalResolution { get; }
         int PlaylistID { get; }
+        int MaxCommentsCount { get; }
         Vdl::IVideoDownloadSettings ConvertToVideoDownloadSettings(string filenameFormat, bool autodispose, int maxParallelDLCount);
         Tdl::IThumbDownloadSettings ConvertToThumbDownloadSetting(string fileFormat);
         Cdl::ICommentDownloadSettings ConvertToCommentDownloadSetting(string fileFormat, int commentOffset);
@@ -634,6 +635,8 @@ namespace Niconicome.Models.Network.Download
 
         public int PlaylistID { get; set; }
 
+        public int MaxCommentsCount { get; set; }
+
         public string NiconicoId { get; set; } = string.Empty;
 
         public string FolderPath { get; set; } = string.Empty;
@@ -679,25 +682,10 @@ namespace Niconicome.Models.Network.Download
                 IsDownloadingOwnerCommentEnable = this.DownloadOwner,
                 CommentOffset = commentOffset,
                 IsReplaceStrictedEnable = this.IsReplaceStrictedEnable,
+                MaxcommentsCount = this.MaxCommentsCount,
             };
         }
 
-    }
-
-    /// <summary>
-    /// インデックス付きの動画情報
-    /// </summary>
-    public class VideoToDownload : IVideoToDownload
-    {
-        public VideoToDownload(IVideoListInfo video, int index)
-        {
-            this.Video = video;
-            this.Index = index;
-        }
-
-        public IVideoListInfo Video { get; set; }
-
-        public int Index { get; set; }
     }
 
     /// <summary>

--- a/Niconicome/Models/Network/Download/ContentDownloader.cs
+++ b/Niconicome/Models/Network/Download/ContentDownloader.cs
@@ -41,6 +41,7 @@ namespace Niconicome.Models.Network.Download
         bool DownloadLog { get; }
         bool DownloadOwner { get; }
         bool IsReplaceStrictedEnable { get; }
+        bool OverrideVideoFileDateToUploadedDT { get; }
         string NiconicoId { get; }
         string FolderPath { get; }
         uint VerticalResolution { get; }
@@ -226,6 +227,11 @@ namespace Niconicome.Models.Network.Download
             var session = DIFactory.Provider.GetRequiredService<IWatchSession>();
 
             await session.GetVideoDataAsync(setting.NiconicoId, setting.Video);
+
+            if (session.Video?.DmcInfo.DownloadStartedOn is not null)
+            {
+                session.Video.DmcInfo.DownloadStartedOn = DateTime.Now;
+            }
 
             if (session.State != WatchSessionState.GotPage || session.Video is null)
             {
@@ -622,6 +628,8 @@ namespace Niconicome.Models.Network.Download
 
         public bool IsReplaceStrictedEnable { get; set; }
 
+        public bool OverrideVideoFileDateToUploadedDT { get; set; }
+
         public uint VerticalResolution { get; set; }
 
         public int PlaylistID { get; set; }
@@ -642,6 +650,7 @@ namespace Niconicome.Models.Network.Download
                 VerticalResolution = this.VerticalResolution,
                 MaxParallelDownloadCount = maxParallelDLCount,
                 IsReplaceStrictedEnable = this.IsReplaceStrictedEnable,
+                IsOvwrridingFileDTEnable = this.OverrideVideoFileDateToUploadedDT,
             };
         }
 

--- a/Niconicome/Models/Network/Download/ContentDownloader.cs
+++ b/Niconicome/Models/Network/Download/ContentDownloader.cs
@@ -394,7 +394,7 @@ namespace Niconicome.Models.Network.Download
                 this.CurrentResult = new NetworkResult();
             }
 
-            var t = new DownloadTaskParallel(async parallelTask =>
+            var t = new DownloadTaskParallel(async (parallelTask, lockObj) =>
             {
                 if (!e.Task.IsCanceled && !e.Task.IsDone)
                 {
@@ -705,7 +705,7 @@ namespace Niconicome.Models.Network.Download
     /// </summary>
     public class DownloadTaskParallel : IParallelTask<DownloadTaskParallel>
     {
-        public DownloadTaskParallel(Func<DownloadTaskParallel, Task> taskFunction, Action<int> onwait)
+        public DownloadTaskParallel(Func<DownloadTaskParallel, object, Task> taskFunction, Action<int> onwait)
         {
             this.TaskFunction = taskFunction;
             this.OnWait = onwait;
@@ -713,7 +713,7 @@ namespace Niconicome.Models.Network.Download
 
         public Guid TaskId { get; init; }
 
-        public Func<DownloadTaskParallel, Task> TaskFunction { get; init; }
+        public Func<DownloadTaskParallel, object, Task> TaskFunction { get; init; }
 
         public Action<int> OnWait { get; init; }
 

--- a/Niconicome/Models/Network/Download/DownloadTask.cs
+++ b/Niconicome/Models/Network/Download/DownloadTask.cs
@@ -1,0 +1,163 @@
+﻿using System;
+using System.Threading;
+using Niconicome.Models.Playlist;
+using Niconicome.ViewModels;
+
+namespace Niconicome.Models.Network.Download
+{
+
+    public interface IDownloadTask
+    {
+        Guid ID { get; }
+        string DirectoryPath { get; }
+        string Message { get; set; }
+        int PlaylistID { get; }
+        bool IsCanceled { get; set; }
+        bool IsProcessing { get; set; }
+        uint VerticalResolution { get; }
+        DownloadSettings DownloadSettings { get; }
+        IVideoListInfo Video { get; }
+        CancellationToken CancellationToken { get; }
+        event EventHandler<DownloadTaskMessageChangedEventArgs>? MessageChange;
+        void Cancel();
+    }
+
+    public class DownloadTaskMessageChangedEventArgs : EventArgs
+    {
+        public string? Message { get; set; }
+    }
+
+    /// <summary>
+    /// ダウンロードタスク
+    /// </summary>
+    public record DownloadTask : BindableRecordBase, IDownloadTask
+    {
+        public DownloadTask(IVideoListInfo video, DownloadSettings downloadSettings)
+        {
+            this.DirectoryPath = downloadSettings.FolderPath;
+            this.VerticalResolution = downloadSettings.VerticalResolution;
+            this.messageFIeld = string.Empty;
+            this.ID = Guid.NewGuid();
+            this.PlaylistID = downloadSettings.PlaylistID;
+            this.DownloadSettings = downloadSettings;
+            this.Video = video;
+            this.cts = new CancellationTokenSource();
+            this.CancellationToken = this.cts.Token;
+        }
+
+        protected string messageFIeld;
+
+        protected readonly CancellationTokenSource cts;
+
+        /// <summary>
+        /// メッセージ変更イベントを発火させる
+        /// </summary>
+        protected void RaiseMessageChanged()
+        {
+            this.MessageChange?.Invoke(this, new DownloadTaskMessageChangedEventArgs() { Message = this.Message });
+        }
+
+        /// <summary>
+        /// ダウンロードタスクID
+        /// </summary>
+        public Guid ID { get; init; }
+
+        /// <summary>
+        /// 保存フォルダーパス
+        /// </summary>
+        public string DirectoryPath { get; init; }
+
+        /// <summary>
+        /// メッセージ
+        /// </summary>
+        public virtual string Message
+        {
+            get => this.messageFIeld;
+            set
+            {
+                this.messageFIeld = value;
+                this.RaiseMessageChanged();
+            }
+        }
+
+        /// <summary>
+        /// 動画情報
+        /// </summary>
+        public IVideoListInfo Video { get; init; }
+
+        /// <summary>
+        /// プレイリストID
+        /// </summary>
+        public int PlaylistID { get; init; }
+
+        /// <summary>
+        /// キャンセルフラグ
+        /// </summary>
+        public virtual bool IsCanceled { get; set; }
+
+        /// <summary>
+        /// 実行中フラグ
+        /// </summary>
+        public virtual bool IsProcessing { get; set; }
+
+        /// <summary>
+        /// /垂直解像度
+        /// </summary>
+        public uint VerticalResolution { get; init; }
+
+        /// <summary>
+        /// ダウンロード設定
+        /// </summary>
+        public DownloadSettings DownloadSettings { get; init; }
+
+
+        /// <summary>
+        /// メッセージ変更イベント
+        /// </summary>
+        public event EventHandler<DownloadTaskMessageChangedEventArgs>? MessageChange;
+
+        /// <summary>
+        /// トークン
+        /// </summary>
+        public CancellationToken CancellationToken { get; init; }
+
+        /// <summary>
+        /// タスクをキャンセル
+        /// </summary>
+        public void Cancel()
+        {
+            this.cts.Cancel();
+            this.IsCanceled = true;
+            this.IsProcessing = false;
+        }
+
+    }
+
+    /// <summary>
+    /// バインド可能なタスク
+    /// </summary>
+    public record BindableDownloadTask : DownloadTask
+    {
+        public BindableDownloadTask(IVideoListInfo video, DownloadSettings downloadSettings) : base(video, downloadSettings)
+        {
+        }
+
+        private bool isProcessingField;
+
+        private bool isCanceledField;
+
+        public override string Message
+        {
+            get => this.messageFIeld;
+            set
+            {
+                this.SetProperty(ref this.messageFIeld, value);
+                this.RaiseMessageChanged();
+            }
+        }
+
+        public override bool IsCanceled { get => this.isCanceledField; set => this.SetProperty(ref this.isCanceledField, value); }
+
+        public override bool IsProcessing { get => this.isProcessingField; set => this.SetProperty(ref this.isProcessingField, value); }
+    }
+}

--- a/Niconicome/Models/Network/Download/DownloadTask.cs
+++ b/Niconicome/Models/Network/Download/DownloadTask.cs
@@ -11,14 +11,21 @@ namespace Niconicome.Models.Network.Download
         Guid ID { get; }
         string DirectoryPath { get; }
         string Message { get; set; }
+        string NiconicoID { get; }
+        string Title { get; }
         int PlaylistID { get; }
+        int VideoID { get; }
         bool IsCanceled { get; set; }
         bool IsProcessing { get; set; }
+        bool IsDone { get; set; }
         uint VerticalResolution { get; }
         DownloadSettings DownloadSettings { get; }
-        IVideoListInfo Video { get; }
         CancellationToken CancellationToken { get; }
         event EventHandler<DownloadTaskMessageChangedEventArgs>? MessageChange;
+        event EventHandler? ProcessingEnd;
+        event EventHandler? ProcessStart;
+        event EventHandler? Done;
+        event EventHandler? TaskCancel;
         void Cancel();
     }
 
@@ -32,7 +39,7 @@ namespace Niconicome.Models.Network.Download
     /// </summary>
     public record DownloadTask : BindableRecordBase, IDownloadTask
     {
-        public DownloadTask(IVideoListInfo video, DownloadSettings downloadSettings)
+        public DownloadTask(string niconicpoID, string title, int videoID, DownloadSettings downloadSettings)
         {
             this.DirectoryPath = downloadSettings.FolderPath;
             this.VerticalResolution = downloadSettings.VerticalResolution;
@@ -40,7 +47,9 @@ namespace Niconicome.Models.Network.Download
             this.ID = Guid.NewGuid();
             this.PlaylistID = downloadSettings.PlaylistID;
             this.DownloadSettings = downloadSettings;
-            this.Video = video;
+            this.NiconicoID = niconicpoID;
+            this.VideoID = videoID;
+            this.Title = title;
             this.cts = new CancellationTokenSource();
             this.CancellationToken = this.cts.Token;
         }
@@ -49,12 +58,48 @@ namespace Niconicome.Models.Network.Download
 
         protected readonly CancellationTokenSource cts;
 
+        protected bool isProcessingField;
+
+        protected bool isDoneField;
+
         /// <summary>
         /// メッセージ変更イベントを発火させる
         /// </summary>
         protected void RaiseMessageChanged()
         {
             this.MessageChange?.Invoke(this, new DownloadTaskMessageChangedEventArgs() { Message = this.Message });
+        }
+
+        /// <summary>
+        /// 終了イベントを発火させる
+        /// </summary>
+        protected void RaiseProcessingEnd()
+        {
+            this.ProcessingEnd?.Invoke(this, EventArgs.Empty);
+        }
+
+        /// <summary>
+        /// 開始イベントを発火させる
+        /// </summary>
+        protected void RaiseProcessingStart()
+        {
+            this.ProcessStart?.Invoke(this, EventArgs.Empty);
+        }
+
+        /// <summary>
+        /// 終了イベントを発火させる
+        /// </summary>
+        protected void RaiseDone()
+        {
+            this.Done?.Invoke(this, EventArgs.Empty);
+        }
+
+        /// <summary>
+        /// キャンセルイベントを発火させる
+        /// </summary>
+        protected void RaiseCancel()
+        {
+            this.TaskCancel?.Invoke(this, EventArgs.Empty);
         }
 
         /// <summary>
@@ -66,6 +111,16 @@ namespace Niconicome.Models.Network.Download
         /// 保存フォルダーパス
         /// </summary>
         public string DirectoryPath { get; init; }
+
+        /// <summary>
+        /// ニコニコ動画のID
+        /// </summary>
+        public string NiconicoID { get; init; }
+
+        /// <summary>
+        /// タイトル
+        /// </summary>
+        public string Title { get; init; }
 
         /// <summary>
         /// メッセージ
@@ -81,14 +136,14 @@ namespace Niconicome.Models.Network.Download
         }
 
         /// <summary>
-        /// 動画情報
-        /// </summary>
-        public IVideoListInfo Video { get; init; }
-
-        /// <summary>
         /// プレイリストID
         /// </summary>
         public int PlaylistID { get; init; }
+
+        /// <summary>
+        /// 動画ID
+        /// </summary>
+        public int VideoID { get; init; }
 
         /// <summary>
         /// キャンセルフラグ
@@ -98,7 +153,38 @@ namespace Niconicome.Models.Network.Download
         /// <summary>
         /// 実行中フラグ
         /// </summary>
-        public virtual bool IsProcessing { get; set; }
+        public virtual bool IsProcessing
+        {
+            get => this.isProcessingField;
+            set
+            {
+                this.isProcessingField = value;
+                if (!value)
+                {
+                    this.RaiseProcessingEnd();
+                }
+                else
+                {
+                    this.RaiseProcessingStart();
+                }
+            }
+        }
+
+        /// <summary>
+        /// 完了フラグ
+        /// </summary>
+        public virtual bool IsDone
+        {
+            get => this.isDoneField;
+            set
+            {
+                this.isDoneField = value;
+                if (value)
+                {
+                    this.RaiseDone();
+                }
+            }
+        }
 
         /// <summary>
         /// /垂直解像度
@@ -117,6 +203,26 @@ namespace Niconicome.Models.Network.Download
         public event EventHandler<DownloadTaskMessageChangedEventArgs>? MessageChange;
 
         /// <summary>
+        /// 終了イベント
+        /// </summary>
+        public event EventHandler? ProcessingEnd;
+
+        /// <summary>
+        /// 開始イベント
+        /// </summary>
+        public event EventHandler? ProcessStart;
+
+        /// <summary>
+        /// 完了イベント
+        /// </summary>
+        public event EventHandler? Done;
+
+        /// <summary>
+        /// キャンセルイベント
+        /// </summary>
+        public event EventHandler? TaskCancel;
+
+        /// <summary>
         /// トークン
         /// </summary>
         public CancellationToken CancellationToken { get; init; }
@@ -129,6 +235,7 @@ namespace Niconicome.Models.Network.Download
             this.cts.Cancel();
             this.IsCanceled = true;
             this.IsProcessing = false;
+            this.RaiseCancel();
         }
 
     }
@@ -138,11 +245,9 @@ namespace Niconicome.Models.Network.Download
     /// </summary>
     public record BindableDownloadTask : DownloadTask
     {
-        public BindableDownloadTask(IVideoListInfo video, DownloadSettings downloadSettings) : base(video, downloadSettings)
+        public BindableDownloadTask(string niconicpoID, string title, int videoID, DownloadSettings downloadSettings) : base(niconicpoID, title, videoID, downloadSettings)
         {
         }
-
-        private bool isProcessingField;
 
         private bool isCanceledField;
 
@@ -158,6 +263,23 @@ namespace Niconicome.Models.Network.Download
 
         public override bool IsCanceled { get => this.isCanceledField; set => this.SetProperty(ref this.isCanceledField, value); }
 
-        public override bool IsProcessing { get => this.isProcessingField; set => this.SetProperty(ref this.isProcessingField, value); }
+        public override bool IsProcessing
+        {
+            get => this.isProcessingField;
+            set
+            {
+                this.SetProperty(ref this.isProcessingField, value);
+                if (!value)
+                {
+                    this.RaiseProcessingEnd();
+                }
+                else
+                {
+                    this.RaiseProcessingStart();
+                }
+            }
+        }
+
+        public override bool IsDone { get => this.isDoneField; set => this.SetProperty(ref this.isDoneField, value); }
     }
 }

--- a/Niconicome/Models/Network/Download/DownloadTaskPool.cs
+++ b/Niconicome/Models/Network/Download/DownloadTaskPool.cs
@@ -14,6 +14,7 @@ namespace Niconicome.Models.Network.Download
         void AddTasks(IEnumerable<IDownloadTask> tasks);
         void RemoveTask(IDownloadTask task);
         void RemoveTasks(IEnumerable<IDownloadTask> tasks);
+        void RemoveTasks(Predicate<IDownloadTask> predicate);
         event EventHandler<TaskPoolChangeEventargs>? TaskPoolChange;
         void CancelAllTasks();
         void Clear(bool cancel = true);
@@ -124,6 +125,16 @@ namespace Niconicome.Models.Network.Download
                 this.RemoveTask(task);
             }
         }
+
+        /// <summary>
+        /// 複数のタスクを削除する
+        /// </summary>
+        /// <param name="predicate"></param>
+        public void RemoveTasks(Predicate<IDownloadTask> predicate)
+        {
+            this.innerList.RemoveAll(predicate);
+        }
+
 
         /// <summary>
         /// プール変更イベント

--- a/Niconicome/Models/Network/Download/DownloadTaskPool.cs
+++ b/Niconicome/Models/Network/Download/DownloadTaskPool.cs
@@ -1,0 +1,171 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Niconicome.Models.Network.Download
+{
+    public interface IDownloadTaskPool
+    {
+        IEnumerable<IDownloadTask> GetAllTasks();
+        IEnumerable<IDownloadTask> GetTaskWhere(Func<IDownloadTask, bool> predicate);
+        void AddTask(IDownloadTask task);
+        void AddTasks(IEnumerable<IDownloadTask> tasks);
+        void RemoveTask(IDownloadTask task);
+        void RemoveTasks(IEnumerable<IDownloadTask> tasks);
+        event EventHandler<TaskPoolChangeEventargs>? TaskPoolChange;
+        void CancelAllTasks();
+        void Clear(bool cancel = true);
+        bool HasTask(Func<IDownloadTask, bool> predicate);
+        int Count { get; }
+    }
+
+    public class TaskPoolChangeEventargs : EventArgs
+    {
+        public TaskPoolChangeEventargs(TaskPoolChangeType changeType, IDownloadTask task)
+        {
+            this.ChangeType = changeType;
+            this.Task = task;
+        }
+
+
+        public TaskPoolChangeType ChangeType { get; init; }
+
+        public IDownloadTask Task { get; init; }
+
+    }
+
+    public enum TaskPoolChangeType
+    {
+        Remove,
+        Add,
+    }
+
+    /// <summary>
+    /// DLタスクプール
+    /// </summary>
+   public  class DownloadTaskPool : IDownloadTaskPool
+    {
+
+        private readonly List<IDownloadTask> innerList = new();
+
+        /// <summary>
+        /// 全てのタスクを取得する
+        /// </summary>
+        /// <returns></returns>
+        public IEnumerable<IDownloadTask> GetAllTasks()
+        {
+            return this.innerList;
+        }
+
+        /// <summary>
+        /// 条件を指定してタスクを取得
+        /// </summary>
+        /// <param name="predicate"></param>
+        /// <returns></returns>
+        public IEnumerable<IDownloadTask> GetTaskWhere(Func<IDownloadTask, bool> predicate)
+        {
+            return this.innerList.Where(predicate);
+        }
+
+        /// <summary>
+        /// 全てのタスクをキャンセル
+        /// </summary>
+        public void CancelAllTasks()
+        {
+            foreach (var task in this.innerList)
+            {
+                task.Cancel();
+            }
+        }
+
+        /// <summary>
+        ///タスクを追加する 
+        /// </summary>
+        /// <param name="task"></param>
+        public void AddTask(IDownloadTask task)
+        {
+            this.innerList.Add(task);
+            this.RaiseTaskPoolChanged(TaskPoolChangeType.Add, task);
+
+        }
+
+        /// <summary>
+        /// 複数のタスクを追加する
+        /// </summary>
+        /// <param name="tasks"></param>
+        public void AddTasks(IEnumerable<IDownloadTask> tasks)
+        {
+            foreach (var task in tasks)
+            {
+                this.AddTask(task);
+            }
+        }
+
+        /// <summary>
+        /// タスクを削除する
+        /// </summary>
+        /// <param name="task"></param>
+        public void RemoveTask(IDownloadTask task)
+        {
+            this.innerList.RemoveAll(t => t == task);
+            this.RaiseTaskPoolChanged(TaskPoolChangeType.Remove, task);
+        }
+
+        /// <summary>
+        /// 複数のタスクを削除する
+        /// </summary>
+        /// <param name="tasks"></param>
+        public void RemoveTasks(IEnumerable<IDownloadTask> tasks)
+        {
+            foreach (var task in tasks)
+            {
+                this.RemoveTask(task);
+            }
+        }
+
+        /// <summary>
+        /// プール変更イベント
+        /// </summary>
+        public event EventHandler<TaskPoolChangeEventargs>? TaskPoolChange;
+
+        /// <summary>
+        /// プール変更イベントを発火させる
+        /// </summary>
+        /// <param name="changeType"></param>
+        /// <param name="task"></param>
+        private void RaiseTaskPoolChanged(TaskPoolChangeType changeType, IDownloadTask task)
+        {
+            this.TaskPoolChange?.Invoke(this, new TaskPoolChangeEventargs(changeType, task));
+        }
+
+        /// <summary>
+        /// タスクの存在をチェックする
+        /// </summary>
+        /// <param name="predicate"></param>
+        /// <returns></returns>
+        public bool HasTask(Func<IDownloadTask, bool> predicate)
+        {
+            return this.innerList.Any(predicate);
+        }
+
+        /// <summary>
+        /// 全て削除する
+        /// </summary>
+        public void Clear(bool cancel = true)
+        {
+            if (cancel)
+            {
+                this.CancelAllTasks();
+            }
+            this.innerList.Clear();
+        }
+
+
+        /// <summary>
+        /// タスク数を取得
+        /// </summary>
+        public int Count { get => this.innerList.Count; }
+    }
+}

--- a/Niconicome/Models/Network/Download/DownloadTasksHandler.cs
+++ b/Niconicome/Models/Network/Download/DownloadTasksHandler.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Niconicome.Models.Playlist;
+
+namespace Niconicome.Models.Network.Download
+{
+    interface IDownloadTasksHandler
+    {
+        IDownloadTaskPool DownloadTaskPool { get; init; }
+        IDownloadTaskPool StagedDownloadTaskPool { get; init; }
+
+        void ClearStaged();
+        void MoveStagedToQueue(bool clearAfterMove = true);
+        void StageVIdeo(IVideoListInfo video, DownloadSettings settings);
+        void StageVIdeos(IEnumerable<IVideoListInfo> videos, DownloadSettings settings);
+    }
+
+    class DownloadTasksHandler : IDownloadTasksHandler
+    {
+
+        public DownloadTasksHandler(IDownloadTaskPool staged,IDownloadTaskPool download) {
+            this.StagedDownloadTaskPool = staged;
+            this.DownloadTaskPool = download;
+        }
+
+        /// <summary>
+        /// ステージング済み
+        /// </summary>
+        public IDownloadTaskPool StagedDownloadTaskPool { get; init; }
+
+        /// <summary>
+        /// ダウンロード対象
+        /// </summary>
+        public IDownloadTaskPool DownloadTaskPool { get; init; }
+
+        /// <summary>
+        /// 動画をステージする
+        /// </summary>
+        /// <param name="video"></param>
+        /// <param name="settings"></param>
+        public void StageVIdeo(IVideoListInfo video, DownloadSettings settings)
+        {
+            var task = new BindableDownloadTask(video, settings);
+            this.StagedDownloadTaskPool.AddTask(task);
+        }
+
+        /// <summary>
+        /// 複数の動画をステージする
+        /// </summary>
+        /// <param name="videos"></param>
+        /// <param name="settings"></param>
+        public void StageVIdeos(IEnumerable<IVideoListInfo> videos, DownloadSettings settings)
+        {
+            foreach (var video in videos)
+            {
+                this.StageVIdeo(video, settings);
+            }
+        }
+
+        /// <summary>
+        /// ステージング済みをクリア
+        /// </summary>
+        public void ClearStaged()
+        {
+            this.StagedDownloadTaskPool.Clear(false);
+        }
+
+        /// <summary>
+        /// ステージング済みをキューに追加
+        /// </summary>
+        /// <param name="clearAfterMove"></param>
+        public void MoveStagedToQueue(bool clearAfterMove = true)
+        {
+            this.DownloadTaskPool.AddTasks(this.StagedDownloadTaskPool.GetAllTasks());
+            if (clearAfterMove) this.ClearStaged();
+        }
+    }
+}

--- a/Niconicome/Models/Network/NetworkVideoHandler.cs
+++ b/Niconicome/Models/Network/NetworkVideoHandler.cs
@@ -22,8 +22,8 @@ namespace Niconicome.Models.Network
         Task<INetworkResult> AddVideosAsync(IEnumerable<string> videosId, int playlistId, Action<IResult> onFailed, Action<IVideoListInfo> onSucceed);
         Task AddVideosAsync(IEnumerable<IVideoListInfo> videos, int playlistId);
         Task<INetworkResult> UpdateVideosAsync(IEnumerable<IVideoListInfo> videos, string folderPath, Action<IVideoListInfo> onSucceeded, CancellationToken ct);
-        Task<IEnumerable<IVideoListInfo>> GetTreeVideoInfosAsync(IEnumerable<IVideoListInfo> ids, Action<IVideoListInfo, IVideoListInfo, int> onSucceeded, Action<IResult, IVideoListInfo> onFailed, Action<IVideoListInfo, int> onStarted, Action<IVideoListInfo> onWaiting);
-        Task<IEnumerable<IVideoListInfo>> GetTreeVideoInfosAsync(IEnumerable<string> ids, Action<IVideoListInfo, IVideoListInfo, int> onSucceeded, Action<IResult, IVideoListInfo> onFailed, Action<IVideoListInfo, int> onStarted, Action<IVideoListInfo> onWaiting);
+        Task<IEnumerable<IVideoListInfo>> GetVideoListInfosAsync(IEnumerable<IVideoListInfo> ids, Action<IVideoListInfo, IVideoListInfo, int> onSucceeded, Action<IResult, IVideoListInfo> onFailed, Action<IVideoListInfo, int> onStarted, Action<IVideoListInfo> onWaiting);
+        Task<IEnumerable<IVideoListInfo>> GetVideoListInfosAsync(IEnumerable<string> ids, Action<IVideoListInfo, IVideoListInfo, int> onSucceeded, Action<IResult, IVideoListInfo> onFailed, Action<IVideoListInfo, int> onStarted, Action<IVideoListInfo> onWaiting);
     }
 
     public interface INetworkResult
@@ -88,7 +88,7 @@ namespace Niconicome.Models.Network
 
             this.messageHandler.AppendMessage($"{videosCount}件の動画を追加します。");
 
-            await this.GetTreeVideoInfosAsync(videoIds.Copy(), async (newVideo, video, i) =>
+            await this.GetVideoListInfosAsync(videoIds.Copy(), async (newVideo, video, i) =>
             {
                 netResult.SucceededCount++;
                 await this.videoThumnailUtility.SetThumbPathAsync(newVideo);
@@ -163,7 +163,7 @@ namespace Niconicome.Models.Network
 
             this.messageHandler.AppendMessage($"{videosCount}件の動画情報を更新します。");
 
-            await this.GetTreeVideoInfosAsync(videos.Copy(), async (newVideo, video, i) =>
+            await this.GetVideoListInfosAsync(videos.Copy(), async (newVideo, video, i) =>
             {
                 netResult.SucceededCount++;
                 video.IsSelected = false;
@@ -206,7 +206,7 @@ namespace Niconicome.Models.Network
         /// <param name="onStarted"></param>
         /// <param name="onWaiting"></param>
         /// <returns></returns>
-        public async Task<IEnumerable<IVideoListInfo>> GetTreeVideoInfosAsync(IEnumerable<IVideoListInfo> ids, Action<IVideoListInfo, IVideoListInfo, int> onSucceeded, Action<IResult, IVideoListInfo> onFailed, Action<IVideoListInfo, int> onStarted, Action<IVideoListInfo> onWaiting)
+        public async Task<IEnumerable<IVideoListInfo>> GetVideoListInfosAsync(IEnumerable<IVideoListInfo> ids, Action<IVideoListInfo, IVideoListInfo, int> onSucceeded, Action<IResult, IVideoListInfo> onFailed, Action<IVideoListInfo, int> onStarted, Action<IVideoListInfo> onWaiting)
         {
             int videosCount = ids.Count();
             var videos = new List<IVideoListInfo>();
@@ -254,9 +254,9 @@ namespace Niconicome.Models.Network
         /// <param name="onStarted"></param>
         /// <param name="onWaiting"></param>
         /// <returns></returns>
-        public async Task<IEnumerable<IVideoListInfo>> GetTreeVideoInfosAsync(IEnumerable<string> ids, Action<IVideoListInfo, IVideoListInfo, int> onSucceeded, Action<IResult, IVideoListInfo> onFailed, Action<IVideoListInfo, int> onStarted, Action<IVideoListInfo> onWaiting)
+        public async Task<IEnumerable<IVideoListInfo>> GetVideoListInfosAsync(IEnumerable<string> ids, Action<IVideoListInfo, IVideoListInfo, int> onSucceeded, Action<IResult, IVideoListInfo> onFailed, Action<IVideoListInfo, int> onStarted, Action<IVideoListInfo> onWaiting)
         {
-            return await this.GetTreeVideoInfosAsync(ids.Select(i => new BindableVIdeoListInfo() { NiconicoId = i }), onSucceeded, onFailed, onStarted, onWaiting);
+            return await this.GetVideoListInfosAsync(ids.Select(i => new BindableVIdeoListInfo() { NiconicoId = i }), onSucceeded, onFailed, onStarted, onWaiting);
         }
 
         /// <summary>

--- a/Niconicome/Models/Network/VideoIDHandler.cs
+++ b/Niconicome/Models/Network/VideoIDHandler.cs
@@ -170,7 +170,7 @@ namespace Niconicome.Models.Network
             var ids = this.localDirectoryHandler.GetVideoIdsFromDirectory(localPath);
             var videoCount = ids.Count();
 
-            var videos = await this.networkVideoHandler.GetVideoListInfosAsync(ids, (newVideo, video, i) =>
+            var videos = await this.networkVideoHandler.GetVideoListInfosAsync(ids, (newVideo, video, i, _) =>
             {
                 onMessage($"{video.NiconicoId}の情報を取得しました。({i + 1}/{videoCount})");
 
@@ -200,7 +200,7 @@ namespace Niconicome.Models.Network
         /// <returns></returns>
         private async Task<IEnumerable<IVideoListInfo>> GetVideoListInfosFromID(string id, Action<string> onMessage)
         {
-            var videos = await this.networkVideoHandler.GetVideoListInfosAsync(new List<string>() { id }, (newVideo, video, i) =>
+            var videos = await this.networkVideoHandler.GetVideoListInfosAsync(new List<string>() { id }, (newVideo, video, i, _) =>
             {
                 onMessage($"{video.NiconicoId}の情報を取得しました。");
 
@@ -260,7 +260,7 @@ namespace Niconicome.Models.Network
 
             int videoCount = searchResult.Videos.Count();
 
-            videos = await this.networkVideoHandler.GetVideoListInfosAsync(searchResult.Videos.Select(v => v.Id).Where(v => !registeredVideos.Contains(v)), (newVideo, video, i) =>
+            videos = await this.networkVideoHandler.GetVideoListInfosAsync(searchResult.Videos.Select(v => v.Id).Where(v => !registeredVideos.Contains(v)), (newVideo, video, i, _) =>
             {
                 onMessage($"{video.NiconicoId}の情報を取得しました。({i + 1}/{videoCount})");
 

--- a/Niconicome/Models/Network/VideoIDHandler.cs
+++ b/Niconicome/Models/Network/VideoIDHandler.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using Niconicome.Models.Domain.Local.LocalFile;
+using Niconicome.Models.Domain.Niconico.Search;
 using Niconicome.Models.Domain.Utils;
 using Niconicome.Models.Playlist;
 
@@ -12,6 +14,8 @@ namespace Niconicome.Models.Network
     {
         Task<IEnumerable<IVideoListInfo>> GetVideoListInfosAsync(string inputText, IEnumerable<string> registeredVideos, Action<string> onMessage, Action<string> onMessageVerbose);
         Task<INetworkResult> TryGetVideoListInfosAsync(List<IVideoListInfo> videos, string inputText, IEnumerable<string> registeredVideos, Action<string> onMessage, Action<string> onMessageVerbose);
+        bool IsProcessing { get; }
+        event EventHandler? StateChange;
     }
 
     class VideoIDHandler : IVideoIDHandler
@@ -32,6 +36,26 @@ namespace Niconicome.Models.Network
 
         private readonly IRemotePlaylistHandler remotePlaylistHandler;
 
+        private bool isProcessingField;
+
+        /// <summary>
+        /// 処理中フラグ
+        /// </summary>
+        public bool IsProcessing
+        {
+            get => this.isProcessingField;
+            private set
+            {
+                this.isProcessingField = value;
+                this.RaiseStatechange();
+            }
+        }
+
+        /// <summary>
+        /// 状態変更イベント
+        /// </summary>
+        public event EventHandler? StateChange;
+
         /// <summary>
         /// 動画情報を取得する
         /// </summary>
@@ -41,14 +65,17 @@ namespace Niconicome.Models.Network
         /// <returns></returns>
         public async Task<IEnumerable<IVideoListInfo>> GetVideoListInfosAsync(string inputText, IEnumerable<string> registeredVideos, Action<string> onMessage, Action<string> onMessageVerbose)
         {
+            this.IsProcessing = true;
+
             inputText = inputText.Trim();
             var videos = new List<IVideoListInfo>();
 
             if (Path.IsPathRooted(inputText))
             {
                 onMessage("ローカルディレクトリーから動画を取得します");
-                var retlieved = await this.GetVideoListInfosFromLocalPath(inputText, (_, _, _) => { }, (_, _) => { }, (_, _) => { }, (_) => { });
+                var retlieved = await this.GetVideoListInfosFromLocalPath(inputText, onMessageVerbose);
                 videos.AddRange(retlieved);
+                this.IsProcessing = false;
                 return videos;
             }
             else if (inputText.StartsWith("http"))
@@ -65,14 +92,28 @@ namespace Niconicome.Models.Network
                     onMessage("ネットワークから動画を取得します");
                     var retlieved = await this.GetVideoListInfosFromRemote(registeredVideos, type, id, (m) => onMessageVerbose(m));
                     videos.AddRange(retlieved);
+                    this.IsProcessing = false;
                     return videos;
                 }
             }
 
-            onMessage("IDを登録します");
-            var retlievedId = await this.GetVideoListInfosFromID(inputText, (_, _, _) => { }, (_, _) => { }, (_, _) => { }, (_) => { });
-            videos.AddRange(retlievedId);
-            return videos;
+            if (this.niconicoUtils.IsNiconicoID(inputText))
+            {
+                onMessage("IDを登録します");
+                var retlievedId = await this.GetVideoListInfosFromID(inputText, onMessageVerbose);
+                videos.AddRange(retlievedId);
+                this.IsProcessing = false;
+                return videos;
+            }
+            else
+            {
+                onMessage("動画を検索します");
+                var retlievedId = await this.GetVideoListInfosFromSearchResult(registeredVideos, inputText, onMessageVerbose);
+                videos.AddRange(retlievedId);
+                this.IsProcessing = false;
+                return videos;
+            }
+
         }
 
         /// <summary>
@@ -90,7 +131,8 @@ namespace Niconicome.Models.Network
             {
                 var retlieved = await this.GetVideoListInfosAsync(inputText, registeredVideos, onMessage, onMessageVerbose);
                 videos.AddRange(retlieved);
-            } catch
+            }
+            catch
             {
                 var result = new NetworkResult()
                 {
@@ -100,11 +142,20 @@ namespace Niconicome.Models.Network
                 return result;
             }
 
-             return new NetworkResult();
+            return new NetworkResult();
 
 
         }
 
+        /// <summary>
+        /// 状態変更イベントを発火させる
+        /// </summary>
+        private void RaiseStatechange()
+        {
+            this.StateChange?.Invoke(this, EventArgs.Empty);
+        }
+
+        #region 内部処理
         /// <summary>
         /// ローカルフォルダーから動画情報を取得する
         /// </summary>
@@ -114,11 +165,26 @@ namespace Niconicome.Models.Network
         /// <param name="onStarted"></param>
         /// <param name="onWaiting"></param>
         /// <returns></returns>
-        private async Task<IEnumerable<IVideoListInfo>> GetVideoListInfosFromLocalPath(string localPath, Action<IVideoListInfo, IVideoListInfo, int> onSucceeded, Action<IResult, IVideoListInfo> onFailed, Action<IVideoListInfo, int> onStarted, Action<IVideoListInfo> onWaiting)
+        private async Task<IEnumerable<IVideoListInfo>> GetVideoListInfosFromLocalPath(string localPath, Action<string> onMessage)
         {
             var ids = this.localDirectoryHandler.GetVideoIdsFromDirectory(localPath);
+            var videoCount = ids.Count();
 
-            var videos = await this.networkVideoHandler.GetVideoListInfosAsync(ids, onSucceeded, onFailed, onStarted, onWaiting);
+            var videos = await this.networkVideoHandler.GetVideoListInfosAsync(ids, (newVideo, video, i) =>
+            {
+                onMessage($"{video.NiconicoId}の情報を取得しました。({i + 1}/{videoCount})");
+
+            }, (result, video) =>
+            {
+                onMessage($"{video.NiconicoId}の情報を更新に失敗しました。(詳細: {result.Message ?? "None"})");
+            }, (video, i) =>
+            {
+                onMessage($"情報を取得中...({i + 1}/{videoCount})");
+            },
+            video =>
+            {
+                onMessage("待機中...(15s)");
+            });
 
             return videos;
         }
@@ -132,9 +198,23 @@ namespace Niconicome.Models.Network
         /// <param name="onStarted"></param>
         /// <param name="onWaiting"></param>
         /// <returns></returns>
-        private async Task<IEnumerable<IVideoListInfo>> GetVideoListInfosFromID(string id, Action<IVideoListInfo, IVideoListInfo, int> onSucceeded, Action<IResult, IVideoListInfo> onFailed, Action<IVideoListInfo, int> onStarted, Action<IVideoListInfo> onWaiting)
+        private async Task<IEnumerable<IVideoListInfo>> GetVideoListInfosFromID(string id, Action<string> onMessage)
         {
-            var videos = await this.networkVideoHandler.GetVideoListInfosAsync(new List<string>() { id }, onSucceeded, onFailed, onStarted, onWaiting);
+            var videos = await this.networkVideoHandler.GetVideoListInfosAsync(new List<string>() { id }, (newVideo, video, i) =>
+            {
+                onMessage($"{video.NiconicoId}の情報を取得しました。");
+
+            }, (result, video) =>
+            {
+                onMessage($"{video.NiconicoId}の情報を更新に失敗しました。(詳細: {result.Message ?? "None"})");
+            }, (video, i) =>
+            {
+                onMessage($"情報を取得中...");
+            },
+            video =>
+            {
+                onMessage("待機中...(15s)");
+            });
 
             return videos;
         }
@@ -155,5 +235,50 @@ namespace Niconicome.Models.Network
 
             return videos;
         }
+
+        /// <summary>
+        /// 動画を検索する
+        /// </summary>
+        /// <param name="registeredVideos"></param>
+        /// <param name="keyword"></param>
+        /// <param name="onSucceeded"></param>
+        /// <param name="onFailed"></param>
+        /// <param name="onStarted"></param>
+        /// <param name="onWaiting"></param>
+        /// <returns></returns>
+        private async Task<IEnumerable<IVideoListInfo>> GetVideoListInfosFromSearchResult(IEnumerable<string> registeredVideos, string keyword, Action<string> onMessage)
+        {
+            IEnumerable<IVideoListInfo> videos = new List<IVideoListInfo>();
+
+            var searchResult = await this.remotePlaylistHandler.TrySearchVideosAsync(keyword, SearchType.Keyword, 1);
+
+            if (!searchResult.IsSucceeded || searchResult.Videos is null)
+            {
+                onMessage($"検索に失敗しました(詳細: {searchResult.Message ?? "none"})");
+                return videos;
+            }
+
+            int videoCount = searchResult.Videos.Count();
+
+            videos = await this.networkVideoHandler.GetVideoListInfosAsync(searchResult.Videos.Select(v => v.Id).Where(v => !registeredVideos.Contains(v)), (newVideo, video, i) =>
+            {
+                onMessage($"{video.NiconicoId}の情報を取得しました。({i + 1}/{videoCount})");
+
+            }, (result, video) =>
+            {
+                onMessage($"{video.NiconicoId}の情報を更新に失敗しました。(詳細: {result.Message ?? "None"})");
+            }, (video, i) =>
+            {
+                onMessage($"情報を取得中...({i + 1}/{videoCount})");
+            },
+            video =>
+            {
+                onMessage("待機中...(15s)");
+            });
+
+            return videos;
+
+        }
+        #endregion
     }
 }

--- a/Niconicome/Models/Network/VideoIDHandler.cs
+++ b/Niconicome/Models/Network/VideoIDHandler.cs
@@ -1,0 +1,159 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Niconicome.Models.Domain.Local.LocalFile;
+using Niconicome.Models.Domain.Utils;
+using Niconicome.Models.Playlist;
+
+namespace Niconicome.Models.Network
+{
+    interface IVideoIDHandler
+    {
+        Task<IEnumerable<IVideoListInfo>> GetVideoListInfosAsync(string inputText, IEnumerable<string> registeredVideos, Action<string> onMessage, Action<string> onMessageVerbose);
+        Task<INetworkResult> TryGetVideoListInfosAsync(List<IVideoListInfo> videos, string inputText, IEnumerable<string> registeredVideos, Action<string> onMessage, Action<string> onMessageVerbose);
+    }
+
+    class VideoIDHandler : IVideoIDHandler
+    {
+        public VideoIDHandler(INetworkVideoHandler networkVideoHandler, INiconicoUtils niconicoUtils, ILocalDirectoryHandler localDirectoryHandler, IRemotePlaylistHandler remotePlaylistHandler)
+        {
+            this.networkVideoHandler = networkVideoHandler;
+            this.niconicoUtils = niconicoUtils;
+            this.localDirectoryHandler = localDirectoryHandler;
+            this.remotePlaylistHandler = remotePlaylistHandler;
+        }
+
+        private readonly INetworkVideoHandler networkVideoHandler;
+
+        private readonly INiconicoUtils niconicoUtils;
+
+        private readonly ILocalDirectoryHandler localDirectoryHandler;
+
+        private readonly IRemotePlaylistHandler remotePlaylistHandler;
+
+        /// <summary>
+        /// 動画情報を取得する
+        /// </summary>
+        /// <param name="inputText"></param>
+        /// <param name="registeredVideos"></param>
+        /// <param name="onMessage"></param>
+        /// <returns></returns>
+        public async Task<IEnumerable<IVideoListInfo>> GetVideoListInfosAsync(string inputText, IEnumerable<string> registeredVideos, Action<string> onMessage, Action<string> onMessageVerbose)
+        {
+            inputText = inputText.Trim();
+            var videos = new List<IVideoListInfo>();
+
+            if (Path.IsPathRooted(inputText))
+            {
+                onMessage("ローカルディレクトリーから動画を取得します");
+                var retlieved = await this.GetVideoListInfosFromLocalPath(inputText, (_, _, _) => { }, (_, _) => { }, (_, _) => { }, (_) => { });
+                videos.AddRange(retlieved);
+                return videos;
+            }
+            else if (inputText.StartsWith("http"))
+            {
+                var type = this.niconicoUtils.GetRemoteType(inputText);
+                var id = this.niconicoUtils.GetID(inputText, type);
+
+                if (type == RemoteType.WatchPage)
+                {
+                    inputText = id;
+                }
+                else
+                {
+                    onMessage("ネットワークから動画を取得します");
+                    var retlieved = await this.GetVideoListInfosFromRemote(registeredVideos, type, id, (m) => onMessageVerbose(m));
+                    videos.AddRange(retlieved);
+                    return videos;
+                }
+            }
+
+            onMessage("IDを登録します");
+            var retlievedId = await this.GetVideoListInfosFromID(inputText, (_, _, _) => { }, (_, _) => { }, (_, _) => { }, (_) => { });
+            videos.AddRange(retlievedId);
+            return videos;
+        }
+
+        /// <summary>
+        /// 安全に動画情報を取得する
+        /// </summary>
+        /// <param name="videos"></param>
+        /// <param name="inputText"></param>
+        /// <param name="registeredVideos"></param>
+        /// <param name="onMessage"></param>
+        /// <param name="onMessageVerbose"></param>
+        /// <returns></returns>
+        public async Task<INetworkResult> TryGetVideoListInfosAsync(List<IVideoListInfo> videos, string inputText, IEnumerable<string> registeredVideos, Action<string> onMessage, Action<string> onMessageVerbose)
+        {
+            try
+            {
+                var retlieved = await this.GetVideoListInfosAsync(inputText, registeredVideos, onMessage, onMessageVerbose);
+                videos.AddRange(retlieved);
+            } catch(Exception e)
+            {
+                var result = new NetworkResult()
+                {
+                    IsFailed = true
+                };
+
+                return result;
+            }
+
+             return new NetworkResult();
+
+
+        }
+
+        /// <summary>
+        /// ローカルフォルダーから動画情報を取得する
+        /// </summary>
+        /// <param name="localPath"></param>
+        /// <param name="onSucceeded"></param>
+        /// <param name="onFailed"></param>
+        /// <param name="onStarted"></param>
+        /// <param name="onWaiting"></param>
+        /// <returns></returns>
+        private async Task<IEnumerable<IVideoListInfo>> GetVideoListInfosFromLocalPath(string localPath, Action<IVideoListInfo, IVideoListInfo, int> onSucceeded, Action<IResult, IVideoListInfo> onFailed, Action<IVideoListInfo, int> onStarted, Action<IVideoListInfo> onWaiting)
+        {
+            var ids = this.localDirectoryHandler.GetVideoIdsFromDirectory(localPath);
+
+            var videos = await this.networkVideoHandler.GetVideoListInfosAsync(ids, onSucceeded, onFailed, onStarted, onWaiting);
+
+            return videos;
+        }
+
+        /// <summary>
+        /// IDから動画を取得する
+        /// </summary>
+        /// <param name="id"></param>
+        /// <param name="onSucceeded"></param>
+        /// <param name="onFailed"></param>
+        /// <param name="onStarted"></param>
+        /// <param name="onWaiting"></param>
+        /// <returns></returns>
+        private async Task<IEnumerable<IVideoListInfo>> GetVideoListInfosFromID(string id, Action<IVideoListInfo, IVideoListInfo, int> onSucceeded, Action<IResult, IVideoListInfo> onFailed, Action<IVideoListInfo, int> onStarted, Action<IVideoListInfo> onWaiting)
+        {
+            var videos = await this.networkVideoHandler.GetVideoListInfosAsync(new List<string>() { id }, onSucceeded, onFailed, onStarted, onWaiting);
+
+            return videos;
+        }
+
+        /// <summary>
+        /// リモートプレイリストから取得する
+        /// </summary>
+        /// <param name="url"></param>
+        /// <param name="registeredVideos"></param>
+        /// <param name="onMessage"></param>
+        /// <returns></returns>
+        private async Task<IEnumerable<IVideoListInfo>> GetVideoListInfosFromRemote(IEnumerable<string> registeredVideos, RemoteType type, string id, Action<string> onMessage)
+        {
+
+            var videos = new List<IVideoListInfo>();
+
+            await this.remotePlaylistHandler.TryGetRemotePlaylistAsync(id, videos, type, registeredVideos, onMessage);
+
+            return videos;
+        }
+    }
+}

--- a/Niconicome/Models/Network/VideoIDHandler.cs
+++ b/Niconicome/Models/Network/VideoIDHandler.cs
@@ -90,7 +90,7 @@ namespace Niconicome.Models.Network
             {
                 var retlieved = await this.GetVideoListInfosAsync(inputText, registeredVideos, onMessage, onMessageVerbose);
                 videos.AddRange(retlieved);
-            } catch(Exception e)
+            } catch
             {
                 var result = new NetworkResult()
                 {

--- a/Niconicome/Models/Network/Watch.cs
+++ b/Niconicome/Models/Network/Watch.cs
@@ -18,6 +18,7 @@ namespace Niconicome.Models.Network
         string Id { get; set; }
         string FileName { get; set; }
         string ChannelID { get; set; }
+        string ChannelName { get; set; }
         int ViewCount { get; set; }
         IEnumerable<string> Tags { get; set; }
         DateTime UploadedOn { get; set; }
@@ -129,8 +130,9 @@ namespace Niconicome.Models.Network
             //再生回数
             info.ViewCount = retrieved.ViewCount;
 
-            //チャンネルID
+            //チャンネル情報
             info.ChannelID = retrieved.ChannelID;
+            info.ChannelName = retrieved.ChannelName;
 
             //投稿日時
             if (retrieved.DmcInfo is not null)
@@ -175,6 +177,8 @@ namespace Niconicome.Models.Network
 
         public string ChannelID { get; set; } = string.Empty;
 
+        public string ChannelName { get; set; } = string.Empty;
+
 
         public int ViewCount { get; set; }
 
@@ -203,6 +207,7 @@ namespace Niconicome.Models.Network
                 ViewCount = this.ViewCount,
                 FileName = this.FileName,
                 ChannelId = this.ChannelID,
+                ChannelName = this.ChannelName,
             };
         }
 

--- a/Niconicome/Models/Network/Watch.cs
+++ b/Niconicome/Models/Network/Watch.cs
@@ -115,6 +115,8 @@ namespace Niconicome.Models.Network
                 return result;
             }
 
+            var replaceStricted = this.settingHandler.GetBoolSetting(Settings.ReplaceSBToMB);
+
             //タイトル
             info.Title = retrieved.Title;
 
@@ -125,7 +127,7 @@ namespace Niconicome.Models.Network
             info.Tags = retrieved.Tags;
 
             //ファイル名
-            info.FileName = this.utils.GetFileName(filenameFormat, retrieved.DmcInfo, ".mp4");
+            info.FileName = this.utils.GetFileName(filenameFormat, retrieved.DmcInfo, ".mp4", replaceStricted);
 
             //再生回数
             info.ViewCount = retrieved.ViewCount;

--- a/Niconicome/Models/Network/Watch.cs
+++ b/Niconicome/Models/Network/Watch.cs
@@ -19,7 +19,13 @@ namespace Niconicome.Models.Network
         string FileName { get; set; }
         string ChannelID { get; set; }
         string ChannelName { get; set; }
+        string OwnerName { get; set; }
         int ViewCount { get; set; }
+        int CommentCount { get; set; }
+        int MylistCount { get; set; }
+        int LikeCount { get; set; }
+        int OwnerID { get; set; }
+        int Duration { get; set; }
         IEnumerable<string> Tags { get; set; }
         DateTime UploadedOn { get; set; }
         Uri LargeThumbUri { get; set; }
@@ -131,10 +137,20 @@ namespace Niconicome.Models.Network
 
             //再生回数
             info.ViewCount = retrieved.ViewCount;
+            info.CommentCount = retrieved.CommentCount;
+            info.MylistCount = retrieved.MylistCount;
+            info.LikeCount = retrieved.LikeCount;
 
             //チャンネル情報
             info.ChannelID = retrieved.ChannelID;
             info.ChannelName = retrieved.ChannelName;
+
+            //投稿者情報
+            info.OwnerID = retrieved.OwnerID;
+            info.OwnerName = retrieved.Owner;
+
+            //再生時間
+            info.Duration = retrieved.Duration;
 
             //投稿日時
             if (retrieved.DmcInfo is not null)
@@ -181,8 +197,19 @@ namespace Niconicome.Models.Network
 
         public string ChannelName { get; set; } = string.Empty;
 
+        public string OwnerName { get; set; } = string.Empty;
 
         public int ViewCount { get; set; }
+
+        public int CommentCount { get; set; }
+
+        public int MylistCount { get; set; }
+
+        public int LikeCount { get; set; }
+
+        public int OwnerID { get; set; }
+
+        public int Duration { get; set; }
 
         public IEnumerable<string> Tags { get; set; } = new List<string>();
 
@@ -210,6 +237,12 @@ namespace Niconicome.Models.Network
                 FileName = this.FileName,
                 ChannelId = this.ChannelID,
                 ChannelName = this.ChannelName,
+                MylistCount = this.MylistCount,
+                CommentCount = this.CommentCount,
+                LikeCount = this.LikeCount,
+                OwnerID = this.OwnerID,
+                Duration = this.Duration,
+                OwnerName = this.OwnerName,
             };
         }
 

--- a/Niconicome/Models/Network/Watch.cs
+++ b/Niconicome/Models/Network/Watch.cs
@@ -17,6 +17,7 @@ namespace Niconicome.Models.Network
         string Title { get; set; }
         string Id { get; set; }
         string FileName { get; set; }
+        string ChannelID { get; set; }
         int ViewCount { get; set; }
         IEnumerable<string> Tags { get; set; }
         DateTime UploadedOn { get; set; }
@@ -128,6 +129,9 @@ namespace Niconicome.Models.Network
             //再生回数
             info.ViewCount = retrieved.ViewCount;
 
+            //チャンネルID
+            info.ChannelID = retrieved.ChannelID;
+
             //投稿日時
             if (retrieved.DmcInfo is not null)
             {
@@ -169,6 +173,8 @@ namespace Niconicome.Models.Network
 
         public string FileName { get; set; } = string.Empty;
 
+        public string ChannelID { get; set; } = string.Empty;
+
 
         public int ViewCount { get; set; }
 
@@ -196,6 +202,7 @@ namespace Niconicome.Models.Network
                 Tags = this.Tags,
                 ViewCount = this.ViewCount,
                 FileName = this.FileName,
+                ChannelId = this.ChannelID,
             };
         }
 

--- a/Niconicome/Models/Playlist/Current.cs
+++ b/Niconicome/Models/Playlist/Current.cs
@@ -159,6 +159,8 @@ namespace Niconicome.Models.Playlist
                             if (playlistId != (this.CurrentSelectedPlaylist?.Id ?? -1)) return;
 
                             var video = this.videoHandler.GetVideo(oldVideo.Id);
+
+                            //保持されている動画情報が亜あれば引き継ぐ
                             var lightVideo = LightVideoListinfoHandler.GetLightVideoListInfo(oldVideo.Id, playlistId);
 
                             if (lightVideo is not null)
@@ -168,6 +170,7 @@ namespace Niconicome.Models.Playlist
                                 video.Message = VideoMessanger.GetMessage(lightVideo.MessageGuid);
                             }
 
+                            //サムネイル
                             bool isValid = this.videoThumnailUtility.IsValidThumbnail(video);
                             bool hasCache = this.videoThumnailUtility.HasThumbnailCache(video);
                             if (!isValid || !hasCache)

--- a/Niconicome/Models/Playlist/Current.cs
+++ b/Niconicome/Models/Playlist/Current.cs
@@ -156,6 +156,7 @@ namespace Niconicome.Models.Playlist
                         foreach (var oldVideo in videos)
                         {
                             if (!this.videoHandler.Exist(oldVideo.Id)) continue;
+                            if (playlistId != (this.CurrentSelectedPlaylist?.Id ?? -1)) return;
 
                             var video = this.videoHandler.GetVideo(oldVideo.Id);
                             var lightVideo = LightVideoListinfoHandler.GetLightVideoListInfo(oldVideo.Id, playlistId);

--- a/Niconicome/Models/Playlist/Current.cs
+++ b/Niconicome/Models/Playlist/Current.cs
@@ -52,6 +52,8 @@ namespace Niconicome.Models.Playlist
 
         private readonly IPlaylistStoreHandler playlistStoreHandler;
 
+        private readonly object lockObj = new();
+
         public ObservableCollection<IVideoListInfo> Videos { get; init; }
 
         /// <summary>
@@ -242,16 +244,20 @@ namespace Niconicome.Models.Playlist
         {
 
             if (this.Videos.Count == 0) return;
-            if (!this.Videos.Any(v => (v?.Id ?? 0) == video.Id))
+            
+            lock (this.lockObj)
             {
-                this.Videos.Add(video);
-            }
-            else
-            {
-                int index = this.Videos.FindIndex(v => v.Id == video.Id);
-                if (index == -1) return;
-                this.Videos.RemoveAt(index);
-                this.Videos.Insert(index, video);
+                if (!this.Videos.Any(v => (v?.Id ?? 0) == video.Id))
+                {
+                    this.Videos.Add(video);
+                }
+                else
+                {
+                    int index = this.Videos.FindIndex(v => v.Id == video.Id);
+                    if (index == -1) return;
+                    this.Videos.RemoveAt(index);
+                    this.Videos.Insert(index, video);
+                }
             }
 
 

--- a/Niconicome/Models/Playlist/LightVideoListInfo.cs
+++ b/Niconicome/Models/Playlist/LightVideoListInfo.cs
@@ -23,8 +23,6 @@ namespace Niconicome.Models.Playlist
     {
         private static readonly List<ILightVideoListInfo> videoListInfos = new();
 
-        private static readonly object lockObj = new();
-
         public static bool Contains(ILightVideoListInfo video)
         {
             return LightVideoListinfoHandler.videoListInfos.Any(v => v.VideoId == video.VideoId && v.PlaylistId == video.PlaylistId);

--- a/Niconicome/Models/Playlist/Tree.cs
+++ b/Niconicome/Models/Playlist/Tree.cs
@@ -819,6 +819,7 @@ namespace Niconicome.Models.Playlist
         Mylist,
         UserVideos,
         WatchLater,
-        Channel
+        Channel,
+        WatchPage
     }
 }

--- a/Niconicome/Models/Playlist/Tree.cs
+++ b/Niconicome/Models/Playlist/Tree.cs
@@ -51,7 +51,6 @@ namespace Niconicome.Models.Playlist
         void Merge(ITreePlaylistInfo playlist);
         void MergeRange(IEnumerable<ITreePlaylistInfo> playlists);
         bool Contains(int id);
-        bool ContainsVideo(string niconicoId, int playlistId);
         bool IsLastChild(ITreePlaylistInfo child);
         bool IsLastChild(int id);
         ITreePlaylistInfo? GetParent(int id);
@@ -238,7 +237,7 @@ namespace Niconicome.Models.Playlist
         /// <returns></returns>
         public bool ContainsVideo(string niconicoId, int playlistId)
         {
-            return this.handler.ContainsVideo(niconicoId, playlistId);
+            return this.playlistStoreHandler.ContainsVideo(niconicoId, playlistId);
         }
 
         /// <summary>
@@ -370,19 +369,6 @@ namespace Niconicome.Models.Playlist
         public bool Contains(int id)
         {
             return this.TreePlaylistInfoes.Any(p => p.Id == id);
-        }
-
-        /// <summary>
-        /// 指定されたIDの動画を含むかどうかを返す
-        /// </summary>
-        /// <param name="videoId"></param>
-        /// <param name="playlistId"></param>
-        /// <returns></returns>
-        public bool ContainsVideo(string niconicoId, int playlistId)
-        {
-            var playlist = this.GetPlaylist(playlistId);
-            if (playlist is null) return false;
-            return playlist.Videos.Any(v => v.NiconicoId == niconicoId);
         }
 
         /// <summary>

--- a/Niconicome/Models/Playlist/VideoList.cs
+++ b/Niconicome/Models/Playlist/VideoList.cs
@@ -27,6 +27,7 @@ namespace Niconicome.Models.Playlist
         string FileName { get; set; }
         string BindableThumbPath { get; }
         string MessageGuid { get; set; }
+        string ChannelId { get; set; }
         IEnumerable<string> Tags { get; set; }
         DateTime UploadedOn { get; set; }
         Uri GetNiconicoPageUri();
@@ -138,6 +139,11 @@ namespace Niconicome.Models.Playlist
         /// メッセージID
         /// </summary>
         public string MessageGuid { get; set; } = Guid.NewGuid().ToString("D");
+
+        /// <summary>
+        /// チャンネルID
+        /// </summary>
+        public string ChannelId { get; set; } = string.Empty;
 
         /// <summary>
         /// 投稿日時

--- a/Niconicome/Models/Playlist/VideoList.cs
+++ b/Niconicome/Models/Playlist/VideoList.cs
@@ -15,6 +15,11 @@ namespace Niconicome.Models.Playlist
     {
         int Id { get; set; }
         int ViewCount { get; set; }
+        int CommentCount { get; set; }
+        int MylistCount { get; set; }
+        int LikeCount { get; set; }
+        int OwnerID { get; set; }
+        int Duration { get; set; }
         string NiconicoId { get; set; }
         string Title { get; set; }
         bool IsDeleted { get; set; }
@@ -58,6 +63,32 @@ namespace Niconicome.Models.Playlist
         /// 再生回数
         /// </summary>
         public int ViewCount { get; set; }
+
+        /// <summary>
+        /// コメント数
+        /// </summary>
+        public int CommentCount { get; set; }
+
+        /// <summary>
+        /// マイリス数
+        /// </summary>
+        public int MylistCount { get; set; }
+
+        /// <summary>
+        /// いいね数
+        /// </summary>
+        public int LikeCount { get; set; }
+
+        /// <summary>
+        /// 投稿者ID
+        /// </summary>
+        public int OwnerID { get; set; }
+
+        /// <summary>
+        /// 再生時間
+        /// </summary>
+        public int Duration { get; set; }
+
 
         /// <summary>
         /// ニコニコ動画におけるID
@@ -227,7 +258,7 @@ namespace Niconicome.Models.Playlist
             videoInfo.NiconicoId = dbVideo.NiconicoId;
             videoInfo.Title = dbVideo.Title;
             videoInfo.IsDeleted = dbVideo.IsDeleted;
-            videoInfo.OwnerName = dbVideo.Owner?.Nickname ?? string.Empty;
+            videoInfo.OwnerName = dbVideo.OwnerName;
             videoInfo.UploadedOn = dbVideo.UploadedOn;
             videoInfo.LargeThumbUrl = dbVideo.LargeThumbUrl;
             videoInfo.ThumbUrl = dbVideo.ThumbUrl;
@@ -236,6 +267,11 @@ namespace Niconicome.Models.Playlist
             videoInfo.IsSelected = dbVideo.IsSelected;
             videoInfo.Tags = dbVideo.Tags ?? new List<string>();
             videoInfo.ViewCount = dbVideo.ViewCount;
+            videoInfo.CommentCount = dbVideo.CommentCount;
+            videoInfo.MylistCount = dbVideo.MylistCount;
+            videoInfo.LikeCount = dbVideo.LikeCount;
+            videoInfo.OwnerID = dbVideo.OwnerID;
+            videoInfo.Duration = dbVideo.Duration;
         }
 
         /// <summary>
@@ -243,7 +279,7 @@ namespace Niconicome.Models.Playlist
         /// </summary>
         /// <param name="newVideo"></param>
         /// <param name="oldVideo"></param>
-        protected static void SetData(IVideoListInfo newVideo, IVideoListInfo oldVideo)
+        public static void SetData(IVideoListInfo newVideo, IVideoListInfo oldVideo)
         {
             newVideo.Id = oldVideo.Id;
             newVideo.ViewCount = oldVideo.ViewCount;
@@ -260,6 +296,11 @@ namespace Niconicome.Models.Playlist
             newVideo.MessageGuid = oldVideo.MessageGuid;
             newVideo.Tags = oldVideo.Tags;
             newVideo.UploadedOn = oldVideo.UploadedOn;
+            newVideo.CommentCount = oldVideo.CommentCount;
+            newVideo.MylistCount = oldVideo.MylistCount;
+            newVideo.LikeCount = oldVideo.LikeCount;
+            newVideo.Duration = oldVideo.Duration;
+            newVideo.OwnerID = oldVideo.OwnerID;
         }
     }
 

--- a/Niconicome/Models/Playlist/VideoList.cs
+++ b/Niconicome/Models/Playlist/VideoList.cs
@@ -28,6 +28,7 @@ namespace Niconicome.Models.Playlist
         string BindableThumbPath { get; }
         string MessageGuid { get; set; }
         string ChannelId { get; set; }
+        string ChannelName { get; set; }
         IEnumerable<string> Tags { get; set; }
         DateTime UploadedOn { get; set; }
         Uri GetNiconicoPageUri();
@@ -144,6 +145,12 @@ namespace Niconicome.Models.Playlist
         /// チャンネルID
         /// </summary>
         public string ChannelId { get; set; } = string.Empty;
+
+        /// <summary>
+        /// チャンネル名
+        /// </summary>
+        public string ChannelName { get; set; } = string.Empty;
+
 
         /// <summary>
         /// 投稿日時

--- a/Niconicome/Models/Playlist/VideoMessanger.cs
+++ b/Niconicome/Models/Playlist/VideoMessanger.cs
@@ -15,6 +15,8 @@ namespace Niconicome.Models.Playlist
 
         private static readonly Dictionary<string, string> messages = new();
 
+        private static object lockObj = new();
+
         public static event EventHandler<VideoMessageChangeEventArgs>? VideoMessageChange;
 
         /// <summary>
@@ -24,19 +26,22 @@ namespace Niconicome.Models.Playlist
         /// <param name="message"></param>
         public static void Write(string guid, string message)
         {
-            string old = string.Empty;
-
-            if (!VideoMessanger.messages.ContainsKey(guid))
+            lock (VideoMessanger.lockObj)
             {
-                VideoMessanger.messages.Add(guid, message);
-            }
-            else
-            {
-                old = VideoMessanger.messages[guid];
-                VideoMessanger.messages[guid] = message;
-            }
+                string old = string.Empty;
 
-            VideoMessanger.RaiseOnMessage(guid, old, message);
+                if (!VideoMessanger.messages.ContainsKey(guid))
+                {
+                    VideoMessanger.messages.Add(guid, message);
+                }
+                else
+                {
+                    old = VideoMessanger.messages[guid];
+                    VideoMessanger.messages[guid] = message;
+                }
+
+                VideoMessanger.RaiseOnMessage(guid, old, message);
+            }
 
         }
 
@@ -47,13 +52,16 @@ namespace Niconicome.Models.Playlist
         /// <returns></returns>
         public static string GetMessage(string guid)
         {
-            if (!VideoMessanger.messages.ContainsKey(guid))
+            lock (VideoMessanger.lockObj)
             {
-                return String.Empty;
-            }
-            else
-            {
-                return VideoMessanger.messages[guid];
+                if (!VideoMessanger.messages.ContainsKey(guid))
+                {
+                    return String.Empty;
+                }
+                else
+                {
+                    return VideoMessanger.messages[guid];
+                }
             }
         }
 

--- a/Niconicome/Models/Playlist/VideoMessanger.cs
+++ b/Niconicome/Models/Playlist/VideoMessanger.cs
@@ -15,7 +15,7 @@ namespace Niconicome.Models.Playlist
 
         private static readonly Dictionary<string, string> messages = new();
 
-        private static object lockObj = new();
+        private static readonly object lockObj = new();
 
         public static event EventHandler<VideoMessageChangeEventArgs>? VideoMessageChange;
 

--- a/Niconicome/Models/Utils/ParallelTasksHandler.cs
+++ b/Niconicome/Models/Utils/ParallelTasksHandler.cs
@@ -45,7 +45,7 @@ namespace Niconicome.Models.Utils
         /// <summary>
         /// 実行フラグ
         /// </summary>
-        private bool IsProcessing;
+        public bool IsProcessing { get; private set; }
 
         /// <summary>
         /// ロックオブジェクト

--- a/Niconicome/Models/Utils/ParallelTasksHandler.cs
+++ b/Niconicome/Models/Utils/ParallelTasksHandler.cs
@@ -10,7 +10,7 @@ namespace Niconicome.Models.Utils
     public interface IParallelTask<T>
     {
         Guid TaskId { get; }
-        Func<T, Task> TaskFunction { get; }
+        Func<T, object, Task> TaskFunction { get; }
         Action<int> OnWait { get; }
     }
 
@@ -127,6 +127,7 @@ namespace Niconicome.Models.Utils
             int index = 0;
             var mre = new ManualResetEventSlim(true);
             var tasks = new List<Task>();
+            var lockObj = new object();
 
             lock (this.lockobj)
             {
@@ -169,7 +170,7 @@ namespace Niconicome.Models.Utils
 
                     mre.Wait();
 
-                    await Task.Run(async () => await task.TaskFunction(task));
+                    await Task.Run(async () => await task.TaskFunction(task, lockobj));
 
                     semaphore.Release();
                 };

--- a/Niconicome/Models/Utils/ParallelTasksHandler.cs
+++ b/Niconicome/Models/Utils/ParallelTasksHandler.cs
@@ -25,7 +25,7 @@ namespace Niconicome.Models.Utils
             this.createThread = createThread;
         }
 
-        public ParallelTasksHandler(int maxPallarelTasksCount, bool createThread = true) : this(maxPallarelTasksCount, -1, -1,createThread) { }
+        public ParallelTasksHandler(int maxPallarelTasksCount, bool createThread = true) : this(maxPallarelTasksCount, -1, -1, createThread) { }
 
         /// <summary>
         /// 最大動機実行数
@@ -118,7 +118,7 @@ namespace Niconicome.Models.Utils
         /// 実処理
         /// </summary>
         /// <returns></returns>
-        public async Task ProcessTasksAsync()
+        public async Task ProcessTasksAsync(Action? preAction = null)
         {
             //すでにタスクを実行中の場合はキャンセル
             if (this.IsProcessing) return;
@@ -131,6 +131,11 @@ namespace Niconicome.Models.Utils
             lock (this.lockobj)
             {
                 this.IsProcessing = true;
+            }
+
+            if (preAction is not null)
+            {
+                preAction();
             }
 
             //スレッドを作成して並列実行する
@@ -173,7 +178,8 @@ namespace Niconicome.Models.Utils
                 {
                     var t = Task.Run(func);
                     tasks.Add(t);
-                } else
+                }
+                else
                 {
                     var t = func();
                     tasks.Add(t);

--- a/Niconicome/Niconicome.csproj
+++ b/Niconicome/Niconicome.csproj
@@ -43,16 +43,17 @@
   <ItemGroup>
     <PackageReference Include="AngleSharp" Version="0.14.0" />
     <PackageReference Include="CredentialManagement" Version="1.0.2" />
-    <PackageReference Include="LiteDB" Version="5.0.9" />
-    <PackageReference Include="MaterialDesignColors" Version="1.2.7" />
-    <PackageReference Include="MaterialDesignThemes" Version="3.2.0" />
+    <PackageReference Include="LiteDB" Version="5.0.10" />
+    <PackageReference Include="MaterialDesignColors" Version="2.0.0" />
+    <PackageReference Include="MaterialDesignThemes" Version="4.0.0" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="5.0.4" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.721-prerelease" />
+    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.774.44" />
     <PackageReference Include="Microsoft.WindowsAPICodePack-Core" Version="1.1.0.2" />
     <PackageReference Include="Microsoft.WindowsAPICodePack-Shell" Version="1.1.0" />
     <PackageReference Include="System.Security.Permissions" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.19" />
+    <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.31" />
     <PackageReference Include="Microsoft.Expression.Interactions" Version="1.0.0" />
   </ItemGroup>
   

--- a/Niconicome/Niconicome.csproj
+++ b/Niconicome/Niconicome.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net5.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <Nullable>enable</Nullable>
-    <AssemblyVersion>0.2.4.*</AssemblyVersion>
+    <AssemblyVersion>0.3.0.*</AssemblyVersion>
     <FileVersion>0.0.0.0</FileVersion>
     <StartupObject>Niconicome.App</StartupObject>
     <AnalysisLevel>latest</AnalysisLevel>
@@ -15,7 +15,7 @@
     <PublishTrimmed>false</PublishTrimmed>
     <Deterministic>false</Deterministic>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
-    <Version>0.2.4</Version>
+    <Version>0.3.0</Version>
     <PackageProjectUrl>https://github.com/Hayao-H/Niconicome</PackageProjectUrl>
     <Copyright>c2021 Hayao-H</Copyright>
     <Authors>Hayao-H</Authors>

--- a/Niconicome/Niconicome.csproj
+++ b/Niconicome/Niconicome.csproj
@@ -34,6 +34,7 @@
 
   <ItemGroup>
     <None Remove="src\app.ico" />
+    <None Remove="Views\Setting\DownloadTasksWindows.xaml" />
     <None Include="src\icon.png">
       <Pack>True</Pack>
       <PackagePath></PackagePath>

--- a/Niconicome/Style/WindowStyle.xaml
+++ b/Niconicome/Style/WindowStyle.xaml
@@ -1,8 +1,12 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:wpf="clr-namespace:MaterialDesignThemes.Wpf;assembly=MaterialDesignThemes.Wpf"
                     xmlns:local="clr-namespace:Niconicome.Style">
     <Style x:Key="Window_Style" TargetType="Window">
         <Setter Property="FontFamily" Value="Yu Gothic"/>
         <Setter Property="Icon" Value="/src/app.ico"/>
+    </Style>
+    <Style TargetType="{x:Type GridViewColumnHeader}" BasedOn="{StaticResource {x:Type GridViewColumnHeader}}">
+        <Setter Property="HorizontalAlignment" Value="Center" />
     </Style>
 </ResourceDictionary>

--- a/Niconicome/ViewModels/BindableBase.cs
+++ b/Niconicome/ViewModels/BindableBase.cs
@@ -23,4 +23,22 @@ namespace Niconicome.ViewModels
             return true;
         }
     }
+
+    public record BindableRecordBase : INotifyPropertyChanged
+    {
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        protected virtual void OnPropertyChanged([CallerMemberName] string? name = null)
+        {
+            this.PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+        }
+
+        protected virtual bool SetProperty<T>(ref T field, T value, [CallerMemberName] string? name = null)
+        {
+            if (field?.Equals(value) ?? false) return false;
+            field = value;
+            this.OnPropertyChanged(name);
+            return true;
+        }
+    }
 }

--- a/Niconicome/ViewModels/Controls/MessageBoxViewModel.cs
+++ b/Niconicome/ViewModels/Controls/MessageBoxViewModel.cs
@@ -29,9 +29,9 @@ namespace Niconicome.ViewModels.Controls
                 DataContext = new MessageBoxViewModel(message, buttons, icon)
             };
 
-            object result = await DialogHost.Show(dialog, identifier);
+            object? result = await DialogHost.Show(dialog, identifier);
 
-            return (MaterialMessageBoxResult)result;
+            return (MaterialMessageBoxResult?)result ?? MaterialMessageBoxResult.No;
         }
     }
 

--- a/Niconicome/ViewModels/Controls/MessageBoxViewModel.cs
+++ b/Niconicome/ViewModels/Controls/MessageBoxViewModel.cs
@@ -1,0 +1,164 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Media;
+using MaterialDesignThemes.Wpf;
+using Niconicome.Models.Domain.Utils;
+using MaterialDesign = MaterialDesignThemes.Wpf;
+
+namespace Niconicome.ViewModels.Controls
+{
+    static class MaterialMessageBox
+    {
+        /// <summary>
+        /// メッセージボックスを表示する
+        /// </summary>
+        /// <param name="message"></param>
+        /// <param name="buttons"></param>
+        /// <param name="icon"></param>
+        /// <param name="identifier"></param>
+        /// <returns></returns>
+        public static async Task<MaterialMessageBoxResult> Show(string message, MessageBoxButtons buttons, MessageBoxIcons icon, string identifier = "default")
+        {
+            var dialog = new Niconicome.Views.Controls.MessageBox()
+            {
+                DataContext = new MessageBoxViewModel(message, buttons, icon)
+            };
+
+            object result = await DialogHost.Show(dialog, identifier);
+
+            return (MaterialMessageBoxResult)result;
+        }
+    }
+
+    class MessageBoxViewModel : BindableBase
+    {
+        public MessageBoxViewModel()
+        {
+            this.Message = "これはメッセージボックスのテストです。";
+            this.IconKind = MaterialDesign::PackIconKind.HelpCircleOutline;
+            this.IconColor = Utils.ConvertToBrush("#42a5f5");
+            this.OKVisibility = Visibility.Visible;
+            this.YesVisibility = Visibility.Collapsed;
+            this.NoVisibility = Visibility.Collapsed;
+            this.CancelVisibility = Visibility.Collapsed;
+        }
+
+        public MessageBoxViewModel(string message, MessageBoxButtons messageBoxButtons, MessageBoxIcons messageBoxIcons)
+        {
+            this.Message = message;
+
+            this.IconKind = messageBoxIcons switch
+            {
+                MessageBoxIcons.Question => MaterialDesign::PackIconKind.HelpCircleOutline,
+                MessageBoxIcons.Caution => MaterialDesign::PackIconKind.AlertOutline,
+                _ => MaterialDesign::PackIconKind.AlertCircleOutline
+            };
+
+            this.IconColor = messageBoxIcons switch
+            {
+
+                MessageBoxIcons.Question => Utils.ConvertToBrush("#42a5f5"),
+                MessageBoxIcons.Caution => Utils.ConvertToBrush("#ffa500"),
+                _ => Utils.ConvertToBrush("#d4000"),
+            };
+
+            if (messageBoxButtons.HasFlag(MessageBoxButtons.Yes))
+            {
+                this.YesVisibility = Visibility.Visible;
+            }
+            else
+            {
+                this.YesVisibility = Visibility.Collapsed;
+            }
+
+            if (messageBoxButtons.HasFlag(MessageBoxButtons.No))
+            {
+                this.NoVisibility = Visibility.Visible;
+            }
+            else
+            {
+                this.NoVisibility = Visibility.Collapsed;
+            }
+
+            if (messageBoxButtons.HasFlag(MessageBoxButtons.OK))
+            {
+                this.OKVisibility = Visibility.Visible;
+            }
+            else
+            {
+                this.OKVisibility = Visibility.Collapsed;
+            }
+
+            if (messageBoxButtons.HasFlag(MessageBoxButtons.Cancel))
+            {
+                this.CancelVisibility = Visibility.Visible;
+            }
+            else
+            {
+                this.CancelVisibility = Visibility.Collapsed;
+            }
+        }
+
+        /// <summary>
+        /// メッセージ
+        /// </summary>
+        public string Message { get; init; }
+
+        /// <summary>
+        /// メニューアイコン
+        /// </summary>
+        public MaterialDesign::PackIconKind IconKind { get; init; }
+
+        public System.Windows.Media.Brush IconColor { get; init; }
+
+        /// <summary>
+        /// Yesボタン
+        /// </summary>
+        public Visibility YesVisibility { get; init; }
+
+        /// <summary>
+        /// Noボタン
+        /// </summary>
+        public Visibility NoVisibility { get; init; }
+
+        /// <summary>
+        /// OKボタン
+        /// </summary>
+        public Visibility OKVisibility { get; init; }
+
+        /// <summary>
+        /// Cancelボタン
+        /// </summary>
+        public Visibility CancelVisibility { get; init; }
+
+    }
+
+    [Flags]
+    enum MessageBoxButtons
+    {
+        Yes = 1,
+        No = 2,
+        OK = 4,
+        Cancel = 8,
+    }
+
+    enum MessageBoxIcons
+    {
+        Question,
+        Caution,
+        Error
+    }
+
+    enum MaterialMessageBoxResult
+    {
+        Yes,
+        No,
+        OK,
+        Cancel
+    }
+}

--- a/Niconicome/ViewModels/Login/LoginBrowserViewModel.cs
+++ b/Niconicome/ViewModels/Login/LoginBrowserViewModel.cs
@@ -11,6 +11,7 @@ using Niconicome.Models.Domain.Utils;
 using Handlers = Niconicome.Models.Domain.Local.Handlers;
 using Utils = Niconicome.Models.Domain.Utils;
 using System.Threading.Tasks;
+using Niconicome.ViewModels.Controls;
 
 namespace Niconicome.ViewModels.Login
 {
@@ -87,9 +88,9 @@ namespace Niconicome.ViewModels.Login
 
             if (cookies.Any(cookie => cookie.Name == "user_session" && cookie.Expires > DateTime.Now))
             {
-                var result = MessageBox.Show("有効なセッションが存在します。ログインをスキップしますか？", "セッションの再利用", MessageBoxButton.YesNo, MessageBoxImage.Question);
+                var result = await MaterialMessageBox.Show("有効なセッションが存在します。ログインをスキップしますか？", MessageBoxButtons.Yes | MessageBoxButtons.No, MessageBoxIcons.Question);
 
-                if (result == MessageBoxResult.Yes)
+                if (result == MaterialMessageBoxResult.Yes)
                 {
                     await this.SetCookiesAndExitAsync(cookies);
                     return;

--- a/Niconicome/ViewModels/Login/LoginWindowViewModel.cs
+++ b/Niconicome/ViewModels/Login/LoginWindowViewModel.cs
@@ -9,6 +9,7 @@ using Niconicome.Models.Auth;
 using System.Diagnostics;
 using Niconicome.Views;
 using Utils = Niconicome.Models.Domain.Utils;
+using Niconicome.Models.Domain.Niconico;
 
 namespace Niconicome.ViewModels.Login
 {

--- a/Niconicome/ViewModels/Mainpage/DownloadSettingsViewModel.cs
+++ b/Niconicome/ViewModels/Mainpage/DownloadSettingsViewModel.cs
@@ -74,6 +74,7 @@ namespace Niconicome.ViewModels.Mainpage
                    int videoCount = videos.Count();
                    var firstVideo = videos.First();
                    var allowDupe = WS::Mainpage.SettingHandler.GetBoolSetting(Settings.AllowDupeOnStage);
+                   var replaceStricted = WS::Mainpage.SettingHandler.GetBoolSetting(Settings.ReplaceSBToMB);
                    string folderPath = this.playlist!.Folderpath.IsNullOrEmpty() ? WS::Mainpage.SettingHandler.GetStringSetting(Settings.DefaultFolder) ?? "downloaded" : this.playlist.Folderpath;
                    var setting = new DownloadSettings
                    {
@@ -89,6 +90,7 @@ namespace Niconicome.ViewModels.Mainpage
                        FolderPath = folderPath,
                        VerticalResolution = this.SelectedResolution.Resolution.Vertical,
                        PlaylistID = WS::Mainpage.CurrentPlaylist.CurrentSelectedPlaylist?.Id ?? 0,
+                       IsReplaceStrictedEnable = replaceStricted,
                    };
                    var dlFromQueue = WS::Mainpage.SettingHandler.GetBoolSetting(Settings.DLAllFromQueue);
 
@@ -133,6 +135,7 @@ namespace Niconicome.ViewModels.Mainpage
                 int videoCount = videos.Count();
                 var firstVideo = videos.First();
                 var allowDupe = WS::Mainpage.SettingHandler.GetBoolSetting(Settings.AllowDupeOnStage);
+                var replaceStricted = WS::Mainpage.SettingHandler.GetBoolSetting(Settings.ReplaceSBToMB);
                 string folderPath = this.playlist!.Folderpath.IsNullOrEmpty() ? WS::Mainpage.SettingHandler.GetStringSetting(Settings.DefaultFolder) ?? "downloaded" : this.playlist.Folderpath;
 
                 WS::Mainpage.DownloadTasksHandler.StageVIdeos(videos, new DownloadSettings
@@ -149,6 +152,7 @@ namespace Niconicome.ViewModels.Mainpage
                     FolderPath = folderPath,
                     VerticalResolution = this.SelectedResolution.Resolution.Vertical,
                     PlaylistID = WS::Mainpage.CurrentPlaylist.CurrentSelectedPlaylist?.Id ?? 0,
+                    IsReplaceStrictedEnable = replaceStricted,
                 }, allowDupe);
 
                 this.SnackbarMessageQueue.Enqueue($"{videos.Count()}件の動画をステージしました。", "管理画面を開く", () =>

--- a/Niconicome/ViewModels/Mainpage/DownloadSettingsViewModel.cs
+++ b/Niconicome/ViewModels/Mainpage/DownloadSettingsViewModel.cs
@@ -41,7 +41,7 @@ namespace Niconicome.ViewModels.Mainpage
     };
             this.selectedResolutionField = s1;
 
-            this.SnackbarMessageQueue = WS::Mainpage.SnackbarMessageQueue;
+            this.SnackbarMessageQueue = WS::Mainpage.SnaclbarHandler.Queue;
 
             this.DownloadCommand = new CommandBase<object>(_ => this.playlist is not null && !this.isDownloadingField, async _ =>
                {

--- a/Niconicome/ViewModels/Mainpage/DownloadSettingsViewModel.cs
+++ b/Niconicome/ViewModels/Mainpage/DownloadSettingsViewModel.cs
@@ -2,17 +2,15 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
-using System.Threading.Tasks;
-using System.Windows;
 using Niconicome.Extensions.System;
+using Niconicome.Extensions.System.List;
 using Niconicome.Models.Local;
-using Niconicome.Models.Network;
+using Niconicome.Models.Network.Download;
 using Niconicome.Models.Playlist;
+using Niconicome.Views;
+using MaterialDesign = MaterialDesignThemes.Wpf;
 using VideoInfo = Niconicome.Models.Domain.Niconico.Video.Infomations;
 using WS = Niconicome.Workspaces;
-using MaterialDesign = MaterialDesignThemes.Wpf;
-using Niconicome.Extensions.System.List;
-using Niconicome.Models.Network.Download;
 
 namespace Niconicome.ViewModels.Mainpage
 {
@@ -32,6 +30,8 @@ namespace Niconicome.ViewModels.Mainpage
             this.isSkippingEnablefield = WS::Mainpage.SettingHandler.GetBoolSetting(Settings.DLSkip);
             this.isCopyFromAnotherFolderEnableFIeld = WS::Mainpage.SettingHandler.GetBoolSetting(Settings.DLCopy);
 
+            WS::Mainpage.Videodownloader.CanDownloadChange += this.OnCanDownloadChange;
+
             var s1 = new ResolutionSetting("1920x1080");
             var s2 = new ResolutionSetting("1280x720");
             var s3 = new ResolutionSetting("854x480");
@@ -44,7 +44,7 @@ namespace Niconicome.ViewModels.Mainpage
 
             this.SnackbarMessageQueue = WS::Mainpage.SnaclbarHandler.Queue;
 
-            this.DownloadCommand = new CommandBase<object>(_ => this.playlist is not null && !this.isDownloadingField, async _ =>
+            this.DownloadCommand = new CommandBase<object>(_ => this.playlist is not null && !this.IsDownloading, async _ =>
                {
                    if (this.playlist is null)
                    {
@@ -64,16 +64,16 @@ namespace Niconicome.ViewModels.Mainpage
                        return;
                    }
 
-                   if (!this.IsDownloadingVideoEnable && !this.IsDownloadingCommentEnable  && !this.IsDownloadingThumbEnable) return;
+                   if (!this.IsDownloadingVideoEnable && !this.IsDownloadingCommentEnable && !this.IsDownloadingThumbEnable) return;
 
                    var videos = WS::Mainpage.CurrentPlaylist.Videos.Where(v => v.IsSelected).Copy();
                    if (!videos.Any()) return;
 
                    var cts = new CancellationTokenSource();
-                   this.StartDownload();
 
                    int videoCount = videos.Count();
                    var firstVideo = videos.First();
+                   var allowDupe = WS::Mainpage.SettingHandler.GetBoolSetting(Settings.AllowDupeOnStage);
                    string folderPath = this.playlist!.Folderpath.IsNullOrEmpty() ? WS::Mainpage.SettingHandler.GetStringSetting(Settings.DefaultFolder) ?? "downloaded" : this.playlist.Folderpath;
                    var setting = new DownloadSettings
                    {
@@ -88,64 +88,87 @@ namespace Niconicome.ViewModels.Mainpage
                        Skip = this.IsSkippingEnable,
                        FolderPath = folderPath,
                        VerticalResolution = this.SelectedResolution.Resolution.Vertical,
+                       PlaylistID = WS::Mainpage.CurrentPlaylist.CurrentSelectedPlaylist?.Id ?? 0,
                    };
+                   var dlFromQueue = WS::Mainpage.SettingHandler.GetBoolSetting(Settings.DLAllFromQueue);
 
 
                    WS::Mainpage.Messagehandler.AppendMessage($"動画のダウンロードを開始します。({videoCount}件)");
                    this.SnackbarMessageQueue.Enqueue($"動画のダウンロードを開始します。({videoCount}件)");
-                   INetworkResult? result = null;
-                   WS::Mainpage.DownloadTasksHandler.StageVIdeos(videos, setting);
-                   WS::Mainpage.DownloadTasksHandler.MoveStagedToQueue();
+                   WS::Mainpage.DownloadTasksHandler.StageVIdeos(videos, setting, allowDupe);
 
-                   try
+                   if (dlFromQueue)
                    {
-                       result = await WS::Mainpage.Videodownloader.DownloadVideos();
-
-                   }
-                   catch (Exception e)
-                   {
-                       WS::Mainpage.Messagehandler.AppendMessage($"ダウンロード中にエラーが発生しました。(詳細: {e.Message})");
-                       this.SnackbarMessageQueue.Enqueue($"ダウンロード中にエラーが発生しました。");
-                   }
-
-                   if (result?.SucceededCount > 1)
-                   {
-                       if (result?.FirstVideo is not null)
-                       {
-                           WS::Mainpage.Messagehandler.AppendMessage($"{result.FirstVideo.NiconicoId}ほか{result.SucceededCount - 1}件の動画をダウンロードしました。");
-                           this.SnackbarMessageQueue.Enqueue($"{result.FirstVideo.NiconicoId}ほか{result.SucceededCount - 1}件の動画をダウンロードしました。");
-
-                           if (!result.IsSucceededAll)
-                           {
-                               WS::Mainpage.Messagehandler.AppendMessage($"{result.FailedCount}件の動画のダウンロードに失敗しました。");
-                           }
-                       }
-                   }
-                   else if (result?.SucceededCount == 1)
-                   {
-                       if (result?.FirstVideo is not null)
-                       {
-                           WS::Mainpage.Messagehandler.AppendMessage($"{result.FirstVideo.NiconicoId}をダウンロードしました。");
-                           this.SnackbarMessageQueue.Enqueue($"{result.FirstVideo.NiconicoId}をダウンロードしました。");
-                       }
+                       WS::Mainpage.DownloadTasksHandler.MoveStagedToQueue();
                    }
                    else
                    {
-                       WS::Mainpage.Messagehandler.AppendMessage($"ダウンロード出来ませんでした。");
-                       this.SnackbarMessageQueue.Enqueue($"ダウンロード出来ませんでした。");
+                       WS::Mainpage.DownloadTasksHandler.MoveStagedToQueue(t => t.PlaylistID == this.playlist.Id);
                    }
 
-                   this.CompleteDownload();
+                   await WS::Mainpage.Videodownloader.DownloadVideosFriendly(m => WS::Mainpage.Messagehandler.AppendMessage(m), m => this.SnackbarMessageQueue.Enqueue(m));
+
 
                });
 
-            this.CancelCommand = new CommandBase<object>(_ => this.isDownloadingField, _ =>
+            this.StageVideosCommand = new CommandBase<object>(_ => true, _ =>
+            {
+                if (this.playlist is null)
+                {
+                    this.SnackbarMessageQueue.Enqueue("プレイリストが選択されていないため、ステージできません");
+                    return;
+                }
+
+                if (!this.IsDownloadingCommentEnable && (this.IsDownloadingCommentLogEnable || this.IsDownloadingEasyComment || this.IsDownloadingOwnerComment))
+                {
+                    this.SnackbarMessageQueue.Enqueue("過去ログ・投コメ・かんたんコメントをDLするにはコメントにチェックを入れてください。");
+                    return;
+                }
+
+                if (!this.IsDownloadingVideoEnable && !this.IsDownloadingCommentEnable && !this.IsDownloadingThumbEnable) return;
+
+                var videos = WS::Mainpage.CurrentPlaylist.Videos.Where(v => v.IsSelected).Copy();
+                if (!videos.Any()) return;
+
+                int videoCount = videos.Count();
+                var firstVideo = videos.First();
+                var allowDupe = WS::Mainpage.SettingHandler.GetBoolSetting(Settings.AllowDupeOnStage);
+                string folderPath = this.playlist!.Folderpath.IsNullOrEmpty() ? WS::Mainpage.SettingHandler.GetStringSetting(Settings.DefaultFolder) ?? "downloaded" : this.playlist.Folderpath;
+
+                WS::Mainpage.DownloadTasksHandler.StageVIdeos(videos, new DownloadSettings
+                {
+                    Video = this.IsDownloadingVideoEnable,
+                    Thumbnail = this.IsDownloadingThumbEnable,
+                    Overwrite = this.IsOverwriteEnable,
+                    Comment = this.IsDownloadingCommentEnable,
+                    DownloadLog = this.IsDownloadingCommentLogEnable,
+                    DownloadEasy = this.IsDownloadingEasyComment,
+                    DownloadOwner = this.IsDownloadingOwnerComment,
+                    FromAnotherFolder = this.IsCopyFromAnotherFolderEnable,
+                    Skip = this.IsSkippingEnable,
+                    FolderPath = folderPath,
+                    VerticalResolution = this.SelectedResolution.Resolution.Vertical,
+                    PlaylistID = WS::Mainpage.CurrentPlaylist.CurrentSelectedPlaylist?.Id ?? 0,
+                }, allowDupe);
+
+                this.SnackbarMessageQueue.Enqueue($"{videos.Count()}件の動画をステージしました。", "管理画面を開く", () =>
+                {
+                    var windows = new DownloadTasksWindows();
+                    windows.Show();
+                });
+            });
+
+            this.CancelCommand = new CommandBase<object>(_ => this.IsDownloading, _ =>
             {
                 WS::Mainpage.Videodownloader.Cancel();
-                this.CompleteDownload();
             });
 
             WS::Mainpage.CurrentPlaylist.SelectedItemChanged += this.OnSelectedChanged;
+        }
+
+        ~DownloadSettingsViewModel()
+        {
+            WS::Mainpage.Videodownloader.CanDownloadChange -= this.OnCanDownloadChange;
         }
 
         private bool isDownloadingVideoEnableField = true;
@@ -162,8 +185,6 @@ namespace Niconicome.ViewModels.Mainpage
 
         private bool isOverwriteEnableField;
 
-        private bool isDownloadingField;
-
         private bool isSkippingEnablefield;
 
         private bool isCopyFromAnotherFolderEnableFIeld;
@@ -175,7 +196,7 @@ namespace Niconicome.ViewModels.Mainpage
         /// <summary>
         /// ダウンロードフラグ
         /// </summary>
-        public bool IsDownloading { get => this.isDownloadingField; set => this.SetProperty(ref this.isDownloadingField, value); }
+        public bool IsDownloading { get => !WS::Mainpage.Videodownloader.CanDownload; }
 
         /// <summary>
         /// 動画をダウンロードする
@@ -186,6 +207,11 @@ namespace Niconicome.ViewModels.Mainpage
         /// ダウンロードをキャンセルする
         /// </summary>
         public CommandBase<object> CancelCommand { get; init; }
+
+        /// <summary>
+        /// ステージする
+        /// </summary>
+        public CommandBase<object> StageVideosCommand { get; init; }
 
         /// <summary>
         /// 動画ダウンロードフラグ
@@ -263,15 +289,8 @@ namespace Niconicome.ViewModels.Mainpage
             }
         }
 
-        private void StartDownload()
+        private void OnCanDownloadChange(object? sender, EventArgs e)
         {
-            this.IsDownloading = true;
-            this.RaiseCanExecuteChange();
-        }
-
-        private void CompleteDownload()
-        {
-            this.IsDownloading = false;
             this.RaiseCanExecuteChange();
         }
     }

--- a/Niconicome/ViewModels/Mainpage/DownloadSettingsViewModel.cs
+++ b/Niconicome/ViewModels/Mainpage/DownloadSettingsViewModel.cs
@@ -75,6 +75,7 @@ namespace Niconicome.ViewModels.Mainpage
                    var firstVideo = videos.First();
                    var allowDupe = WS::Mainpage.SettingHandler.GetBoolSetting(Settings.AllowDupeOnStage);
                    var replaceStricted = WS::Mainpage.SettingHandler.GetBoolSetting(Settings.ReplaceSBToMB);
+                   var overrideVideoDT = WS::Mainpage.SettingHandler.GetBoolSetting(Settings.OverrideVideoFileDTToUploadedDT);
                    string folderPath = this.playlist!.Folderpath.IsNullOrEmpty() ? WS::Mainpage.SettingHandler.GetStringSetting(Settings.DefaultFolder) ?? "downloaded" : this.playlist.Folderpath;
                    var setting = new DownloadSettings
                    {
@@ -91,6 +92,7 @@ namespace Niconicome.ViewModels.Mainpage
                        VerticalResolution = this.SelectedResolution.Resolution.Vertical,
                        PlaylistID = WS::Mainpage.CurrentPlaylist.CurrentSelectedPlaylist?.Id ?? 0,
                        IsReplaceStrictedEnable = replaceStricted,
+                       OverrideVideoFileDateToUploadedDT = overrideVideoDT,
                    };
                    var dlFromQueue = WS::Mainpage.SettingHandler.GetBoolSetting(Settings.DLAllFromQueue);
 
@@ -136,6 +138,7 @@ namespace Niconicome.ViewModels.Mainpage
                 var firstVideo = videos.First();
                 var allowDupe = WS::Mainpage.SettingHandler.GetBoolSetting(Settings.AllowDupeOnStage);
                 var replaceStricted = WS::Mainpage.SettingHandler.GetBoolSetting(Settings.ReplaceSBToMB);
+                var overrideVideoDT = WS::Mainpage.SettingHandler.GetBoolSetting(Settings.OverrideVideoFileDTToUploadedDT);
                 string folderPath = this.playlist!.Folderpath.IsNullOrEmpty() ? WS::Mainpage.SettingHandler.GetStringSetting(Settings.DefaultFolder) ?? "downloaded" : this.playlist.Folderpath;
 
                 WS::Mainpage.DownloadTasksHandler.StageVIdeos(videos, new DownloadSettings
@@ -153,6 +156,7 @@ namespace Niconicome.ViewModels.Mainpage
                     VerticalResolution = this.SelectedResolution.Resolution.Vertical,
                     PlaylistID = WS::Mainpage.CurrentPlaylist.CurrentSelectedPlaylist?.Id ?? 0,
                     IsReplaceStrictedEnable = replaceStricted,
+                    OverrideVideoFileDateToUploadedDT = overrideVideoDT,
                 }, allowDupe);
 
                 this.SnackbarMessageQueue.Enqueue($"{videos.Count()}件の動画をステージしました。", "管理画面を開く", () =>

--- a/Niconicome/ViewModels/Mainpage/DownloadSettingsViewModel.cs
+++ b/Niconicome/ViewModels/Mainpage/DownloadSettingsViewModel.cs
@@ -101,8 +101,6 @@ namespace Niconicome.ViewModels.Mainpage
                    var dlFromQueue = WS::Mainpage.SettingHandler.GetBoolSetting(Settings.DLAllFromQueue);
 
 
-                   WS::Mainpage.Messagehandler.AppendMessage($"動画のダウンロードを開始します。({videoCount}件)");
-                   this.SnackbarMessageQueue.Enqueue($"動画のダウンロードを開始します。({videoCount}件)");
                    WS::Mainpage.DownloadTasksHandler.StageVIdeos(videos, setting, allowDupe);
 
                    if (dlFromQueue)

--- a/Niconicome/ViewModels/Mainpage/DownloadSettingsViewModel.cs
+++ b/Niconicome/ViewModels/Mainpage/DownloadSettingsViewModel.cs
@@ -20,6 +20,8 @@ namespace Niconicome.ViewModels.Mainpage
 
         public DownloadSettingsViewModel()
         {
+            this.isLimittingCommentCountEnableField = WS::Mainpage.SettingHandler.GetBoolSetting(Settings.LimitCommentsCount);
+            this.maxCommentsCountField = WS::Mainpage.SettingHandler.GetIntSetting(Settings.MaxCommentsCount);
             this.IsDownloadingVideoEnable = WS::Mainpage.SettingHandler.GetBoolSetting(Settings.DLVideo);
             this.IsDownloadingCommentEnable = WS::Mainpage.SettingHandler.GetBoolSetting(Settings.DLComment);
             this.isDownloadingCommentLogEnableField = WS::Mainpage.SettingHandler.GetBoolSetting(Settings.DLKako);
@@ -38,8 +40,7 @@ namespace Niconicome.ViewModels.Mainpage
             var s4 = new ResolutionSetting("640x360");
             var s5 = new ResolutionSetting("426x240");
 
-            this.Resolutions = new List<ResolutionSetting>() { s1, s2, s3, s4, s5
-    };
+            this.Resolutions = new List<ResolutionSetting>() { s1, s2, s3, s4, s5 };
             this.selectedResolutionField = s1;
 
             this.SnackbarMessageQueue = WS::Mainpage.SnaclbarHandler.Queue;
@@ -93,6 +94,7 @@ namespace Niconicome.ViewModels.Mainpage
                        PlaylistID = WS::Mainpage.CurrentPlaylist.CurrentSelectedPlaylist?.Id ?? 0,
                        IsReplaceStrictedEnable = replaceStricted,
                        OverrideVideoFileDateToUploadedDT = overrideVideoDT,
+                       MaxCommentsCount = this.IsLimittingCommentCountEnable ? this.MaxCommentsCount : 0,
                    };
                    var dlFromQueue = WS::Mainpage.SettingHandler.GetBoolSetting(Settings.DLAllFromQueue);
 
@@ -157,6 +159,7 @@ namespace Niconicome.ViewModels.Mainpage
                     PlaylistID = WS::Mainpage.CurrentPlaylist.CurrentSelectedPlaylist?.Id ?? 0,
                     IsReplaceStrictedEnable = replaceStricted,
                     OverrideVideoFileDateToUploadedDT = overrideVideoDT,
+                    MaxCommentsCount = this.IsLimittingCommentCountEnable ? this.MaxCommentsCount : 0,
                 }, allowDupe);
 
                 this.SnackbarMessageQueue.Enqueue($"{videos.Count()}件の動画をステージしました。", "管理画面を開く", () =>
@@ -196,6 +199,10 @@ namespace Niconicome.ViewModels.Mainpage
         private bool isSkippingEnablefield;
 
         private bool isCopyFromAnotherFolderEnableFIeld;
+
+        private bool isLimittingCommentCountEnableField;
+
+        private int maxCommentsCountField;
 
         private ResolutionSetting selectedResolutionField;
 
@@ -266,6 +273,15 @@ namespace Niconicome.ViewModels.Mainpage
         /// </summary>
         public bool IsCopyFromAnotherFolderEnable { get => this.isCopyFromAnotherFolderEnableFIeld; set => this.Savesetting(ref this.isCopyFromAnotherFolderEnableFIeld, value, Settings.DLCopy); }
 
+        /// <summary>
+        /// コメント取得数を制限する
+        /// </summary>
+        public bool IsLimittingCommentCountEnable { get => this.isLimittingCommentCountEnableField; set => this.Savesetting(ref this.isLimittingCommentCountEnableField, value, Settings.LimitCommentsCount); }
+
+        /// <summary>
+        /// コメントの最大取得数
+        /// </summary>
+        public int MaxCommentsCount { get => this.maxCommentsCountField; set => this.Savesetting(ref this.maxCommentsCountField, value, Settings.MaxCommentsCount); }
 
         /// <summary>
         /// 選択中の解像度
@@ -301,6 +317,57 @@ namespace Niconicome.ViewModels.Mainpage
         {
             this.RaiseCanExecuteChange();
         }
+    }
+
+    class DownloadSettingsViewModelD
+    {
+        public DownloadSettingsViewModelD()
+        {
+            var s1 = new ResolutionSetting("1920x1080");
+            var s2 = new ResolutionSetting("1280x720");
+            var s3 = new ResolutionSetting("854x480");
+            var s4 = new ResolutionSetting("640x360");
+            var s5 = new ResolutionSetting("426x240");
+
+            this.Resolutions = new List<ResolutionSetting>() { s1, s2, s3, s4, s5 };
+            this.SelectedResolution = s1;
+        }
+
+        public bool IsDownloading { get => false; }
+
+        public CommandBase<object> DownloadCommand { get; init; } = new CommandBase<object>(_ => true, _ => { });
+
+        public CommandBase<object> CancelCommand { get; init; } = new CommandBase<object>(_ => true, _ => { });
+
+        public CommandBase<object> StageVideosCommand { get; init; } = new CommandBase<object>(_ => true, _ => { });
+
+        public bool IsDownloadingVideoEnable { get; set; } = true;
+
+        public bool IsDownloadingCommentEnable { get; set; } = true;
+
+        public bool IsDownloadingCommentLogEnable { get; set; } = true;
+
+        public bool IsDownloadingOwnerComment { get; set; } = true;
+
+        public bool IsDownloadingEasyComment { get; set; } = true;
+
+        public bool IsDownloadingThumbEnable { get; set; } = true;
+
+        public bool IsOverwriteEnable { get; set; } = true;
+
+        public bool IsSkippingEnable { get; set; } = true;
+
+        public bool IsCopyFromAnotherFolderEnable { get; set; } = true;
+
+        public bool IsLimittingCommentCountEnable { get; set; } = true;
+
+        public int MaxCommentsCount { get; set; } = 2000;
+
+        public ResolutionSetting SelectedResolution { get; set; }
+
+        public List<ResolutionSetting> Resolutions { get; init; }
+
+        public MaterialDesign::ISnackbarMessageQueue SnackbarMessageQueue { get; init; } = new MaterialDesign::SnackbarMessageQueue();
     }
 
     class ResolutionSetting

--- a/Niconicome/ViewModels/Mainpage/DownloadSettingsViewModel.cs
+++ b/Niconicome/ViewModels/Mainpage/DownloadSettingsViewModel.cs
@@ -20,6 +20,7 @@ namespace Niconicome.ViewModels.Mainpage
 
         public DownloadSettingsViewModel()
         {
+            this.isDownloadingVideoIndoEnableField = WS::Mainpage.SettingHandler.GetBoolSetting(Settings.DLVideoInfo);
             this.isLimittingCommentCountEnableField = WS::Mainpage.SettingHandler.GetBoolSetting(Settings.LimitCommentsCount);
             this.maxCommentsCountField = WS::Mainpage.SettingHandler.GetIntSetting(Settings.MaxCommentsCount);
             this.IsDownloadingVideoEnable = WS::Mainpage.SettingHandler.GetBoolSetting(Settings.DLVideo);
@@ -65,7 +66,7 @@ namespace Niconicome.ViewModels.Mainpage
                        return;
                    }
 
-                   if (!this.IsDownloadingVideoEnable && !this.IsDownloadingCommentEnable && !this.IsDownloadingThumbEnable) return;
+                   if (!this.IsDownloadingVideoEnable && !this.IsDownloadingCommentEnable && !this.IsDownloadingThumbEnable && !this.IsDownloadingVideoInfoEnable) return;
 
                    var videos = WS::Mainpage.CurrentPlaylist.Videos.Where(v => v.IsSelected).Copy();
                    if (!videos.Any()) return;
@@ -95,6 +96,7 @@ namespace Niconicome.ViewModels.Mainpage
                        IsReplaceStrictedEnable = replaceStricted,
                        OverrideVideoFileDateToUploadedDT = overrideVideoDT,
                        MaxCommentsCount = this.IsLimittingCommentCountEnable ? this.MaxCommentsCount : 0,
+                       DownloadVideoInfo = this.IsDownloadingVideoInfoEnable,
                    };
                    var dlFromQueue = WS::Mainpage.SettingHandler.GetBoolSetting(Settings.DLAllFromQueue);
 
@@ -131,7 +133,7 @@ namespace Niconicome.ViewModels.Mainpage
                     return;
                 }
 
-                if (!this.IsDownloadingVideoEnable && !this.IsDownloadingCommentEnable && !this.IsDownloadingThumbEnable) return;
+                if (!this.IsDownloadingVideoEnable && !this.IsDownloadingCommentEnable && !this.IsDownloadingThumbEnable && !this.IsDownloadingVideoInfoEnable) return;
 
                 var videos = WS::Mainpage.CurrentPlaylist.Videos.Where(v => v.IsSelected).Copy();
                 if (!videos.Any()) return;
@@ -160,6 +162,7 @@ namespace Niconicome.ViewModels.Mainpage
                     IsReplaceStrictedEnable = replaceStricted,
                     OverrideVideoFileDateToUploadedDT = overrideVideoDT,
                     MaxCommentsCount = this.IsLimittingCommentCountEnable ? this.MaxCommentsCount : 0,
+                    DownloadVideoInfo = this.IsDownloadingVideoInfoEnable,
                 }, allowDupe);
 
                 this.SnackbarMessageQueue.Enqueue($"{videos.Count()}件の動画をステージしました。", "管理画面を開く", () =>
@@ -201,6 +204,8 @@ namespace Niconicome.ViewModels.Mainpage
         private bool isCopyFromAnotherFolderEnableFIeld;
 
         private bool isLimittingCommentCountEnableField;
+
+        private bool isDownloadingVideoIndoEnableField;
 
         private int maxCommentsCountField;
 
@@ -257,6 +262,12 @@ namespace Niconicome.ViewModels.Mainpage
         /// サムネイルダウンロードフラグ
         /// </summary>
         public bool IsDownloadingThumbEnable { get => this.isDownloadingThumbEnableField; set => this.Savesetting(ref this.isDownloadingThumbEnableField, value, Settings.DLThumb); }
+
+        /// <summary>
+        /// 動画情報
+        /// </summary>
+        public bool IsDownloadingVideoInfoEnable { get => this.isDownloadingVideoIndoEnableField; set => this.Savesetting(ref this.isDownloadingVideoIndoEnableField, value, Settings.DLVideoInfo); }
+
 
         /// <summary>
         /// 上書き保存フラグ
@@ -360,6 +371,8 @@ namespace Niconicome.ViewModels.Mainpage
         public bool IsCopyFromAnotherFolderEnable { get; set; } = true;
 
         public bool IsLimittingCommentCountEnable { get; set; } = true;
+
+        public bool IsDownloadingVideoInfoEnable { get; set; } = true;
 
         public int MaxCommentsCount { get; set; } = 2000;
 

--- a/Niconicome/ViewModels/Mainpage/MainWindowViewModel.cs
+++ b/Niconicome/ViewModels/Mainpage/MainWindowViewModel.cs
@@ -8,10 +8,11 @@ using Niconicome.Views;
 using Niconicome.ViewModels;
 using Niconicome.Models.Domain.Niconico;
 using Niconicome.Models.Auth;
-using WS= Niconicome.Workspaces;
+using WS = Niconicome.Workspaces;
 using Niconicome.Views.Setting;
 using System.ComponentModel;
 using Niconicome.Extensions;
+using Niconicome.ViewModels.Controls;
 
 namespace Niconicome.ViewModels.Mainpage
 {
@@ -28,6 +29,7 @@ namespace Niconicome.ViewModels.Mainpage
                     (object? arg) => true,
                     async (object? arg) =>
                     {
+
                         if (!this.IsLogin)
                         {
                             Window loginpage = new Loginxaml
@@ -214,7 +216,7 @@ namespace Niconicome.ViewModels.Mainpage
             this.AssociatedObject.Closing -= this.OnClosing;
         }
 
-        private void OnClosing(object? sender,CancelEventArgs e)
+        private void OnClosing(object? sender, CancelEventArgs e)
         {
             if (sender is null || sender.AsNullable<Window>() is not Window window) return;
             if (window != Application.Current.MainWindow) return;

--- a/Niconicome/ViewModels/Mainpage/MainWindowViewModel.cs
+++ b/Niconicome/ViewModels/Mainpage/MainWindowViewModel.cs
@@ -24,6 +24,14 @@ namespace Niconicome.ViewModels.Mainpage
 
         public MainWindowViewModel()
         {
+            if (WS::Mainpage.Session.IsLogin)
+            {
+                this.OnLogin(this, EventArgs.Empty);
+            } else
+            {
+                WS::Mainpage.StartUp.AutoLoginSucceeded += this.OnLogin;
+            }
+
 
             this.LoginCommand = new CommandBase<object>(
                     (object? arg) => true,
@@ -38,17 +46,7 @@ namespace Niconicome.ViewModels.Mainpage
                                 ShowInTaskbar = true
                             };
 #pragma warning disable CS8602
-                            (loginpage.DataContext as Login.LoginWindowViewModel).LoginSucceeded += (s, e) =>
-#pragma warning restore CS8602
-                            {
-                                this.IsLogin = true;
-                                INiconicoContext context = NiconicoContext.Context;
-                                this.user = NiconicoContext.User;
-                                this.LoginBtnVal = "ログアウト";
-                                this.OnPropertyChanged(nameof(this.LoginBtnTooltip));
-                                this.OnPropertyChanged(nameof(this.Username));
-                                this.OnPropertyChanged(nameof(this.UserImage));
-                            };
+                            (loginpage.DataContext as Login.LoginWindowViewModel).LoginSucceeded += this.OnLogin;
                             loginpage.Show();
                         }
                         else
@@ -173,6 +171,21 @@ namespace Niconicome.ViewModels.Mainpage
                 this.message.AppendLine(value);
                 this.OnPropertyChanged(nameof(this.message));
             }
+        }
+
+        /// <summary>
+        /// ログイン成功時
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void OnLogin(object? sender,EventArgs e)
+        {
+            this.IsLogin = true;
+            this.user = NiconicoContext.User;
+            this.LoginBtnVal = "ログアウト";
+            this.OnPropertyChanged(nameof(this.LoginBtnTooltip));
+            this.OnPropertyChanged(nameof(this.Username));
+            this.OnPropertyChanged(nameof(this.UserImage));
         }
 
 

--- a/Niconicome/ViewModels/Mainpage/MainWindowViewModel.cs
+++ b/Niconicome/ViewModels/Mainpage/MainWindowViewModel.cs
@@ -1,18 +1,16 @@
 ﻿using System;
+using System.ComponentModel;
 using System.Text;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media.Imaging;
 using Microsoft.Xaml.Behaviors;
-using Niconicome.Views;
-using Niconicome.ViewModels;
-using Niconicome.Models.Domain.Niconico;
-using Niconicome.Models.Auth;
-using WS = Niconicome.Workspaces;
-using Niconicome.Views.Setting;
-using System.ComponentModel;
 using Niconicome.Extensions;
-using Niconicome.ViewModels.Controls;
+using Niconicome.Models.Auth;
+using Niconicome.Models.Domain.Niconico;
+using Niconicome.Views;
+using Niconicome.Views.Setting;
+using WS = Niconicome.Workspaces;
 
 namespace Niconicome.ViewModels.Mainpage
 {
@@ -70,6 +68,12 @@ namespace Niconicome.ViewModels.Mainpage
                     Owner = Application.Current.MainWindow,
                 };
                 window.Show();
+            });
+
+            this.OpenDownloadTaskWindowsCommand = new CommandBase<object>(_ => true,_=>
+            {
+                var windows = new DownloadTasksWindows();
+                windows.Show();
             });
         }
 
@@ -131,6 +135,8 @@ namespace Niconicome.ViewModels.Mainpage
         public CommandBase<object> LoginCommand { get; private set; }
 
         public CommandBase<object> OpenSettingCommand { get; init; }
+
+        public CommandBase<object> OpenDownloadTaskWindowsCommand { get; init; }
 
         /// <summary>
         /// ログイン状態(フィールド)

--- a/Niconicome/ViewModels/Mainpage/PlayistTreeViewModel.cs
+++ b/Niconicome/ViewModels/Mainpage/PlayistTreeViewModel.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
+using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
@@ -10,6 +11,7 @@ using Microsoft.Xaml.Behaviors;
 using Niconicome.Extensions;
 using Niconicome.Extensions.System.Windows;
 using Niconicome.Models.Playlist;
+using Niconicome.ViewModels.Controls;
 using Niconicome.ViewModels.Mainpage.Subwindows;
 using Niconicome.Views;
 using Utils = Niconicome.Models.Domain.Utils;
@@ -23,16 +25,16 @@ namespace Niconicome.ViewModels.Mainpage
     /// </summary>
     class PlaylistTreeViewModel : BindableBase
     {
-        public PlaylistTreeViewModel() : this((text, title, button, icon) => MessageBox.Show(text, title, button, icon)) { }
+        public PlaylistTreeViewModel() : this((text, button, icon) => MaterialMessageBox.Show(text, button, icon)) { }
 
-        public PlaylistTreeViewModel(Func<string, string, MessageBoxButton, MessageBoxImage, MessageBoxResult> showMessageBox)
+        public PlaylistTreeViewModel(Func<string, MessageBoxButtons, MessageBoxIcons, Task<MaterialMessageBoxResult>> showMessageBox)
         {
             this.ShowMessageBox = showMessageBox;
 
             //初期化失敗時
             void initializeFailed()
             {
-                this.ShowMessageBox("アプリケーションの初期化中にエラーが発生しました。詳しくはエラーログをご確認下さい。", "エラー", MessageBoxButton.OK, MessageBoxImage.Error);
+                this.ShowMessageBox("アプリケーションの初期化中にエラーが発生しました。詳しくはエラーログをご確認下さい。", MessageBoxButtons.OK, MessageBoxIcons.Error);
                 Application.Current?.Shutdown();
             }
 
@@ -52,8 +54,12 @@ namespace Niconicome.ViewModels.Mainpage
                 WS::Mainpage.PlaylistTree.AddPlaylist(parent);
                 this.OnPropertyChanged(nameof(this.PlaylistTree));
             });
-            this.RemovePlaylist = new CommandBase<int>((object? arg) => true, (int playlist) =>
+            this.RemovePlaylist = new CommandBase<int>((object? arg) => true, async (int playlist) =>
             {
+                var result = await this.ShowMessageBox("本当にプレイリストを削除しますか？", MessageBoxButtons.Yes | MessageBoxButtons.No, MessageBoxIcons.Question);
+
+                if (result != MaterialMessageBoxResult.Yes) return;
+
                 WS::Mainpage.PlaylistTree.DeletePlaylist(playlist);
                 this.OnPropertyChanged(nameof(this.PlaylistTree));
             });
@@ -86,7 +92,7 @@ namespace Niconicome.ViewModels.Mainpage
         /// <summary>
         /// メッセージボックスを表示する
         /// </summary>
-        private Func<string, string, MessageBoxButton, MessageBoxImage, MessageBoxResult> ShowMessageBox { get; set; }
+        private Func<string, MessageBoxButtons, MessageBoxIcons, Task<MaterialMessageBoxResult>> ShowMessageBox { get; set; }
 
         /// <summary>
         /// プレイリストのツリー

--- a/Niconicome/ViewModels/Mainpage/PlayistTreeViewModel.cs
+++ b/Niconicome/ViewModels/Mainpage/PlayistTreeViewModel.cs
@@ -180,6 +180,9 @@ namespace Niconicome.ViewModels.Mainpage
             //キャストできない場合はキャンセル
             if (this.AssociatedObject.SelectedItem.As<ITreePlaylistInfo>() is not ITreePlaylistInfo playlistInfo) return;
 
+            //nullの場合はキャンセル
+            if (playlistInfo is null) return;
+
             //変更がない場合はキャンセル
             if (WS::Mainpage.CurrentPlaylist.CurrentSelectedPlaylist?.Id == playlistInfo.Id) return;
 

--- a/Niconicome/ViewModels/Mainpage/Subwindows/DownloadTasksWindowViewModel.cs
+++ b/Niconicome/ViewModels/Mainpage/Subwindows/DownloadTasksWindowViewModel.cs
@@ -1,0 +1,379 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using Niconicome.Extensions.System.List;
+using Niconicome.Models.Network.Download;
+using Niconicome.ViewModels.Mainpage.Utils;
+using Material = MaterialDesignThemes.Wpf;
+using WS = Niconicome.Workspaces;
+
+namespace Niconicome.ViewModels.Mainpage.Subwindows
+{
+    class DownloadTasksWindowViewModel : BindableBase
+    {
+        public DownloadTasksWindowViewModel()
+        {
+            this.StagedTasks = new ObservableCollection<DownloadTaskViewModel>();
+            this.Tasks = new ObservableCollection<DownloadTaskViewModel>();
+
+            WS::Mainpage.DownloadTasksHandler.StagedDownloadTaskPool.TaskPoolChange += this.OnStagedTaskChanged;
+            WS::Mainpage.DownloadTasksHandler.DownloadTaskPool.TaskPoolChange += this.OnTaskChanged;
+
+            WS::Mainpage.Videodownloader.CanDownloadChange += this.OnCandownloadChanged;
+
+            this.RefreshTask(TaskPoolType.Download);
+            this.RefreshTask(TaskPoolType.Staged);
+
+            this.RefreshStagedTaskCommand = new CommandBase<object>(_ => true, _ => this.RefreshTask(TaskPoolType.Staged));
+            this.RefreshTaskCommand = new CommandBase<object>(_ => true, _ => this.RefreshTask(TaskPoolType.Download));
+
+            this.StartDownloadCommand = new CommandBase<object>(_ => WS::Mainpage.Videodownloader.CanDownload, async _ =>
+            {
+                await WS::Mainpage.Videodownloader.DownloadVideosFriendly(m => WS::Mainpage.Messagehandler.AppendMessage(m), m => this.Queue.Enqueue(m));
+            });
+
+            this.CancelDownloadCommand = new CommandBase<object>(_ => !WS::Mainpage.Videodownloader.CanDownload, _ =>
+            {
+                WS::Mainpage.DownloadTasksHandler.DownloadTaskPool.CancelAllTasks();
+                this.Queue.Enqueue("ユーザーによってダウンロードがキャンセルされました。");
+                WS::Mainpage.Messagehandler.AppendMessage("ユーザーによってダウンロードがキャンセルされました。");
+            });
+
+            this.ClearStagedCommand = new CommandBase<object>(_ => true, _ =>
+            {
+                WS::Mainpage.DownloadTasksHandler.StagedDownloadTaskPool.Clear();
+                this.StagedTasks.Clear();
+            });
+
+            this.RemoveStagedTaskCommand = new CommandBase<object>(_ => true, _ =>
+             {
+                 var tasks = this.StagedTasks.Where(t => t.IsChecked);
+                 foreach (var task in tasks)
+                 {
+                     WS::Mainpage.DownloadTasksHandler.StagedDownloadTaskPool.RemoveTask(task.Task);
+                 }
+
+                 this.StagedTasks.RemoveAll(t => t.IsChecked);
+             });
+
+            this.MoveTasksToQueue = new CommandBase<object>(_ => true, _ =>
+            {
+                WS::Mainpage.DownloadTasksHandler.MoveStagedToQueue();
+                this.StagedTasks.Clear();
+            });
+        }
+
+        ~DownloadTasksWindowViewModel()
+        {
+            WS::Mainpage.DownloadTasksHandler.StagedDownloadTaskPool.TaskPoolChange -= this.OnStagedTaskChanged;
+            WS::Mainpage.DownloadTasksHandler.DownloadTaskPool.TaskPoolChange -= this.OnTaskChanged;
+            WS::Mainpage.Videodownloader.CanDownloadChange -= this.OnCandownloadChanged;
+        }
+
+        private bool displayCanceledField;
+
+        private bool displayCompletedField;
+
+        /// <summary>
+        /// ステージング済みタスク
+        /// </summary>
+        public ObservableCollection<DownloadTaskViewModel> StagedTasks { get; init; }
+
+        /// <summary>
+        /// タスク
+        /// </summary>
+        public ObservableCollection<DownloadTaskViewModel> Tasks { get; init; }
+
+        /// <summary>
+        /// ステージング済みタスク追加時
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void OnStagedTaskChanged(object? sender, TaskPoolChangeEventargs e)
+        {
+            if (e.ChangeType == TaskPoolChangeType.Add)
+            {
+                var tvm = new DownloadTaskViewModel(e.Task);
+                this.StagedTasks.Add(tvm);
+            }
+        }
+
+        /// <summary>
+        /// タスク追加時
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void OnTaskChanged(object? sender, TaskPoolChangeEventargs e)
+        {
+            if (e.ChangeType == TaskPoolChangeType.Add)
+            {
+                var tvm = new DownloadTaskViewModel(e.Task);
+                this.Tasks.Add(tvm);
+            }
+        }
+
+        /// <summary>
+        /// DL可能フラグ変更時
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void OnCandownloadChanged(object? sender, EventArgs e)
+        {
+            this.StartDownloadCommand.RaiseCanExecutechanged();
+            this.CancelDownloadCommand.RaiseCanExecutechanged();
+        }
+
+        /// <summary>
+        /// キャンセル済みを表示
+        /// </summary>
+        public bool DisplayCanceled { get => this.displayCanceledField; set => this.SetProperty(ref this.displayCanceledField, value); }
+
+        /// <summary>
+        /// 完了済みを表示
+        /// </summary>
+        public bool DisplayCompleted { get => this.displayCompletedField; set => this.SetProperty(ref this.displayCompletedField, value); }
+
+        /// <summary>
+        /// タスクを更新する
+        /// </summary>
+        public CommandBase<object> RefreshTaskCommand { get; init; }
+
+        /// <summary>
+        /// ステージング済みタスクを更新
+        /// </summary>
+        public CommandBase<object> RefreshStagedTaskCommand { get; init; }
+
+        /// <summary>
+        /// DLを開始
+        /// </summary>
+        public CommandBase<object> StartDownloadCommand { get; init; }
+
+        /// <summary>
+        /// DLを中止
+        /// </summary>
+        public CommandBase<object> CancelDownloadCommand { get; init; }
+
+        /// <summary>
+        /// ステージング済みをクリア
+        /// </summary>
+        public CommandBase<object> ClearStagedCommand { get; init; }
+
+        /// <summary>
+        /// 削除する
+        /// </summary>
+        public CommandBase<object> RemoveStagedTaskCommand { get; init; }
+
+        /// <summary>
+        /// ステージング済みタスクをキューに追加
+        /// </summary>
+        public CommandBase<object> MoveTasksToQueue { get; init; }
+
+        /// <summary>
+        /// タスクを更新
+        /// </summary>
+        private void RefreshTask(TaskPoolType type)
+        {
+            var tasks = type switch
+            {
+                TaskPoolType.Download => WS::Mainpage.DownloadTasksHandler.DownloadTaskPool.GetAllTasks(),
+                _ => WS::Mainpage.DownloadTasksHandler.StagedDownloadTaskPool.GetAllTasks(),
+            };
+
+            if (!this.DisplayCanceled)
+            {
+                tasks = tasks.Where(t => !t.IsCanceled);
+            }
+
+            if (!this.DisplayCompleted)
+            {
+                tasks = tasks.Where(t => !t.IsDone);
+            }
+
+            if (type == TaskPoolType.Download)
+            {
+                this.Tasks.Clear();
+            }
+            else
+            {
+                this.StagedTasks.Clear();
+            }
+
+            foreach (var task in tasks)
+            {
+                if (type == TaskPoolType.Download)
+                {
+                    this.Tasks.Add(new DownloadTaskViewModel(task));
+                }
+                else
+                {
+                    this.StagedTasks.Add(new DownloadTaskViewModel(task));
+                }
+            }
+        }
+
+        /// <summary>
+        /// メッセージキュー
+        /// </summary>
+        public Material::SnackbarMessageQueue Queue { get; init; } = new();
+    }
+
+    enum TaskPoolType
+    {
+        Staged,
+        Download
+    }
+
+    class DownloadTaskViewModel : BindableBase
+    {
+        public DownloadTaskViewModel(IDownloadTask task)
+        {
+            this.associatedTask = task;
+
+            var r1 = new ComboboxItem<int>(1080, "1080p");
+            var r2 = new ComboboxItem<int>(720, "720p");
+            var r3 = new ComboboxItem<int>(480, "480p");
+            var r4 = new ComboboxItem<int>(360, "360p");
+            var r5 = new ComboboxItem<int>(240, "240p");
+
+            this.SelectableResolutions = new List<ComboboxItem<int>>() { r1, r2, r3, r4, r5 };
+            this.selectedResolutionField = task.DownloadSettings.VerticalResolution switch
+            {
+                1080 => r1,
+                720 => r2,
+                480 => r3,
+                240 => r4,
+                _ => r1
+            };
+
+
+            this.CancelCommand = new CommandBase<object>(_ => !this.IsCancel, _ =>
+            {
+                this.associatedTask.Cancel();
+            });
+
+            task.ProcessStart += (_, _) =>
+            {
+                this.OnPropertyChanged(nameof(this.IsProcessing));
+            };
+
+            task.ProcessingEnd += (_, _) =>
+            {
+                this.OnPropertyChanged(nameof(this.IsProcessing));
+            };
+
+            task.TaskCancel += (_, _) =>
+            {
+                this.OnPropertyChanged(nameof(this.IsCancel));
+                this.CancelCommand.RaiseCanExecutechanged();
+            };
+
+            task.MessageChange += (_, _) => this.OnPropertyChanged(nameof(this.Message));
+
+            task.Done += (_, _) => this.OnPropertyChanged(nameof(this.IsEnd));
+        }
+
+        private readonly IDownloadTask associatedTask;
+
+        private bool isCheckedField;
+
+        private ComboboxItem<int> selectedResolutionField;
+
+        public List<ComboboxItem<int>> SelectableResolutions { get; init; }
+
+        /// <summary>
+        /// タスク
+        /// </summary>
+        public IDownloadTask Task { get => this.associatedTask; }
+
+        /// <summary>
+        /// 選択された解像度
+        /// </summary>
+        public ComboboxItem<int> SelectedResolution
+        {
+            get => this.selectedResolutionField;
+            set
+            {
+                this.SetProperty(ref this.selectedResolutionField, value);
+                this.associatedTask.DownloadSettings.VerticalResolution = (uint)value.Value;
+            }
+        }
+
+        /// <summary>
+        /// 動画タイトル
+        /// </summary>
+        public string Title { get => this.associatedTask.Title; }
+
+        /// <summary>
+        /// ニコニコのID
+        /// </summary>
+        public string NiconicoID { get => this.associatedTask.NiconicoID; }
+
+        /// <summary>
+        /// 処理中フラグ
+        /// </summary>
+        public bool IsProcessing { get => this.associatedTask.IsProcessing; }
+
+        /// <summary>
+        /// 終了フラグ
+        /// </summary>
+        public bool IsEnd { get => this.associatedTask.IsDone; }
+
+        /// <summary>
+        /// キャンセルフラグ
+        /// </summary>
+        public bool IsCancel { get => this.associatedTask.IsCanceled && !this.IsEnd; }
+
+        /// <summary>
+        /// 状態
+        /// </summary>
+        public string Message { get => this.associatedTask.Message; }
+
+        /// <summary>
+        /// 選択フラグ
+        /// </summary>
+        public bool IsChecked { get => this.isCheckedField; set => this.SetProperty(ref this.isCheckedField, value); }
+
+        /// <summary>
+        /// 処理をキャンセル
+        /// </summary>
+        public CommandBase<object> CancelCommand { get; init; }
+
+
+    }
+
+    class DownloadTasksWindowViewModelD
+    {
+        public DownloadTasksWindowViewModelD()
+        {
+            this.StagedTasks = new ObservableCollection<DownloadTaskViewModel>();
+            this.Tasks = new ObservableCollection<DownloadTaskViewModel>();
+            this.StagedTasks.Add(new DownloadTaskViewModel(new BindableDownloadTask("sm9", "陰陽師", 1, new DownloadSettings()) { IsProcessing = true, Message = "初期化完了" }) { IsChecked = true });
+            this.Tasks.Add(new DownloadTaskViewModel(new BindableDownloadTask("sm9", "陰陽師", 1, new DownloadSettings()) { IsProcessing = true, Message = "初期化完了" }) { IsChecked = true });
+        }
+
+        public ObservableCollection<DownloadTaskViewModel> StagedTasks { get; init; }
+
+        public ObservableCollection<DownloadTaskViewModel> Tasks { get; init; }
+
+        public bool DisplayCanceled { get; set; } = true;
+
+        public bool DisplayCompleted { get; set; } = true;
+
+        public CommandBase<object> RefreshTaskCommand { get; init; } = new CommandBase<object>(_ => true, _ => { });
+
+        public CommandBase<object> RefreshStagedTaskCommand { get; init; } = new CommandBase<object>(_ => true, _ => { });
+
+        public CommandBase<object> StartDownloadCommand { get; init; } = new CommandBase<object>(_ => true, _ => { });
+
+        public CommandBase<object> CancelDownloadCommand { get; init; } = new CommandBase<object>(_ => true, _ => { });
+
+        public CommandBase<object> ClearStagedCommand { get; init; } = new CommandBase<object>(_ => true, _ => { });
+
+        public CommandBase<object> RemoveStagedTaskCommand { get; init; } = new CommandBase<object>(_ => true, _ => { });
+
+        public CommandBase<object> MoveTasksToQueue { get; init; } = new CommandBase<object>(_ => true, _ => { });
+
+        public Material::SnackbarMessageQueue Queue { get; init; } = new();
+    }
+}

--- a/Niconicome/ViewModels/Mainpage/Subwindows/NetoworkVideoSettingsViewModel.cs
+++ b/Niconicome/ViewModels/Mainpage/Subwindows/NetoworkVideoSettingsViewModel.cs
@@ -73,15 +73,7 @@ namespace Niconicome.ViewModels.Mainpage.Subwindows
 
                     this.Message = "情報を取得中です...";
 
-                    INetworkResult result = this.CurrentSetting.NetworkMode switch
-                    {
-                        Playlist::RemoteType.Mylist => await WS::Mainpage.RemotePlaylistHandler.TryGetMylistVideosAsync(id, videos),
-                        Playlist::RemoteType.UserVideos => await WS::Mainpage.RemotePlaylistHandler.TryGetUserVideosAsync(id, videos),
-                        Playlist::RemoteType.WatchLater => await WS::Mainpage.RemotePlaylistHandler.TryGetWatchLaterAsync(videos),
-                        Playlist::RemoteType.Channel => await WS::Mainpage.RemotePlaylistHandler.TryGetChannelVideosAsync(id, videos, new List<string>(), m => this.Message = m),
-                        Playlist::RemoteType.None => new NetworkResult(),
-                        _ => new NetworkResult()
-                    };
+                    var result = await WS::Mainpage.RemotePlaylistHandler.TryGetRemotePlaylistAsync(id, videos,this.CurrentSetting.NetworkMode, new List<string>(), m => this.Message = m);
 
 
                     if (result.IsFailed)
@@ -116,18 +108,14 @@ namespace Niconicome.ViewModels.Mainpage.Subwindows
                         WS::Mainpage.CurrentPlaylist.Update(playlistID);
                     }
 
-
-                    switch (this.CurrentSetting.NetworkMode)
+                    if (this.CurrentSetting.NetworkMode == Playlist::RemoteType.None)
                     {
-                        case Playlist::RemoteType.Mylist:
-                        case Playlist::RemoteType.UserVideos:
-                        case Playlist::RemoteType.WatchLater:
-                        case Playlist::RemoteType.Channel:
-                            WS::Mainpage.PlaylistTree.SetAsRemotePlaylist(playlistID, id, this.CurrentSetting.NetworkMode);
-                            break;
-                        case Playlist::RemoteType.None:
-                            WS::Mainpage.PlaylistTree.SetAsLocalPlaylist(playlistID);
-                            break;
+                        WS::Mainpage.PlaylistTree.SetAsLocalPlaylist(playlistID);
+
+                    }
+                    else
+                    {
+                        WS::Mainpage.PlaylistTree.SetAsRemotePlaylist(playlistID, id, this.CurrentSetting.NetworkMode);
                     }
 
                     if (result.IsSucceededAll)

--- a/Niconicome/ViewModels/Mainpage/Utils/ComboboxItem.cs
+++ b/Niconicome/ViewModels/Mainpage/Utils/ComboboxItem.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Niconicome.ViewModels.Mainpage.Utils
+{
+    class ComboboxItem<T>
+    {
+        public ComboboxItem(T value,string displayvalue)
+        {
+            this.DisplayValue = displayvalue;
+            this.Value = value;
+        }
+
+        public T Value { get; init; }
+
+        public string DisplayValue { get; init; }
+    }
+}

--- a/Niconicome/ViewModels/Mainpage/VideoListViewmodel.cs
+++ b/Niconicome/ViewModels/Mainpage/VideoListViewmodel.cs
@@ -21,6 +21,8 @@ using Utils = Niconicome.Models.Domain.Utils;
 using WS = Niconicome.Workspaces;
 using Playlist = Niconicome.Models.Domain.Local.Playlist;
 using Niconicome.Models.Network;
+using Niconicome.ViewModels.Controls;
+using System.Threading.Tasks;
 
 namespace Niconicome.ViewModels.Mainpage
 {
@@ -30,11 +32,11 @@ namespace Niconicome.ViewModels.Mainpage
     /// </summary>
     class VideoListViewModel : BindableBase
     {
-        public VideoListViewModel() : this((message, title, button, image) => MessageBox.Show(message, title, button, image))
+        public VideoListViewModel() : this((message, button,  image) => MaterialMessageBox.Show(message, button, image))
         {
 
         }
-        public VideoListViewModel(Func<string, string, MessageBoxButton, MessageBoxImage, MessageBoxResult> showMessageBox)
+        public VideoListViewModel(Func<string, MessageBoxButtons, MessageBoxIcons, Task<MaterialMessageBoxResult>> showMessageBox)
         {
             //プレイリスト選択変更イベントを購読する
             WS::Mainpage.CurrentPlaylist.SelectedItemChanged += this.OnSelectedPlaylistChanged;
@@ -91,7 +93,7 @@ namespace Niconicome.ViewModels.Mainpage
                 });
             });
 
-            this.RemoveVideoCommand = new CommandBase<IVideoListInfo>(_ => true, arg =>
+            this.RemoveVideoCommand = new CommandBase<IVideoListInfo>(_ => true,async arg =>
             {
                 if (this.Playlist is null)
                 {
@@ -111,8 +113,8 @@ namespace Niconicome.ViewModels.Mainpage
                 : $"本当に「[{targetVideos[0].NiconicoId}]{targetVideos[0].Title}」ほか{targetVideos.Count - 1}件の動画を削除しますか？";
 
 
-                var confirm = this.showMessageBox(confirmMessage, "削除の確認", MessageBoxButton.YesNo, MessageBoxImage.Question);
-                if (confirm != MessageBoxResult.Yes) return;
+                var confirm = await this.showMessageBox(confirmMessage,MessageBoxButtons.Yes|MessageBoxButtons.No,MessageBoxIcons.Question);
+                if (confirm != MaterialMessageBoxResult.Yes) return;
 
                 foreach (var video in targetVideos)
                 {
@@ -790,7 +792,7 @@ namespace Niconicome.ViewModels.Mainpage
         /// <summary>
         /// メッセージボックスを表示するコマンド
         /// </summary>
-        private readonly Func<string, string, MessageBoxButton, MessageBoxImage, MessageBoxResult> showMessageBox;
+        private readonly Func<string, MessageBoxButtons, MessageBoxIcons, Task<MaterialMessageBoxResult>> showMessageBox;
 
         /// <summary>
         /// 動画のリスト

--- a/Niconicome/ViewModels/Mainpage/VideoListViewmodel.cs
+++ b/Niconicome/ViewModels/Mainpage/VideoListViewmodel.cs
@@ -106,31 +106,6 @@ namespace Niconicome.ViewModels.Mainpage
                         WS::Mainpage.SnaclbarHandler.Enqueue("コピーしました");
                     });
                 }
-
-                ///await WS::Mainpage.NetworkVideoHandler.AddVideosAsync(new List<string>() { niconicoId }, this.Playlist.Id, (result) =>
-                ///{
-                ///    var video = new BindableVIdeoListInfo()
-                ///    {
-                ///        Title = "取得失敗",
-                ///        ThumbUrl = "https://nicovideo.cdn.nimg.jp/web/img/common/video_deleted.jpg",
-                ///        Message = result.Message
-                ///    };
-                ///    this.Videos.Add(video);
-                ///
-                ///}, video =>
-                ///{
-                ///    WS::Mainpage.PlaylistTree.Refresh();
-                ///    WS::Mainpage.CurrentPlaylist.Update(playlistId);
-                ///
-                ///    if (!video.ChannelId.IsNullOrEmpty())
-                ///    {
-                ///        WS::Mainpage.SnaclbarHandler.Enqueue($"この動画のチャンネルは「{video.ChannelId}」です", "IDをコピー", () =>
-                ///        {
-                ///            Clipboard.SetText(video.ChannelId);
-                ///            WS::Mainpage.SnaclbarHandler.Enqueue("コピーしました");
-                ///        });
-                ///    }
-                ///});
             });
 
             this.RemoveVideoCommand = new CommandBase<IVideoListInfo>(_ => true, async arg =>

--- a/Niconicome/ViewModels/Mainpage/VideoListViewmodel.cs
+++ b/Niconicome/ViewModels/Mainpage/VideoListViewmodel.cs
@@ -46,7 +46,7 @@ namespace Niconicome.ViewModels.Mainpage
 
             this.showMessageBox = showMessageBox;
 
-            this.SnackbarMessageQueue = WS::Mainpage.SnackbarMessageQueue;
+            this.SnackbarMessageQueue = WS::Mainpage.SnaclbarHandler.Queue;
 
             //メッセージハンドラーにイベントハンドラを追加する
             WS::Mainpage.Messagehandler.AddChangeHandler(() => this.OnPropertyChanged(nameof(this.Message)));
@@ -906,7 +906,7 @@ namespace Niconicome.ViewModels.Mainpage
                 WS::Mainpage.Messagehandler.ClearMessage();
                 string name = WS::Mainpage.CurrentPlaylist.CurrentSelectedPlaylist.Name;
                 WS::Mainpage.Messagehandler.AppendMessage($"プレイリスト:{name}");
-                WS::Mainpage.SnackbarMessageQueue.Enqueue($"プレイリスト:{name}");
+                WS::Mainpage.SnaclbarHandler.Enqueue($"プレイリスト:{name}");
                 this.ChangePlaylistTitle();
             }
         }

--- a/Niconicome/ViewModels/Setting/Pages/DownloadSettingPageViewModel.cs
+++ b/Niconicome/ViewModels/Setting/Pages/DownloadSettingPageViewModel.cs
@@ -39,6 +39,8 @@ namespace Niconicome.ViewModels.Setting.Pages
 
             this.maxParallelDownloadCountFIeld = maxP;
             this.maxParallelSegmentDownloadCountField = maxSP;
+            this.isDownloadFromQueueEnableField = WS::SettingPage.SettingHandler.GetBoolSetting(Settings.DLAllFromQueue);
+            this.isDupeOnStageAllowedField = WS::SettingPage.SettingHandler.GetBoolSetting(Settings.AllowDupeOnStage);
         }
 
         private int commentOffsetField;
@@ -48,6 +50,10 @@ namespace Niconicome.ViewModels.Setting.Pages
         private int maxParallelDownloadCountFIeld;
 
         private int maxParallelSegmentDownloadCountField;
+
+        private bool isDownloadFromQueueEnableField;
+
+        private bool isDupeOnStageAllowedField;
 
         /// <summary>
         /// コメントのオフセット
@@ -88,6 +94,17 @@ namespace Niconicome.ViewModels.Setting.Pages
                 this.Savesetting(ref this.maxParallelSegmentDownloadCountField, value, Settings.MaxParallelSegDl);
             }
         }
+
+        /// <summary>
+        /// キューからもDLする
+        /// </summary>
+        public bool IsDownloadFromQueueEnable { get => this.isDownloadFromQueueEnableField; set => this.Savesetting(ref this.isDownloadFromQueueEnableField, value, Settings.DLAllFromQueue); }
+
+        /// <summary>
+        /// ステージングの際の重複を許可する
+        /// </summary>
+        public bool IsDupeOnStageAllowed { get => this.isDupeOnStageAllowedField; set => this.Savesetting(ref this.isDupeOnStageAllowedField, value, Settings.AllowDupeOnStage); }
+
     }
 
     [Obsolete("Desinger", true)]
@@ -100,5 +117,9 @@ namespace Niconicome.ViewModels.Setting.Pages
         public int MaxParallelDownloadCount { get; set; } = 3;
 
         public int MaxParallelSegmentDownloadCount { get; set; } = 1;
+
+        public bool IsDownloadFromQueueEnable { get; set; } = true;
+
+        public bool IsDupeOnStageAllowed { get; set; } = true;
     }
 }

--- a/Niconicome/ViewModels/Setting/Pages/DownloadSettingPageViewModel.cs
+++ b/Niconicome/ViewModels/Setting/Pages/DownloadSettingPageViewModel.cs
@@ -18,16 +18,36 @@ namespace Niconicome.ViewModels.Setting.Pages
             if (cOffset == -1)
             {
                 this.commentOffsetField = 40;
-            } else
+            }
+            else
             {
                 this.commentOffsetField = cOffset;
             }
             this.isAutoSwitchOffsetEnableField = WS::SettingPage.SettingHandler.GetBoolSetting(Settings.SwitchOffset);
+
+            var maxP = WS::SettingPage.SettingHandler.GetIntSetting(Settings.MaxParallelDL);
+            var maxSP = WS::SettingPage.SettingHandler.GetIntSetting(Settings.MaxParallelSegDl);
+
+            if (maxP <= 0)
+            {
+                maxP = 3;
+            }
+            if (maxSP <= 0)
+            {
+                maxSP = 1;
+            }
+
+            this.maxParallelDownloadCountFIeld = maxP;
+            this.maxParallelSegmentDownloadCountField = maxSP;
         }
 
         private int commentOffsetField;
 
         private bool isAutoSwitchOffsetEnableField;
+
+        private int maxParallelDownloadCountFIeld;
+
+        private int maxParallelSegmentDownloadCountField;
 
         /// <summary>
         /// コメントのオフセット
@@ -45,8 +65,29 @@ namespace Niconicome.ViewModels.Setting.Pages
         /// <summary>
         /// オフセット調節
         /// </summary>
-        public bool IsAutoSwitchOffsetEnable { get => this.isAutoSwitchOffsetEnableField; set => this.Savesetting(ref this.isAutoSwitchOffsetEnableField, value,Settings.SwitchOffset); }
+        public bool IsAutoSwitchOffsetEnable { get => this.isAutoSwitchOffsetEnableField; set => this.Savesetting(ref this.isAutoSwitchOffsetEnableField, value, Settings.SwitchOffset); }
 
+        /// <summary>
+        /// 最大並列DL数
+        /// </summary>
+        public int MaxParallelDownloadCount { get => this.maxParallelDownloadCountFIeld; set => this.Savesetting(ref this.maxParallelDownloadCountFIeld, value, Settings.MaxParallelDL); }
+
+        /// <summary>
+        /// 最大セグメント並列DL数
+        /// </summary>
+        public int MaxParallelSegmentDownloadCount
+        {
+            get => this.maxParallelSegmentDownloadCountField;
+            set
+            {
+                if (value > 5)
+                {
+                    WS::SettingPage.SnackbarMessageQueue.Enqueue("セグメントの最大並列ダウンロード数は5です");
+                    return;
+                }
+                this.Savesetting(ref this.maxParallelSegmentDownloadCountField, value, Settings.MaxParallelSegDl);
+            }
+        }
     }
 
     [Obsolete("Desinger", true)]
@@ -55,5 +96,9 @@ namespace Niconicome.ViewModels.Setting.Pages
         public int CommentOffsetFIeld { get; set; } = 40;
 
         public bool IsAutoSwitchOffsetEnable { get; set; } = true;
+
+        public int MaxParallelDownloadCount { get; set; } = 3;
+
+        public int MaxParallelSegmentDownloadCount { get; set; } = 1;
     }
 }

--- a/Niconicome/ViewModels/Setting/Pages/DownloadSettingPageViewModel.cs
+++ b/Niconicome/ViewModels/Setting/Pages/DownloadSettingPageViewModel.cs
@@ -41,6 +41,7 @@ namespace Niconicome.ViewModels.Setting.Pages
             this.maxParallelSegmentDownloadCountField = maxSP;
             this.isDownloadFromQueueEnableField = WS::SettingPage.SettingHandler.GetBoolSetting(Settings.DLAllFromQueue);
             this.isDupeOnStageAllowedField = WS::SettingPage.SettingHandler.GetBoolSetting(Settings.AllowDupeOnStage);
+            this.isOverrideVideoFileDTToUploadedDTField = WS::SettingPage.SettingHandler.GetBoolSetting(Settings.OverrideVideoFileDTToUploadedDT);
         }
 
         private int commentOffsetField;
@@ -54,6 +55,8 @@ namespace Niconicome.ViewModels.Setting.Pages
         private bool isDownloadFromQueueEnableField;
 
         private bool isDupeOnStageAllowedField;
+
+        private bool isOverrideVideoFileDTToUploadedDTField;
 
         /// <summary>
         /// コメントのオフセット
@@ -105,6 +108,12 @@ namespace Niconicome.ViewModels.Setting.Pages
         /// </summary>
         public bool IsDupeOnStageAllowed { get => this.isDupeOnStageAllowedField; set => this.Savesetting(ref this.isDupeOnStageAllowedField, value, Settings.AllowDupeOnStage); }
 
+        /// <summary>
+        /// 動画ファイルの更新日時を投稿日時にする
+        /// </summary>
+        public bool IsOverrideVideoFileDTToUploadedDT { get => this.isOverrideVideoFileDTToUploadedDTField; set => this.Savesetting(ref this.isOverrideVideoFileDTToUploadedDTField, value, Settings.OverrideVideoFileDTToUploadedDT); }
+
+
     }
 
     [Obsolete("Desinger", true)]
@@ -121,5 +130,7 @@ namespace Niconicome.ViewModels.Setting.Pages
         public bool IsDownloadFromQueueEnable { get; set; } = true;
 
         public bool IsDupeOnStageAllowed { get; set; } = true;
+
+        public bool IsOverrideVideoFileDTToUploadedDT { get; set; } = true;
     }
 }

--- a/Niconicome/ViewModels/Setting/Pages/DownloadSettingPageViewModel.cs
+++ b/Niconicome/ViewModels/Setting/Pages/DownloadSettingPageViewModel.cs
@@ -7,6 +7,7 @@ using WS = Niconicome.Workspaces;
 using Local = Niconicome.Models.Local;
 using System.ComponentModel;
 using Niconicome.Models.Local;
+using Niconicome.ViewModels.Mainpage.Utils;
 
 namespace Niconicome.ViewModels.Setting.Pages
 {
@@ -38,20 +39,42 @@ namespace Niconicome.ViewModels.Setting.Pages
             }
 
             this.isDownloadVideoInfoInJsonEnableField = WS::SettingPage.SettingHandler.GetBoolSetting(Settings.VideoInfoInJson);
-            this.maxParallelDownloadCountFIeld = maxP;
-            this.maxParallelSegmentDownloadCountField = maxSP;
             this.isDownloadFromQueueEnableField = WS::SettingPage.SettingHandler.GetBoolSetting(Settings.DLAllFromQueue);
             this.isDupeOnStageAllowedField = WS::SettingPage.SettingHandler.GetBoolSetting(Settings.AllowDupeOnStage);
             this.isOverrideVideoFileDTToUploadedDTField = WS::SettingPage.SettingHandler.GetBoolSetting(Settings.OverrideVideoFileDTToUploadedDT);
+
+            var n1 = new ComboboxItem<int>(1, "1");
+            var n2 = new ComboboxItem<int>(2, "2");
+            var n3 = new ComboboxItem<int>(3, "3");
+            var n4 = new ComboboxItem<int>(4, "4");
+
+            this.SelectableMaxParallelDownloadCount = new List<ComboboxItem<int>>() { n1, n2, n3, n4 };
+            this.maxParallelDownloadCountFIeld = maxP switch
+            {
+                1 => n1,
+                2 => n2,
+                3 => n3,
+                4 => n4,
+                _ => n4,
+            };
+            this.maxParallelSegmentDownloadCountField = maxSP switch
+            {
+                1 => n1,
+                2 => n2,
+                3 => n3,
+                4 => n4,
+                _ => n4,
+            };
+
         }
 
         private int commentOffsetField;
 
         private bool isAutoSwitchOffsetEnableField;
 
-        private int maxParallelDownloadCountFIeld;
+        private ComboboxItem<int> maxParallelDownloadCountFIeld;
 
-        private int maxParallelSegmentDownloadCountField;
+        private ComboboxItem<int> maxParallelSegmentDownloadCountField;
 
         private bool isDownloadFromQueueEnableField;
 
@@ -60,6 +83,8 @@ namespace Niconicome.ViewModels.Setting.Pages
         private bool isOverrideVideoFileDTToUploadedDTField;
 
         private bool isDownloadVideoInfoInJsonEnableField;
+
+        public List<ComboboxItem<int>> SelectableMaxParallelDownloadCount { get; init; }
 
         /// <summary>
         /// コメントのオフセット
@@ -82,23 +107,15 @@ namespace Niconicome.ViewModels.Setting.Pages
         /// <summary>
         /// 最大並列DL数
         /// </summary>
-        public int MaxParallelDownloadCount { get => this.maxParallelDownloadCountFIeld; set => this.Savesetting(ref this.maxParallelDownloadCountFIeld, value, Settings.MaxParallelDL); }
+        public ComboboxItem<int> MaxParallelDownloadCount { get => this.maxParallelDownloadCountFIeld; set => this.Savesetting(ref this.maxParallelDownloadCountFIeld, value, Settings.MaxParallelDL); }
 
         /// <summary>
         /// 最大セグメント並列DL数
         /// </summary>
-        public int MaxParallelSegmentDownloadCount
+        public ComboboxItem<int> MaxParallelSegmentDownloadCount
         {
             get => this.maxParallelSegmentDownloadCountField;
-            set
-            {
-                if (value > 5)
-                {
-                    WS::SettingPage.SnackbarMessageQueue.Enqueue("セグメントの最大並列ダウンロード数は5です");
-                    return;
-                }
-                this.Savesetting(ref this.maxParallelSegmentDownloadCountField, value, Settings.MaxParallelSegDl);
-            }
+            set => this.Savesetting(ref this.maxParallelSegmentDownloadCountField, value, Settings.MaxParallelSegDl);
         }
 
         /// <summary>
@@ -127,13 +144,27 @@ namespace Niconicome.ViewModels.Setting.Pages
     [Obsolete("Desinger", true)]
     class DownloadSettingPageViewModelD
     {
+        public DownloadSettingPageViewModelD()
+        {
+            var n1 = new ComboboxItem<int>(1, "1");
+            var n2 = new ComboboxItem<int>(2, "2");
+            var n3 = new ComboboxItem<int>(3, "3");
+            var n4 = new ComboboxItem<int>(4, "4");
+
+            this.SelectableMaxParallelDownloadCount = new List<ComboboxItem<int>>() { n1, n2, n3, n4 };
+            this.MaxParallelDownloadCount = n3;
+            this.MaxParallelSegmentDownloadCount = n4;
+        }
+
         public int CommentOffsetFIeld { get; set; } = 40;
 
         public bool IsAutoSwitchOffsetEnable { get; set; } = true;
 
-        public int MaxParallelDownloadCount { get; set; } = 3;
+        public List<ComboboxItem<int>> SelectableMaxParallelDownloadCount { get; init; }
 
-        public int MaxParallelSegmentDownloadCount { get; set; } = 1;
+        public ComboboxItem<int> MaxParallelDownloadCount { get; set; }
+
+        public ComboboxItem<int> MaxParallelSegmentDownloadCount { get; set; }
 
         public bool IsDownloadFromQueueEnable { get; set; } = true;
 

--- a/Niconicome/ViewModels/Setting/Pages/DownloadSettingPageViewModel.cs
+++ b/Niconicome/ViewModels/Setting/Pages/DownloadSettingPageViewModel.cs
@@ -37,6 +37,7 @@ namespace Niconicome.ViewModels.Setting.Pages
                 maxSP = 1;
             }
 
+            this.isDownloadVideoInfoInJsonEnableField = WS::SettingPage.SettingHandler.GetBoolSetting(Settings.VideoInfoInJson);
             this.maxParallelDownloadCountFIeld = maxP;
             this.maxParallelSegmentDownloadCountField = maxSP;
             this.isDownloadFromQueueEnableField = WS::SettingPage.SettingHandler.GetBoolSetting(Settings.DLAllFromQueue);
@@ -57,6 +58,8 @@ namespace Niconicome.ViewModels.Setting.Pages
         private bool isDupeOnStageAllowedField;
 
         private bool isOverrideVideoFileDTToUploadedDTField;
+
+        private bool isDownloadVideoInfoInJsonEnableField;
 
         /// <summary>
         /// コメントのオフセット
@@ -113,6 +116,11 @@ namespace Niconicome.ViewModels.Setting.Pages
         /// </summary>
         public bool IsOverrideVideoFileDTToUploadedDT { get => this.isOverrideVideoFileDTToUploadedDTField; set => this.Savesetting(ref this.isOverrideVideoFileDTToUploadedDTField, value, Settings.OverrideVideoFileDTToUploadedDT); }
 
+        /// <summary>
+        /// JSONでDLする
+        /// </summary>
+        public bool IsDownloadVideoInfoInJsonEnable { get => this.isDownloadVideoInfoInJsonEnableField; set => this.Savesetting(ref this.isDownloadVideoInfoInJsonEnableField, value, Settings.VideoInfoInJson); }
+
 
     }
 
@@ -132,5 +140,7 @@ namespace Niconicome.ViewModels.Setting.Pages
         public bool IsDupeOnStageAllowed { get; set; } = true;
 
         public bool IsOverrideVideoFileDTToUploadedDT { get; set; } = true;
+
+        public bool IsDownloadVideoInfoInJsonEnable { get; set; } = true;
     }
 }

--- a/Niconicome/ViewModels/Setting/Pages/FileSettingsViewModel.cs
+++ b/Niconicome/ViewModels/Setting/Pages/FileSettingsViewModel.cs
@@ -9,25 +9,51 @@ using WS = Niconicome.Workspaces;
 
 namespace Niconicome.ViewModels.Setting.Pages
 {
-    class FileSettingsViewModel:SettingaBase
+    class FileSettingsViewModel : SettingaBase
     {
 
         public FileSettingsViewModel()
         {
-            this.fileFormatField = WS::SettingPage.SettingHandler.GetStringSetting(Settings.FileNameFormat)??string.Empty;
+            this.fileFormatField = WS::SettingPage.SettingHandler.GetStringSetting(Settings.FileNameFormat) ?? string.Empty;
             this.defaultFolderField = WS::SettingPage.SettingHandler.GetStringSetting(Settings.DefaultFolder) ?? "downloaded";
+            this.isReplaceSBToSBEnableField = WS::SettingPage.SettingHandler.GetBoolSetting(Settings.ReplaceSBToMB);
         }
 
         private string fileFormatField;
 
         private string defaultFolderField;
 
+        private bool isReplaceSBToSBEnableField;
+
+        /// <summary>
+        /// デフォルトのDLパス
+        /// </summary>
         public string DefaultFolder { get => this.defaultFolderField; set => this.Savesetting(ref this.defaultFolderField, value, Settings.DefaultFolder); }
 
         /// <summary>
         /// ファイル名のフォーマット
         /// </summary>
-        public string FileFormat { get=>this.fileFormatField; set=>this.Savesetting(ref this.fileFormatField,value,Settings.FileNameFormat); }
+        public string FileFormat { get => this.fileFormatField; set => this.Savesetting(ref this.fileFormatField, value, Settings.FileNameFormat); }
+
+        /// <summary>
+        /// 禁則文字を2バイト文字に置き換える
+        /// </summary>
+        public bool IsReplaceSBToSBEnable { get => this.isReplaceSBToSBEnableField; set => this.Savesetting(ref this.isReplaceSBToSBEnableField, value, Settings.ReplaceSBToMB); }
+
+
+
+    }
+
+    class FileSettingsViewModelD : SettingaBase
+    {
+
+
+        public string DefaultFolder { get; set; } = "download";
+
+
+        public string FileFormat { get; set; } = "[<id>]<title>";
+
+        public bool IsReplaceSBToSBEnable { get; set; } = true;
 
 
     }

--- a/Niconicome/ViewModels/Setting/Pages/GeneralSettingsPageViewModel.cs
+++ b/Niconicome/ViewModels/Setting/Pages/GeneralSettingsPageViewModel.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Niconicome.Models.Auth;
 using Niconicome.Models.Local;
+using Niconicome.ViewModels.Mainpage.Utils;
 using WS = Niconicome.Workspaces;
 
 namespace Niconicome.ViewModels.Setting.Pages
@@ -27,11 +28,47 @@ namespace Niconicome.ViewModels.Setting.Pages
                 AutoLoginTypeString.Webview2 => wv2,
                 _ => normal
             };
+
+            var n1 = new ComboboxItem<int>(1, "1");
+            var n2 = new ComboboxItem<int>(2, "2");
+            var n3 = new ComboboxItem<int>(3, "3");
+            var n4 = new ComboboxItem<int>(4, "4");
+            var n5 = new ComboboxItem<int>(5, "5");
+
+            this.SelectablefetchSleepInterval = new List<ComboboxItem<int>> { n1, n2, n3, n4, n5 };
+            this.SelectableMaxParallelFetch = new List<ComboboxItem<int>>() { n1, n2, n3, n4 };
+
+
+            var maxFetchParallelCount = WS::SettingPage.SettingHandler.GetIntSetting(Settings.MaxFetchCount);
+            var fetchSleepInterval = WS::SettingPage.SettingHandler.GetIntSetting(Settings.FetchSleepInterval);
+
+            this.maxFetchParallelCountField = maxFetchParallelCount switch
+            {
+                1 => n1,
+                2 => n2,
+                3 => n3,
+                4 => n4,
+                _ => n4,
+            };
+
+            this.fetchSleepIntervalFIeld = fetchSleepInterval switch
+            {
+                1 => n1,
+                2 => n2,
+                3 => n3,
+                4 => n4,
+                5 => n5,
+                _ => n4,
+            };
         }
 
         private bool isAutologinEnableField;
 
         private string empty = string.Empty;
+
+        private ComboboxItem<int> maxFetchParallelCountField;
+
+        private ComboboxItem<int> fetchSleepIntervalFIeld;
 
         private AutoLoginTypes selectedAutoLoginTypeField;
 
@@ -53,24 +90,66 @@ namespace Niconicome.ViewModels.Setting.Pages
         }
 
         /// <summary>
+        /// 同時取得数
+        /// </summary>
+        public List<ComboboxItem<int>> SelectableMaxParallelFetch { get; init; }
+
+        /// <summary>
+        /// スリープ間隔
+        /// </summary>
+        public List<ComboboxItem<int>> SelectablefetchSleepInterval { get; init; }
+
+        /// <summary>
         /// 自動ログイン
         /// </summary>
         public bool IsAutologinEnable { get => this.isAutologinEnableField; set => this.Savesetting(ref this.isAutologinEnableField, value, Settings.AutologinEnable); }
+
+        /// <summary>
+        /// 動画情報最大並列取得数
+        /// </summary>
+        public ComboboxItem<int> MaxFetchParallelCount
+        {
+            get => this.maxFetchParallelCountField;
+            set => this.Savesetting(ref this.maxFetchParallelCountField, value, Settings.MaxFetchCount);
+        }
+
+        /// <summary>
+        /// 待機間隔
+        /// </summary>
+        public ComboboxItem<int> FetchSleepInterval { get => this.fetchSleepIntervalFIeld; set => this.Savesetting(ref this.fetchSleepIntervalFIeld, value, Settings.FetchSleepInterval); }
     }
 
     class GeneralSettingsPageViewModelD
     {
+
+        public GeneralSettingsPageViewModelD()
+        {
+            var n1 = new ComboboxItem<int>(1, "1");
+            var n2 = new ComboboxItem<int>(2, "2");
+            var n3 = new ComboboxItem<int>(3, "3");
+            var n4 = new ComboboxItem<int>(4, "4");
+            var n5 = new ComboboxItem<int>(5, "5");
+
+            this.SelectablefetchSleepInterval = new List<ComboboxItem<int>> { n1, n2, n3, n4, n5 };
+            this.SelectableMaxParallelFetch = new List<ComboboxItem<int>>() { n1, n2, n3, n4 };
+
+            this.MaxFetchParallelCount = n3;
+            this.FetchSleepInterval = n5;
+        }
+
         public bool IsAutologinEnable { set; get; } = true;
 
-        /// <summary>
-        /// 選択可能な自動ログインの種別
-        /// </summary>
         public List<AutoLoginTypes> SelectableAutoLoginTypes { get; init; } = new();
 
-        /// <summary>
-        /// 自動ログインの種別
-        /// </summary>
         public AutoLoginTypes SelectedAutoLoginType { get; init; } = new AutoLoginTypes(AutoLoginTypeString.Normal, "パスワード");
+
+        public List<ComboboxItem<int>> SelectableMaxParallelFetch { get; init; }
+
+        public List<ComboboxItem<int>> SelectablefetchSleepInterval { get; init; }
+
+        public ComboboxItem<int> MaxFetchParallelCount { get; set; } 
+
+        public ComboboxItem<int> FetchSleepInterval { get; set; }
 
     }
 
@@ -80,11 +159,24 @@ namespace Niconicome.ViewModels.Setting.Pages
         {
             this.Value = value;
             this.DisplayValue = displayvalue;
+
+            var n1 = new ComboboxItem<int>(1, "1");
+            var n2 = new ComboboxItem<int>(2, "2");
+            var n3 = new ComboboxItem<int>(3, "3");
+            var n4 = new ComboboxItem<int>(4, "4");
+            var n5 = new ComboboxItem<int>(5, "5");
+
+            this.SelectablefetchSleepInterval = new List<ComboboxItem<int>> { n1, n2, n3, n4, n5 };
+            this.SelectableMaxParallelFetch = new List<ComboboxItem<int>>() { n1, n2, n3, n4 };
         }
 
         public string Value { get; init; }
 
         public string DisplayValue { get; init; }
+
+        public List<ComboboxItem<int>> SelectableMaxParallelFetch { get; init; }
+
+        public List<ComboboxItem<int>> SelectablefetchSleepInterval { get; init; }
 
 
     }

--- a/Niconicome/ViewModels/Setting/Pages/GeneralSettingsPageViewModel.cs
+++ b/Niconicome/ViewModels/Setting/Pages/GeneralSettingsPageViewModel.cs
@@ -20,6 +20,7 @@ namespace Niconicome.ViewModels.Setting.Pages
             var wv2 = new AutoLoginTypes(AutoLoginTypeString.Webview2, "Webview2とCookieを共有");
 
             this.SelectableAutoLoginTypes = new List<AutoLoginTypes>() { normal, wv2 };
+            this.isSkippingSSLVerificationEnableField = WS::SettingPage.SettingHandler.GetBoolSetting(Settings.SkipSSLVerification);
 
             var type = WS::SettingPage.SettingHandler.GetStringSetting(Settings.AutologinMode);
             this.selectedAutoLoginTypeField = type switch
@@ -63,6 +64,8 @@ namespace Niconicome.ViewModels.Setting.Pages
         }
 
         private bool isAutologinEnableField;
+
+        private bool isSkippingSSLVerificationEnableField;
 
         private string empty = string.Empty;
 
@@ -117,6 +120,12 @@ namespace Niconicome.ViewModels.Setting.Pages
         /// 待機間隔
         /// </summary>
         public ComboboxItem<int> FetchSleepInterval { get => this.fetchSleepIntervalFIeld; set => this.Savesetting(ref this.fetchSleepIntervalFIeld, value, Settings.FetchSleepInterval); }
+
+        /// <summary>
+        /// SSL証明書の検証をスキップする
+        /// </summary>
+        public bool IsSkippingSSLVerificationEnable { get => this.isSkippingSSLVerificationEnableField; set => this.Savesetting(ref this.isSkippingSSLVerificationEnableField, value, Settings.SkipSSLVerification); }
+
     }
 
     class GeneralSettingsPageViewModelD
@@ -139,6 +148,8 @@ namespace Niconicome.ViewModels.Setting.Pages
 
         public bool IsAutologinEnable { set; get; } = true;
 
+        public bool IsSkippingSSLVerificationEnable { get; set; } = false;
+
         public List<AutoLoginTypes> SelectableAutoLoginTypes { get; init; } = new();
 
         public AutoLoginTypes SelectedAutoLoginType { get; init; } = new AutoLoginTypes(AutoLoginTypeString.Normal, "パスワード");
@@ -147,7 +158,7 @@ namespace Niconicome.ViewModels.Setting.Pages
 
         public List<ComboboxItem<int>> SelectablefetchSleepInterval { get; init; }
 
-        public ComboboxItem<int> MaxFetchParallelCount { get; set; } 
+        public ComboboxItem<int> MaxFetchParallelCount { get; set; }
 
         public ComboboxItem<int> FetchSleepInterval { get; set; }
 

--- a/Niconicome/ViewModels/Setting/Pages/GeneralSettingsPageViewModel.cs
+++ b/Niconicome/ViewModels/Setting/Pages/GeneralSettingsPageViewModel.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Niconicome.Models.Auth;
+using Niconicome.Models.Local;
+using WS = Niconicome.Workspaces;
+
+namespace Niconicome.ViewModels.Setting.Pages
+{
+    class GeneralSettingsPageViewModel : SettingaBase
+    {
+        public GeneralSettingsPageViewModel()
+        {
+            this.isAutologinEnableField = WS::SettingPage.SettingHandler.GetBoolSetting(Settings.AutologinEnable);
+
+            var normal = new AutoLoginTypes(AutoLoginTypeString.Normal, "パスワードログイン");
+            var wv2 = new AutoLoginTypes(AutoLoginTypeString.Webview2, "Webview2とCookieを共有");
+
+            this.SelectableAutoLoginTypes = new List<AutoLoginTypes>() { normal, wv2 };
+
+            var type = WS::SettingPage.SettingHandler.GetStringSetting(Settings.AutologinMode);
+            this.selectedAutoLoginTypeField = type switch
+            {
+                AutoLoginTypeString.Normal => normal,
+                AutoLoginTypeString.Webview2 => wv2,
+                _ => normal
+            };
+        }
+
+        private bool isAutologinEnableField;
+
+        private string empty = string.Empty;
+
+        private AutoLoginTypes selectedAutoLoginTypeField;
+
+        /// <summary>
+        /// 選択可能な自動ログインの種別
+        /// </summary>
+        public List<AutoLoginTypes> SelectableAutoLoginTypes { get; init; }
+
+        /// <summary>
+        /// 自動ログインの種別
+        /// </summary>
+        public AutoLoginTypes SelectedAutoLoginType
+        {
+            get => this.selectedAutoLoginTypeField; set
+            {
+                this.Savesetting(ref this.empty, value.Value, Settings.AutologinMode);
+                this.SetProperty(ref this.selectedAutoLoginTypeField, value);
+            }
+        }
+
+        /// <summary>
+        /// 自動ログイン
+        /// </summary>
+        public bool IsAutologinEnable { get => this.isAutologinEnableField; set => this.Savesetting(ref this.isAutologinEnableField, value, Settings.AutologinEnable); }
+    }
+
+    class GeneralSettingsPageViewModelD
+    {
+        public bool IsAutologinEnable { set; get; } = true;
+
+        /// <summary>
+        /// 選択可能な自動ログインの種別
+        /// </summary>
+        public List<AutoLoginTypes> SelectableAutoLoginTypes { get; init; } = new();
+
+        /// <summary>
+        /// 自動ログインの種別
+        /// </summary>
+        public AutoLoginTypes SelectedAutoLoginType { get; init; } = new AutoLoginTypes(AutoLoginTypeString.Normal, "パスワード");
+
+    }
+
+    class AutoLoginTypes
+    {
+        public AutoLoginTypes(string value, string displayvalue)
+        {
+            this.Value = value;
+            this.DisplayValue = displayvalue;
+        }
+
+        public string Value { get; init; }
+
+        public string DisplayValue { get; init; }
+
+
+    }
+}

--- a/Niconicome/ViewModels/Setting/SettingMainViewModel.cs
+++ b/Niconicome/ViewModels/Setting/SettingMainViewModel.cs
@@ -43,6 +43,7 @@ namespace Niconicome.ViewModels.Setting
                 SettingPages.ApplicationInfo => "/Views/Setting/Pages/AppinfoPage.xaml",
                 SettingPages.Import => "/Views/Setting/Pages/ImportPage.xaml",
                 SettingPages.Download=> "/Views/Setting/Pages/DownloadSettingPage.xaml",
+                SettingPages.General=> "/Views/Setting/Pages/GeneralPage.xaml",
                 _ => "/Views/Setting/Pages/EmptyPage.xaml",
             };
             this.PageUri = new Uri(uri, UriKind.Relative);
@@ -113,6 +114,7 @@ namespace Niconicome.ViewModels.Setting
                 "回復" => SettingPages.Restore,
                 "インポート" => SettingPages.Import,
                 "ダウンロード設定"=>SettingPages.Download,
+                "一般設定"=>SettingPages.General,
                 _ => SettingPages.None
             };
         }
@@ -152,5 +154,6 @@ namespace Niconicome.ViewModels.Setting
         Import,
         Restore,
         Download,
+        General
     }
 }

--- a/Niconicome/ViewModels/Setting/SettingaBase.cs
+++ b/Niconicome/ViewModels/Setting/SettingaBase.cs
@@ -4,6 +4,7 @@ using System.Windows.Navigation;
 using Microsoft.Xaml.Behaviors;
 using Niconicome.Extensions.System.Diagnostics;
 using Niconicome.Models.Local;
+using Niconicome.ViewModels.Mainpage.Utils;
 using WS = Niconicome.Workspaces;
 
 namespace Niconicome.ViewModels.Setting
@@ -40,6 +41,39 @@ namespace Niconicome.ViewModels.Setting
             }
 
             fiels = data;
+            this.OnPropertyChanged(propertyname);
+
+        }
+
+        /// <summary>
+        /// 設定を保存する
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="fiels"></param>
+        /// <param name="data"></param>
+        /// <param name="settingname"></param>
+        /// <param name="propertyname"></param>
+        protected void Savesetting<T>(ref ComboboxItem<T> field, ComboboxItem<T> data, Settings setting, [CallerMemberName] string? propertyname = null)
+        {
+            if (data.Value is bool boolData)
+            {
+                WS::SettingPage.SettingHandler.SaveSetting(boolData, setting);
+            }
+            else if (data.Value is string stringData)
+            {
+                WS::SettingPage.SettingHandler.SaveSetting(stringData, setting);
+            }
+            else if (data.Value is int intData)
+            {
+                WS::SettingPage.SettingHandler.SaveSetting(intData, setting);
+            }
+            else
+            {
+                return;
+            }
+
+            field = data;
+
             this.OnPropertyChanged(propertyname);
 
         }

--- a/Niconicome/Views/Controls/MessageBox.xaml
+++ b/Niconicome/Views/Controls/MessageBox.xaml
@@ -1,0 +1,91 @@
+﻿<UserControl x:Class="Niconicome.Views.Controls.MessageBox"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:Niconicome.Views.Controls"
+             xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+             xmlns:vm="clr-namespace:Niconicome.ViewModels.Controls"
+             mc:Ignorable="d" 
+             Background="#fafafa"
+             Width="800"
+             d:DesignHeight="450" d:DesignWidth="800">
+    <UserControl.DataContext>
+        <vm:MessageBoxViewModel/>
+    </UserControl.DataContext>
+    <Grid x:Name="LayoutRoot">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+        <Border Grid.Row="0">
+            <Grid Margin="12,12,12,8">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="50" />
+                    <RowDefinition Height="auto" />
+                </Grid.RowDefinitions>
+                <materialDesign:PackIcon Width="48"
+                                         Height="48"
+                                         VerticalAlignment="Top"
+                                         Foreground="{Binding IconColor}"
+                                         Kind="{Binding IconKind}"/>
+                <TextBlock Grid.Row="1"
+                           Margin="8,8,0,8"
+                           VerticalAlignment="Top"
+                           FontSize="16"
+                           TextWrapping="Wrap"
+                           Text="{Binding Message, Mode=OneWay}" />
+            </Grid>
+        </Border>
+        <Border Grid.Row="1"
+                Height="2"
+                CornerRadius="2"
+                Margin="16,0">
+            <Border.Background>
+                <LinearGradientBrush StartPoint="0.5,0" EndPoint="0.5,1">
+                    <GradientStop Offset="0" Color="#FFD0D0D0" />
+                    <GradientStop Offset="1" Color="#FFA0A0A0" />
+                    <GradientStop Offset="0.49" Color="#FFD0D0D0" />
+                    <GradientStop Offset="0.5" Color="#FFA0A0A0" />
+                </LinearGradientBrush>
+            </Border.Background>
+        </Border>
+        <Border Grid.Row="2">
+            <StackPanel Margin="16,12"
+                        HorizontalAlignment="Right"
+                        Orientation="Horizontal">
+                <Button Command="{x:Static materialDesign:DialogHost.CloseDialogCommand}"
+                        Content="はい"
+                        Opacity=".6"
+                        Visibility="{Binding YesVisibility}"
+                        CommandParameter="{x:Static vm:MaterialMessageBoxResult.Yes}"
+                        Style="{StaticResource MaterialDesignFlatButton}">
+                </Button>
+                <Button Margin="24,0,0,0"
+                        Command="{x:Static materialDesign:DialogHost.CloseDialogCommand}"
+                        Content="いいえ"
+                        IsCancel="True"
+                        Opacity=".6"
+                        Visibility="{Binding NoVisibility}"
+                        CommandParameter="{x:Static vm:MaterialMessageBoxResult.No}"
+                        Style="{StaticResource MaterialDesignFlatButton}">
+                </Button>
+                <Button Command="{x:Static materialDesign:DialogHost.CloseDialogCommand}"
+                        Content="キャンセル"
+                        Opacity=".6"
+                        Visibility="{Binding CancelVisibility}"
+                        CommandParameter="{x:Static vm:MaterialMessageBoxResult.Cancel}"
+                        Style="{StaticResource MaterialDesignFlatButton}">
+                </Button>
+                <Button Command="{x:Static materialDesign:DialogHost.CloseDialogCommand}"
+                        Content="OK"
+                        Opacity=".6"
+                        Visibility="{Binding OKVisibility}"
+                        CommandParameter="{x:Static vm:MaterialMessageBoxResult.OK}"
+                        Style="{StaticResource MaterialDesignFlatButton}">
+                </Button>
+            </StackPanel>
+        </Border>
+    </Grid>
+</UserControl>

--- a/Niconicome/Views/Controls/MessageBox.xaml.cs
+++ b/Niconicome/Views/Controls/MessageBox.xaml.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace Niconicome.Views.Controls
+{
+    /// <summary>
+    /// MessageBox.xaml の相互作用ロジック
+    /// </summary>
+    public partial class MessageBox : UserControl
+    {
+        public MessageBox()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/Niconicome/Views/DownloadTasksWindows.xaml
+++ b/Niconicome/Views/DownloadTasksWindows.xaml
@@ -1,0 +1,172 @@
+﻿<Window x:Class="Niconicome.Views.DownloadTasksWindows"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+        xmlns:vm="clr-namespace:Niconicome.ViewModels.Mainpage.Subwindows"
+        xmlns:tree="clr-namespce:Niconicome.Models.Playlist"
+        xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
+        mc:Ignorable="d"
+        TextElement.Foreground="{DynamicResource MaterialDesignBody}"
+        TextElement.FontWeight="Regular"
+        TextElement.FontSize="13"
+        TextOptions.TextFormattingMode="Ideal"
+        TextOptions.TextRenderingMode="Auto"
+        Background="{DynamicResource MaterialDesignBackground}"
+        WindowStartupLocation="CenterOwner"
+        Style="{StaticResource Window_Style}"
+        d:DataContext="{d:DesignInstance {x:Type vm:DownloadTasksWindowViewModelD}, IsDesignTimeCreatable=True}"
+        Title="ダウンロードタスク管理" Height="600" Width="1200">
+    <Grid>
+        <TabControl
+            Style="{StaticResource MaterialDesignNavigatilRailTabControl}"
+            materialDesign:ColorZoneAssist.Mode="PrimaryLight">
+            <TabItem Style="{StaticResource MaterialDesignNavigationRailTabItem}">
+                <TabItem.Header>
+                    <materialDesign:PackIcon
+                         Kind="DownloadLock"
+                         Width="24"
+                         Height="24"
+                         ToolTip="登録済みタスク（ダウンロード待ち状態のタスク）"
+                    />
+                </TabItem.Header>
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="1*"/>
+                        <RowDefinition Height="1*"/>
+                        <RowDefinition Height="8*"/>
+                    </Grid.RowDefinitions>
+                    <TextBlock
+                    Padding="5"
+                    Style="{DynamicResource MaterialDesignHeadline5TextBlock}">
+                        登録済みタスク
+                    </TextBlock>
+                    <DockPanel Grid.Row="1">
+                        <CheckBox Margin="10 0" HorizontalAlignment="Left" Content="キャンセル済みを表示" IsChecked="{Binding DisplayCanceled}"/>
+                        <CheckBox HorizontalAlignment="Left" Content="完了済みを表示" IsChecked="{Binding DisplayCompleted}"/>
+                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                            <Button Margin="5 0" ToolTip="更新" Command="{Binding RefreshTaskCommand}">
+                                <materialDesign:PackIcon Kind="Reload"/>
+                            </Button>
+                            <Button Margin="4 0" Content="ダウンロード開始" Command="{Binding StartDownloadCommand}"/>
+                            <Button Margin="4 0" Content="全て中断" Command="{Binding CancelDownloadCommand}"/>
+                        </StackPanel>
+                    </DockPanel>
+                    <ListView Grid.Row="2" ItemsSource="{Binding Tasks}" >
+                        <ListView.View>
+                            <GridView>
+                                <GridView.Columns>
+                                    <GridViewColumn Header="ID"         DisplayMemberBinding="{Binding NiconicoID}"/>
+                                    <GridViewColumn Header="タイトル" DisplayMemberBinding="{Binding Title}">
+                                        <GridViewColumn.CellTemplate>
+                                            <DataTemplate>
+                                                <ContentPresenter ToolTip="{Binding Title}"/>
+                                            </DataTemplate>
+                                        </GridViewColumn.CellTemplate>
+                                    </GridViewColumn>
+                                    <GridViewColumn Header="状態">
+                                        <GridViewColumn.CellTemplate>
+                                            <DataTemplate>
+                                                <StackPanel Orientation="Horizontal">
+                                                    <ProgressBar ToolTip="DL中です" Style="{StaticResource MaterialDesignCircularProgressBar}" Value="35" IsIndeterminate="{Binding IsProcessing}" Visibility="{Binding IsProcessing,Converter={StaticResource BooleanToVisibilityConverter}}"/>
+                                                    <materialDesign:PackIcon ToolTip="完了しました" Kind="Check" Foreground="Purple" Visibility="{Binding IsEnd,Converter={StaticResource BooleanToVisibilityConverter}}">
+                                                        <materialDesign:PackIcon.RenderTransform>
+                                                            <ScaleTransform ScaleX="1.4" ScaleY="1.4" CenterY="-8"/>
+                                                        </materialDesign:PackIcon.RenderTransform>
+                                                    </materialDesign:PackIcon>
+                                                    <materialDesign:PackIcon ToolTip="キャンセルされました" Kind="Close" Foreground="Red" Visibility="{Binding IsCancel,Converter={StaticResource BooleanToVisibilityConverter}}">
+                                                        <materialDesign:PackIcon.RenderTransform>
+                                                            <ScaleTransform ScaleX="1.4" ScaleY="1.4" CenterY="-8"/>
+                                                        </materialDesign:PackIcon.RenderTransform>
+                                                    </materialDesign:PackIcon>
+                                                </StackPanel>
+                                            </DataTemplate>
+                                        </GridViewColumn.CellTemplate>
+                                    </GridViewColumn>
+                                    <GridViewColumn Header="メッセージ" DisplayMemberBinding="{Binding Message}"/>
+                                    <GridViewColumn Header="中止">
+                                        <GridViewColumn.CellTemplate>
+                                            <DataTemplate>
+                                                <Button Content="中止" Command="{Binding CancelCommand}" Background="HotPink" BorderThickness="0"/>
+                                            </DataTemplate>
+                                        </GridViewColumn.CellTemplate>
+                                    </GridViewColumn>
+                                </GridView.Columns>
+                            </GridView>
+                        </ListView.View>
+                        <ListView.ItemContainerStyle>
+                            <Style TargetType="ListViewItem" BasedOn="{StaticResource MaterialDesignGridViewItem}">
+                                <Setter Property="VerticalAlignment" Value="Center"/>
+                                <Setter Property="VerticalContentAlignment" Value="Center"/>
+                            </Style>
+                        </ListView.ItemContainerStyle>
+                    </ListView>
+                </Grid>
+            </TabItem>
+            <TabItem Style="{StaticResource MaterialDesignNavigationRailTabItem}">
+                <TabItem.Header>
+                    <materialDesign:PackIcon
+                         Kind="Download"
+                         Width="24"
+                         Height="24"
+                         ToolTip="ステージング済みタスク（仮登録状態のタスク）"/>
+                </TabItem.Header>
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="1*"/>
+                        <RowDefinition Height="1*"/>
+                        <RowDefinition Height="8*"/>
+                    </Grid.RowDefinitions>
+                    <TextBlock
+                    Padding="5"
+                    Style="{DynamicResource MaterialDesignHeadline5TextBlock}" Grid.RowSpan="2">
+                        ステージング（仮登録）済みタスク
+                    </TextBlock>
+                    <DockPanel Grid.Row="1">
+                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                            <Button Margin="5 0" ToolTip="更新" Command="{Binding RefreshStagedTaskCommand}">
+                                <materialDesign:PackIcon Kind="Reload"/>
+                            </Button>
+                            <Button Margin="4 0" Content="全て登録" Command="{Binding MoveTasksToQueue}" />
+                            <Button Margin="4 0" Content="全て削除" Command="{Binding ClearStagedCommand}" />
+                            <Button Margin="4 0" Content="選択したタスクを削除" Command="{Binding RemoveStagedTaskCommand}"/>
+                        </StackPanel>
+                    </DockPanel>
+                    <ListView Grid.Row="2" ItemsSource="{Binding StagedTasks}" >
+                        <ListView.View>
+                            <GridView>
+                                <GridView.Columns>
+                                    <GridViewColumn Header="選択">
+                                        <GridViewColumn.CellTemplate>
+                                            <DataTemplate>
+                                                <CheckBox IsChecked="{Binding IsChecked,UpdateSourceTrigger=PropertyChanged}"/>
+                                            </DataTemplate>
+                                        </GridViewColumn.CellTemplate>
+                                    </GridViewColumn>
+                                    <GridViewColumn Header="ID"         DisplayMemberBinding="{Binding NiconicoID}"/>
+                                    <GridViewColumn Header="タイトル" DisplayMemberBinding="{Binding Title}"/>
+                                    <GridViewColumn Header="解像度">
+                                        <GridViewColumn.CellTemplate>
+                                            <DataTemplate>
+                                                <ComboBox ItemsSource="{Binding SelectableResolutions}" SelectedItem="{Binding SelectedResolution}" DisplayMemberPath="DisplayValue"/>
+                                            </DataTemplate>
+                                        </GridViewColumn.CellTemplate>
+                                    </GridViewColumn>
+                                    <GridViewColumn Header="メッセージ" DisplayMemberBinding="{Binding Message}"/>
+                                </GridView.Columns>
+                            </GridView>
+                        </ListView.View>
+                        <ListView.ItemContainerStyle>
+                            <Style TargetType="ListViewItem" BasedOn="{StaticResource MaterialDesignGridViewItem}">
+                                <Setter Property="VerticalAlignment" Value="Center"/>
+                                <Setter Property="VerticalContentAlignment" Value="Center"/>
+                            </Style>
+                        </ListView.ItemContainerStyle>
+                    </ListView>
+                </Grid>
+            </TabItem>
+        </TabControl>
+        <materialDesign:Snackbar MessageQueue="{Binding Queue}"/>
+    </Grid>
+</Window>

--- a/Niconicome/Views/DownloadTasksWindows.xaml.cs
+++ b/Niconicome/Views/DownloadTasksWindows.xaml.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Shapes;
+using Niconicome.ViewModels.Mainpage.Subwindows;
+
+namespace Niconicome.Views
+{
+    /// <summary>
+    /// DownloadTasksWindows.xaml の相互作用ロジック
+    /// </summary>
+    public partial class DownloadTasksWindows : Window
+    {
+        public DownloadTasksWindows()
+        {
+            InitializeComponent();
+            this.DataContext = new DownloadTasksWindowViewModel();
+        }
+    }
+}

--- a/Niconicome/Views/MainWindow.xaml
+++ b/Niconicome/Views/MainWindow.xaml
@@ -8,7 +8,7 @@
         xmlns:tree="clr-namespce:Niconicome.Models.Playlist"
         xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
         mc:Ignorable="d"
-        TextElement.Foreground="{DynamicResource MaterialDesignBody}"
+        TextElement.Foreground="{DynamicResource MaterialDesignLightForeground}"
         TextElement.FontWeight="Regular"
         TextElement.FontSize="13"
         TextOptions.TextFormattingMode="Ideal"
@@ -25,365 +25,392 @@
         <vm:MainWindowViewModel/>
     </Window.DataContext>
     <materialDesign:DialogHost Identifier="default">
-
-        <Grid>
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="3*"/>
-                <ColumnDefinition Width="17*"/>
-            </Grid.ColumnDefinitions>
-            <Grid Grid.Column= "0" Background="#e7e7e7">
-                <Grid.DataContext>
-                    <vm:PlaylistTreeViewModel/>
-                </Grid.DataContext>
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="2*"/>
-                    <RowDefinition Height="18*"/>
-                </Grid.RowDefinitions>
-                <StackPanel Orientation="Horizontal" Margin="5">
-                    <Button Width="auto" HorizontalAlignment="Left" Command="{Binding PlaylistRefreshcommand}" ToolTip="プレイリストを更新する">
-                        <materialDesign:PackIcon Kind="Refresh" />
-                    </Button>
-                </StackPanel>
-                <TreeView ItemsSource="{Binding PlaylistTree}" Grid.Row="1" >
-                    <i:Interaction.Behaviors>
-                        <vm:PlaylistTreeBehavior/>
-                    </i:Interaction.Behaviors>
-                    <TreeView.ItemTemplate>
-                        <HierarchicalDataTemplate DataType="tree:ITreePlaylistInfo" ItemsSource="{Binding Children}">
-                            <StackPanel>
-                                <Grid Background="{Binding BackgroundColor}">
-                                    <Grid.ToolTip>
-                                        <TextBlock Text="{Binding Videos.Count,StringFormat={}{0}件の動画}"/>
-                                    </Grid.ToolTip>
-                                    <Separator BorderThickness="1" Visibility="{Binding BeforeSeparatorVisibility,Mode=OneWay,UpdateSourceTrigger=PropertyChanged}" BorderBrush="#000"/>
-                                    <TextBlock Text="{Binding Name}"/>
-                                    <Separator BorderThickness="1" Visibility="{Binding AfterSeparatorVisibility,Mode=OneWay,UpdateSourceTrigger=PropertyChanged}" BorderBrush="#000"/>
-                                </Grid>
+        <DockPanel>
+            <materialDesign:DrawerHost IsLeftDrawerOpen="{Binding ElementName=MenuToggleButton, Path=IsChecked}" >
+                <materialDesign:DrawerHost.LeftDrawerContent>
+                    <Grid Width="250">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="3*"/>
+                            <RowDefinition Height="17*"/>
+                        </Grid.RowDefinitions>
+                        <materialDesign:ColorZone materialDesign:ShadowAssist.ShadowDepth="Depth1" Padding="8" >
+                            <StackPanel Orientation="Vertical">
+                                <DockPanel>
+                                    <Image Source="{Binding UserImage}" Height="40"  Margin="5 0">
+                                        <i:Interaction.Behaviors>
+                                            <vm:UserImageBehavior/>
+                                        </i:Interaction.Behaviors>
+                                    </Image>
+                                    <TextBlock Text="{Binding Username}" Style="{DynamicResource MaterialDesignBody1TextBlock}" VerticalAlignment="Center" />
+                                </DockPanel>
+                                <Button Content="{Binding LoginBtnVal}"  Command="{Binding LoginCommand}" Margin="8 10" ToolTip="{Binding LoginBtnTooltip}"/>
                             </StackPanel>
-                        </HierarchicalDataTemplate>
-                    </TreeView.ItemTemplate>
-                    <TreeView.ItemContainerStyle>
-                        <Style TargetType="{x:Type TreeViewItem}" BasedOn="{StaticResource {x:Type TreeViewItem}}">
-                            <Setter Property="Tag" Value="{Binding Path=DataContext, RelativeSource={RelativeSource AncestorType=TreeView, Mode=FindAncestor}}"/>
-                            <Setter Property="ContextMenu">
-                                <Setter.Value>
-                                    <ContextMenu StaysOpen="False" DataContext="{Binding Path=PlacementTarget.Tag, RelativeSource={RelativeSource Self}}" >
-                                        <MenuItem Header="プレイリストを追加する"
-                                                  Command="{Binding AddPlaylist}"
-                                                  CommandParameter="{Binding  Path=PlacementTarget.DataContext.Id, RelativeSource={RelativeSource AncestorType=ContextMenu}}">
-                                            <MenuItem.Icon>
-                                                <materialDesign:PackIcon Kind="Plus"/>
-                                            </MenuItem.Icon>
-                                        </MenuItem>
-                                        <MenuItem Header="このプレイリストを削除する"
-                                                  Command="{Binding RemovePlaylist}"
-                                                  CommandParameter="{Binding  Path=PlacementTarget.DataContext.Id, RelativeSource={RelativeSource AncestorType=ContextMenu}}">
-                                            <MenuItem.Icon>
-                                                <materialDesign:PackIcon Kind="Delete"/>
-                                            </MenuItem.Icon>
-                                        </MenuItem>
-                                        <MenuItem Header="このプレイリストを編集する"
-                                                  Command="{Binding EditPlaylistCommand}"
-                                                  CommandParameter="{Binding  Path=PlacementTarget.DataContext, RelativeSource={RelativeSource AncestorType=ContextMenu}}">
-                                            <MenuItem.Icon>
-                                                <materialDesign:PackIcon Kind="Edit"/>
-                                            </MenuItem.Icon>
-                                        </MenuItem>
-                                    </ContextMenu>
-                                </Setter.Value>
-                            </Setter>
-                            <Setter Property="IsExpanded" Value="{Binding IsExpanded,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}"/>
-                        </Style>
-                    </TreeView.ItemContainerStyle>
-                </TreeView>
-            </Grid>
-            <Grid Grid.Column="1">
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="1*"/>
-                    <RowDefinition Height="19*"/>
-                </Grid.RowDefinitions>
-                <DockPanel HorizontalAlignment="Right">
-                    <Grid HorizontalAlignment="Right" Grid.Column="1">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="auto"/>
-                            <ColumnDefinition Width="auto"/>
-                            <ColumnDefinition Width="auto"/>
-                        </Grid.ColumnDefinitions>
-                        <Button Content="{Binding LoginBtnVal}" Command="{Binding LoginCommand}" Margin="10 0" Grid.Column="2" ToolTip="{Binding LoginBtnTooltip}"/>
-                        <TextBlock Text="{Binding Username}" Grid.Column="1" Style="{DynamicResource MaterialDesignBody1TextBlock}" VerticalAlignment="Center" />
-                        <Image Source="{Binding UserImage}"  Grid.Column="0" Margin="5">
-                            <i:Interaction.Behaviors>
-                                <vm:UserImageBehavior/>
-                            </i:Interaction.Behaviors>
-                        </Image>
-                    </Grid>
-                    <Button Margin="10,0" Grid.Column="0" Width="60" HorizontalAlignment="Left" VerticalAlignment="Center" ToolTip="アプリケーション設定" Command="{Binding OpenSettingCommand}">
-                        <materialDesign:PackIcon Kind="cog">
-                            <materialDesign:PackIcon.RenderTransform>
-                                <ScaleTransform CenterY="8" CenterX="7" ScaleX="1.7" ScaleY="1.7"/>
-                            </materialDesign:PackIcon.RenderTransform>
-                        </materialDesign:PackIcon>
-                    </Button>
-                </DockPanel>
-                <Grid Grid.Row="1">
-                    <Grid.DataContext>
-                        <vm:VideoListViewModel/>
-                    </Grid.DataContext>
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="3*"/>
-                        <RowDefinition Height="3*"/>
-                        <RowDefinition Height="23*"/>
-                        <RowDefinition Height="14*"/>
-                    </Grid.RowDefinitions>
-                    <TextBlock FontSize="30" Text="{Binding PlaylistTitle,UpdateSourceTrigger=PropertyChanged}" Margin="10 0"/>
-                    <Grid Grid.Row="1">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="1*"/>
-                            <ColumnDefinition Width="1*"/>
-                        </Grid.ColumnDefinitions>
-                        <Grid>
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="17*"/>
-                                <ColumnDefinition Width="3*"/>
-                            </Grid.ColumnDefinitions>
-                            <TextBox Text="{Binding InputString,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}" Style="{DynamicResource MaterialDesignTextBox}" FontSize="20" Margin="5,0" VerticalContentAlignment="Bottom" materialDesign:HintAssist.Hint="ID・検索キーワード入力窓" Padding="5 0"/>
-                            <Button Content="登録" Grid.Column="1" Margin="5,0" ToolTip="入力した動画を登録する（インテリインプット）" Command="{Binding AddVideoCommand}"/>
-                        </Grid>
-                        <StackPanel Grid.Column="1" Orientation="Horizontal">
-                            <Button Margin="5,0" Grid.Column="0" Width="60" HorizontalAlignment="Center" VerticalAlignment="Center" ToolTip="入力したキーワードでフィルター" Command="{Binding FilterCommand}">
-                                <materialDesign:PackIcon Kind="{Binding FilterIcon}">
-                                    <materialDesign:PackIcon.RenderTransform>
-                                        <ScaleTransform CenterY="7" CenterX="8" ScaleX="1.8" ScaleY="1.8"/>
-                                    </materialDesign:PackIcon.RenderTransform>
-                                </materialDesign:PackIcon>
-                                <Button.Style>
-                                    <Style TargetType="Button" BasedOn="{StaticResource MaterialDesignFlatMidBgButton}">
-                                        <Setter Property="Tag" Value="{Binding DataContext, RelativeSource={RelativeSource Mode=Self}}"/>
-                                        <Setter Property="ContextMenu">
-                                            <Setter.Value>
-                                                <ContextMenu DataContext="{Binding PlacementTarget.Tag,RelativeSource={RelativeSource Mode=Self}}">
-                                                    <MenuItem IsCheckable="True" Header="タグのみでフィルター" IsChecked="{Binding IsFilteringOnlyByTag}"/>
-                                                    <MenuItem IsCheckable="True" Header="データベースの全ての動画からフィルター" IsChecked="{Binding IsFilteringFromAllVideos}"/>
-                                                </ContextMenu>
-                                            </Setter.Value>
-                                        </Setter>
-                                    </Style>
-                                </Button.Style>
-                            </Button>
-
-                            <Button Margin="5,0" Grid.Column="0" Width="60" HorizontalAlignment="Center" VerticalAlignment="Center" ToolTip="クリップボードから一括登録" Command="{Binding AddVideoFromClipboardCommand}">
-                                <materialDesign:PackIcon Kind="Clipboard">
-                                    <materialDesign:PackIcon.RenderTransform>
-                                        <ScaleTransform CenterY="7" CenterX="8" ScaleX="1.8" ScaleY="1.8"/>
-                                    </materialDesign:PackIcon.RenderTransform>
-                                </materialDesign:PackIcon>
-                            </Button>
-
-                            <Button Margin="5,0" Grid.Column="1" Width="60" HorizontalAlignment="Center" VerticalAlignment="Center" ToolTip="検索して登録" Command="{Binding SearchCommand}">
-                                <materialDesign:PackIcon Kind="Magnify">
-                                    <materialDesign:PackIcon.RenderTransform>
-                                        <ScaleTransform CenterY="7" CenterX="8" ScaleX="1.8" ScaleY="1.8"/>
-                                    </materialDesign:PackIcon.RenderTransform>
-                                </materialDesign:PackIcon>
-                            </Button>
-                            <Button Margin="5,0" Grid.Column="2" Width="60" HorizontalAlignment="Center" VerticalAlignment="Center" ToolTip="オンライン上のコンテンツとの同期設定" Command="{Binding OpenNetworkSettingsCommand}">
-                                <materialDesign:PackIcon Kind="Attachment">
-                                    <materialDesign:PackIcon.RenderTransform>
-                                        <ScaleTransform CenterY="8" CenterX="7" ScaleX="2" ScaleY="2"/>
-                                    </materialDesign:PackIcon.RenderTransform>
-                                </materialDesign:PackIcon>
-                            </Button>
-
-                            <Button Margin="5,0" Grid.Column="3" Width="60" HorizontalAlignment="Center" VerticalAlignment="Center" ToolTip="名前を編集" Command="{Binding EditPlaylistCommand}">
-                                <materialDesign:PackIcon Kind="Pencil">
-                                    <materialDesign:PackIcon.RenderTransform>
-                                        <ScaleTransform CenterY="7" CenterX="8" ScaleX="1.7" ScaleY="1.7"/>
-                                    </materialDesign:PackIcon.RenderTransform>
-                                </materialDesign:PackIcon>
-                            </Button>
-
-                            <Button Margin="5,0" Grid.Column="4" Width="60" HorizontalAlignment="Center" VerticalAlignment="Center" ToolTip="動画情報を更新する" Command="{Binding UpdateVideoCommand}">
-                                <materialDesign:PackIcon Kind="{Binding RefreshCommandIcon}">
-                                    <materialDesign:PackIcon.RenderTransform>
-                                        <ScaleTransform CenterY="7" CenterX="8" ScaleX="1.7" ScaleY="1.7"/>
-                                    </materialDesign:PackIcon.RenderTransform>
-                                </materialDesign:PackIcon>
-                            </Button>
-
-                            <Button Margin="5,0" Grid.Column="5" Width="60" HorizontalAlignment="Center" VerticalAlignment="Center" ToolTip="ネットワークと同期する" Command="{Binding SyncWithNetowrkCommand}">
-                                <materialDesign:PackIcon Kind="DatabaseSync">
-                                    <materialDesign:PackIcon.RenderTransform>
-                                        <ScaleTransform CenterY="7" CenterX="8" ScaleX="1.7" ScaleY="1.7"/>
-                                    </materialDesign:PackIcon.RenderTransform>
-                                </materialDesign:PackIcon>
-                            </Button>
+                        </materialDesign:ColorZone>
+                        <StackPanel Grid.Row="1" HorizontalAlignment="Stretch">
+                            <MenuItem Header="設定" HorizontalContentAlignment="Left"  Height="40" Command="{Binding OpenSettingCommand}" >
+                                <MenuItem.Icon>
+                                    <materialDesign:PackIcon Kind="CogOutline"/>
+                                </MenuItem.Icon>
+                            </MenuItem>
+                            <MenuItem Header="ダウンロード" HorizontalContentAlignment="Left"  Height="40"   Command="{Binding OpenDownloadTaskWindowsCommand}">
+                                <MenuItem.Icon>
+                                    <materialDesign:PackIcon Kind="Download"/>
+                                </MenuItem.Icon>
+                            </MenuItem>
                         </StackPanel>
                     </Grid>
-                    <Grid Grid.Row="2">
-                        <ListView Name="videolist" ItemsSource="{Binding Videos,UpdateSourceTrigger=PropertyChanged,Mode=OneWay}" BorderThickness="1" BorderBrush="#e7e7e7" >
+                </materialDesign:DrawerHost.LeftDrawerContent>
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="3*"/>
+                        <ColumnDefinition Width="17*"/>
+                    </Grid.ColumnDefinitions>
+                    <Grid Grid.Column= "0" Background="#e7e7e7">
+                        <Grid.DataContext>
+                            <vm:PlaylistTreeViewModel/>
+                        </Grid.DataContext>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="1*"/>
+                            <RowDefinition Height="16*"/>
+                        </Grid.RowDefinitions>
+                        <DockPanel Grid.Row="0">
+                            <Button Width="auto" Margin="6" HorizontalAlignment="Left" Command="{Binding PlaylistRefreshcommand}" ToolTip="プレイリストを更新する">
+                                <materialDesign:PackIcon Kind="Refresh" />
+                            </Button>
+                        </DockPanel>
+                        <TreeView ItemsSource="{Binding PlaylistTree}" Grid.Row="1" >
                             <i:Interaction.Behaviors>
-                                <vm:VideoListBehavior/>
+                                <vm:PlaylistTreeBehavior/>
                             </i:Interaction.Behaviors>
-                            <ListView.View>
-                                <GridView>
-                                    <GridViewColumn Header="選択">
-                                        <GridViewColumn.CellTemplate>
-                                            <DataTemplate>
-                                                <CheckBox IsChecked="{Binding IsSelected,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}"/>
-                                            </DataTemplate>
-                                        </GridViewColumn.CellTemplate>
-                                    </GridViewColumn>
-                                    <GridViewColumn >
-                                        <GridViewColumn.CellTemplate>
-                                            <DataTemplate>
-                                                <Image Source="{Binding BindableThumbPath,UpdateSourceTrigger=PropertyChanged}" Height="80"/>
-                                            </DataTemplate>
-                                        </GridViewColumn.CellTemplate>
-                                    </GridViewColumn>
-                                    <GridViewColumn Width="150" Header="ID" DisplayMemberBinding="{Binding NiconicoId}"/>
-                                    <GridViewColumn Header="タイトル" DisplayMemberBinding="{Binding Title}"/>
-                                    <GridViewColumn Header="投稿日" DisplayMemberBinding="{Binding UploadedOn, StringFormat=yyyy年MM月dd日 HH:mm}"/>
-                                    <GridViewColumn Header="再生回数" DisplayMemberBinding="{Binding ViewCount}"/>
-                                    <GridViewColumn Header="状態" DisplayMemberBinding="{Binding Message}"/>
-                                </GridView>
-                            </ListView.View>
-                            <ListView.ItemContainerStyle>
-                                <Style TargetType="ListViewItem" BasedOn="{StaticResource MaterialDesignGridViewItem}">
-                                    <Setter Property="VerticalContentAlignment" Value="Center"/>
-                                    <Setter Property="HorizontalContentAlignment" Value="Center"/>
-                                    <Setter Property="Padding" Value="10"/>
-                                    <Setter Property="Tag" Value="{Binding RelativeSource={RelativeSource AncestorType={x:Type ListView}, Mode=FindAncestor}, Path=DataContext}"/>
+                            <TreeView.ItemTemplate>
+                                <HierarchicalDataTemplate DataType="tree:ITreePlaylistInfo" ItemsSource="{Binding Children}">
+                                    <StackPanel>
+                                        <Grid Background="{Binding BackgroundColor}">
+                                            <Grid.ToolTip>
+                                                <TextBlock Text="{Binding Videos.Count,StringFormat={}{0}件の動画}"/>
+                                            </Grid.ToolTip>
+                                            <Separator BorderThickness="1" Visibility="{Binding BeforeSeparatorVisibility,Mode=OneWay,UpdateSourceTrigger=PropertyChanged}" BorderBrush="#000"/>
+                                            <TextBlock Text="{Binding Name}"/>
+                                            <Separator BorderThickness="1" Visibility="{Binding AfterSeparatorVisibility,Mode=OneWay,UpdateSourceTrigger=PropertyChanged}" BorderBrush="#000"/>
+                                        </Grid>
+                                    </StackPanel>
+                                </HierarchicalDataTemplate>
+                            </TreeView.ItemTemplate>
+                            <TreeView.ItemContainerStyle>
+                                <Style TargetType="{x:Type TreeViewItem}" BasedOn="{StaticResource {x:Type TreeViewItem}}">
+                                    <Setter Property="Tag" Value="{Binding Path=DataContext, RelativeSource={RelativeSource AncestorType=TreeView, Mode=FindAncestor}}"/>
                                     <Setter Property="ContextMenu">
                                         <Setter.Value>
-                                            <ContextMenu DataContext="{Binding Path=PlacementTarget.Tag,RelativeSource={RelativeSource Self}}">
-                                                <MenuItem Header="動画を削除する" Command="{Binding RemoveVideoCommand}"
-                                                          CommandParameter="{Binding PlacementTarget.DataContext,RelativeSource={RelativeSource AncestorType=ContextMenu}}">
+                                            <ContextMenu StaysOpen="False" DataContext="{Binding Path=PlacementTarget.Tag, RelativeSource={RelativeSource Self}}" >
+                                                <MenuItem Header="プレイリストを追加する"
+                                                  Command="{Binding AddPlaylist}"
+                                                  CommandParameter="{Binding  Path=PlacementTarget.DataContext.Id, RelativeSource={RelativeSource AncestorType=ContextMenu}}">
+                                                    <MenuItem.Icon>
+                                                        <materialDesign:PackIcon Kind="Plus"/>
+                                                    </MenuItem.Icon>
+                                                </MenuItem>
+                                                <MenuItem Header="このプレイリストを削除する"
+                                                  Command="{Binding RemovePlaylist}"
+                                                  CommandParameter="{Binding  Path=PlacementTarget.DataContext.Id, RelativeSource={RelativeSource AncestorType=ContextMenu}}">
                                                     <MenuItem.Icon>
                                                         <materialDesign:PackIcon Kind="Delete"/>
                                                     </MenuItem.Icon>
                                                 </MenuItem>
-                                                <MenuItem Header="ニコニコで視聴する" Command="{Binding WatchOnNiconicoCommand}"
-                                                          CommandParameter="{Binding PlacementTarget.DataContext,RelativeSource={RelativeSource AncestorType=ContextMenu}}">
+                                                <MenuItem Header="このプレイリストを編集する"
+                                                  Command="{Binding EditPlaylistCommand}"
+                                                  CommandParameter="{Binding  Path=PlacementTarget.DataContext, RelativeSource={RelativeSource AncestorType=ContextMenu}}">
                                                     <MenuItem.Icon>
-                                                        <materialDesign:PackIcon Kind="Web"/>
+                                                        <materialDesign:PackIcon Kind="Edit"/>
                                                     </MenuItem.Icon>
                                                 </MenuItem>
-                                                <MenuItem Header="保存フォルダーを開く" Command="{Binding OpenPlaylistFolder}">
-                                                    <MenuItem.Icon>
-                                                        <materialDesign:PackIcon Kind="Folder"/>
-                                                    </MenuItem.Icon>
-                                                </MenuItem>
+                                            </ContextMenu>
+                                        </Setter.Value>
+                                    </Setter>
+                                    <Setter Property="IsExpanded" Value="{Binding IsExpanded,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}"/>
+                                </Style>
+                            </TreeView.ItemContainerStyle>
+                        </TreeView>
+                    </Grid>
+                    <Grid Grid.Column="1">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="1*"/>
+                            <RowDefinition Height="19*"/>
+                        </Grid.RowDefinitions>
+                        <DockPanel >
+                            <ToggleButton Margin="10 0" HorizontalAlignment="Left" Style="{StaticResource MaterialDesignHamburgerToggleButton}" x:Name="MenuToggleButton"/>
+                            <DockPanel HorizontalAlignment="Right">
+                                <Button Margin="10,0" Grid.Column="0" Width="60" VerticalAlignment="Center" ToolTip="アプリケーション設定" Command="{Binding OpenSettingCommand}">
+                                    <materialDesign:PackIcon Kind="cog">
+                                        <materialDesign:PackIcon.RenderTransform>
+                                            <ScaleTransform CenterY="8" CenterX="7" ScaleX="1.7" ScaleY="1.7"/>
+                                        </materialDesign:PackIcon.RenderTransform>
+                                    </materialDesign:PackIcon>
+                                </Button>
+                            </DockPanel>
+                        </DockPanel>
+                        <Grid Grid.Row="1">
+                            <Grid.DataContext>
+                                <vm:VideoListViewModel/>
+                            </Grid.DataContext>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="3*"/>
+                                <RowDefinition Height="3*"/>
+                                <RowDefinition Height="23*"/>
+                                <RowDefinition Height="14*"/>
+                            </Grid.RowDefinitions>
+                            <TextBlock FontSize="30" Text="{Binding PlaylistTitle,UpdateSourceTrigger=PropertyChanged}" Margin="10 0"/>
+                            <Grid Grid.Row="1">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="1*"/>
+                                    <ColumnDefinition Width="1*"/>
+                                </Grid.ColumnDefinitions>
+                                <Grid>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="17*"/>
+                                        <ColumnDefinition Width="3*"/>
+                                    </Grid.ColumnDefinitions>
+                                    <TextBox Text="{Binding InputString,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}" Style="{DynamicResource MaterialDesignTextBox}" FontSize="20" Margin="5,0" VerticalContentAlignment="Bottom" materialDesign:HintAssist.Hint="ID・検索キーワード入力窓" Padding="5 0"/>
+                                    <Button Content="登録" Grid.Column="1" Margin="5,0" ToolTip="入力した動画を登録する（インテリインプット）" Command="{Binding AddVideoCommand}"/>
+                                </Grid>
+                                <StackPanel Grid.Column="1" Orientation="Horizontal">
+                                    <Button Margin="5,0" Grid.Column="0" Width="60" HorizontalAlignment="Center" VerticalAlignment="Center" ToolTip="入力したキーワードでフィルター" Command="{Binding FilterCommand}">
+                                        <materialDesign:PackIcon Kind="{Binding FilterIcon}">
+                                            <materialDesign:PackIcon.RenderTransform>
+                                                <ScaleTransform CenterY="7" CenterX="8" ScaleX="1.8" ScaleY="1.8"/>
+                                            </materialDesign:PackIcon.RenderTransform>
+                                        </materialDesign:PackIcon>
+                                        <Button.Style>
+                                            <Style TargetType="Button" BasedOn="{StaticResource MaterialDesignFlatMidBgButton}">
+                                                <Setter Property="Tag" Value="{Binding DataContext, RelativeSource={RelativeSource Mode=Self}}"/>
+                                                <Setter Property="ContextMenu">
+                                                    <Setter.Value>
+                                                        <ContextMenu DataContext="{Binding PlacementTarget.Tag,RelativeSource={RelativeSource Mode=Self}}">
+                                                            <MenuItem IsCheckable="True" Header="タグのみでフィルター" IsChecked="{Binding IsFilteringOnlyByTag}"/>
+                                                            <MenuItem IsCheckable="True" Header="データベースの全ての動画からフィルター" IsChecked="{Binding IsFilteringFromAllVideos}"/>
+                                                        </ContextMenu>
+                                                    </Setter.Value>
+                                                </Setter>
+                                            </Style>
+                                        </Button.Style>
+                                    </Button>
 
-                                                <MenuItem Header="選択">
-                                                    <MenuItem Header="全て選択する" Command="{Binding SelectAllVideosCommand}"/>
-                                                    <MenuItem Header="全て選択解除する" Command="{Binding DisSelectAllVideosCommand}"/>
-                                                    <MenuItem Header="未ダウンロードの動画を選択する" Command="{Binding SelectAllNotDownloadedVideosCommand}"/>
-                                                    <MenuItem Header="未ダウンロードの動画を選択解除する" Command="{Binding DisSelectAllNotDownloadedVideosCommand}"/>
-                                                    <MenuItem Header="ダウンロード済の動画を選択する" Command="{Binding SelectAllDownloadedVideosCommand}"/>
-                                                    <MenuItem Header="ダウンロード済の動画を選択解除する" Command="{Binding DisSelectAllDownloadedVideosCommand}"/>
-                                                </MenuItem>
-                                                <MenuItem Header="開く">
-                                                    <MenuItem Header="アプリで開く(A)" Command="{Binding OpenInPlayerAcommand}"
-                                                          CommandParameter="{Binding PlacementTarget.DataContext,RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
-                                                    <MenuItem Header="アプリで開く(B)" Command="{Binding OpenInPlayerBcommand}"
-                                                          CommandParameter="{Binding PlacementTarget.DataContext,RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
-                                                </MenuItem>
-                                                <MenuItem Header="送る">
-                                                    <MenuItem Header="アプリにURLを送る" Command="{Binding SendUrlToappCommand}"
-                                                          CommandParameter="{Binding PlacementTarget.DataContext,RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
-                                                    <MenuItem Header="アプリにIDを送る" Command="{Binding SendIdToappCommand}"
-                                                          CommandParameter="{Binding PlacementTarget.DataContext,RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
-                                            </MenuItem>
-                                            <MenuItem Header="プレイリストを作成">
-                                                <MenuItem Header=".aimppl4形式のファイルを作成する" Command="{Binding CreatePlaylistCommand}" CommandParameter="aimp"/>
-                                            </MenuItem>
-                                        </ContextMenu>
-                                    </Setter.Value>
-                                </Setter>
-                            </Style>
-                        </ListView.ItemContainerStyle>
-                        <ListView.Resources>
-                            <Style TargetType="{x:Type GridViewColumnHeader}" BasedOn="{StaticResource {x:Type GridViewColumnHeader}}">
-                                <Style.Triggers>
-                                    <Trigger Property="Tag" Value="Selected">
-                                        <Setter Property="Background" Value="#757575"/>
-                                    </Trigger>
-                                </Style.Triggers>
-                            </Style>
-                        </ListView.Resources>
-                    </ListView>
-                    <materialDesign:Snackbar HorizontalAlignment="Stretch" HorizontalContentAlignment="Center" Margin="300 0" Grid.Row="1" MessageQueue="{Binding SnackbarMessageQueue}"/>
-                </Grid>
-                <TabControl Grid.Row="3" Margin="8">
-                    <TabItem Header="設定">
-                        <StackPanel Orientation="Vertical">
-                            <StackPanel.DataContext>
-                                <vm:DownloadSettingsViewModel/>
-                            </StackPanel.DataContext>
-                            <Grid Margin="0 5">
-                                <Grid.RowDefinitions>
-                                    <RowDefinition Height="auto"/>
-                                    <RowDefinition Height="auto"/>
-                                </Grid.RowDefinitions>
-                                <Label Content="ダウンロードする項目"/>
-                                <StackPanel Orientation="Horizontal" Grid.Row="1">
-                                    <CheckBox Margin="5 0" Content="動画" IsChecked="{Binding IsDownloadingVideoEnable,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}"/>
-                                    <CheckBox Margin="5 0" Content="コメント" IsChecked="{Binding IsDownloadingCommentEnable,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}"/>
-                                    <CheckBox Margin="5 0" Content="過去ログ" IsChecked="{Binding IsDownloadingCommentLogEnable,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}"/>
-                                    <CheckBox Margin="5 0" Content="投稿者コメント" IsChecked="{Binding IsDownloadingOwnerComment,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}"/>
-                                    <CheckBox Margin="5 0" Content="かんたんコメント" IsChecked="{Binding IsDownloadingEasyComment,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}"/>
-                                    <CheckBox Margin="5 0" Content="サムネイル" IsChecked="{Binding IsDownloadingThumbEnable,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}"/>
+                                    <Button Margin="5,0" Grid.Column="0" Width="60" HorizontalAlignment="Center" VerticalAlignment="Center" ToolTip="クリップボードから一括登録" Command="{Binding AddVideoFromClipboardCommand}">
+                                        <materialDesign:PackIcon Kind="Clipboard">
+                                            <materialDesign:PackIcon.RenderTransform>
+                                                <ScaleTransform CenterY="7" CenterX="8" ScaleX="1.8" ScaleY="1.8"/>
+                                            </materialDesign:PackIcon.RenderTransform>
+                                        </materialDesign:PackIcon>
+                                    </Button>
+
+                                    <Button Margin="5,0" Grid.Column="1" Width="60" HorizontalAlignment="Center" VerticalAlignment="Center" ToolTip="検索して登録" Command="{Binding SearchCommand}">
+                                        <materialDesign:PackIcon Kind="Magnify">
+                                            <materialDesign:PackIcon.RenderTransform>
+                                                <ScaleTransform CenterY="7" CenterX="8" ScaleX="1.8" ScaleY="1.8"/>
+                                            </materialDesign:PackIcon.RenderTransform>
+                                        </materialDesign:PackIcon>
+                                    </Button>
+                                    <Button Margin="5,0" Grid.Column="2" Width="60" HorizontalAlignment="Center" VerticalAlignment="Center" ToolTip="オンライン上のコンテンツとの同期設定" Command="{Binding OpenNetworkSettingsCommand}">
+                                        <materialDesign:PackIcon Kind="Attachment">
+                                            <materialDesign:PackIcon.RenderTransform>
+                                                <ScaleTransform CenterY="8" CenterX="7" ScaleX="2" ScaleY="2"/>
+                                            </materialDesign:PackIcon.RenderTransform>
+                                        </materialDesign:PackIcon>
+                                    </Button>
+
+                                    <Button Margin="5,0" Grid.Column="3" Width="60" HorizontalAlignment="Center" VerticalAlignment="Center" ToolTip="名前を編集" Command="{Binding EditPlaylistCommand}">
+                                        <materialDesign:PackIcon Kind="Pencil">
+                                            <materialDesign:PackIcon.RenderTransform>
+                                                <ScaleTransform CenterY="7" CenterX="8" ScaleX="1.7" ScaleY="1.7"/>
+                                            </materialDesign:PackIcon.RenderTransform>
+                                        </materialDesign:PackIcon>
+                                    </Button>
+
+                                    <Button Margin="5,0" Grid.Column="4" Width="60" HorizontalAlignment="Center" VerticalAlignment="Center" ToolTip="動画情報を更新する" Command="{Binding UpdateVideoCommand}">
+                                        <materialDesign:PackIcon Kind="{Binding RefreshCommandIcon}">
+                                            <materialDesign:PackIcon.RenderTransform>
+                                                <ScaleTransform CenterY="7" CenterX="8" ScaleX="1.7" ScaleY="1.7"/>
+                                            </materialDesign:PackIcon.RenderTransform>
+                                        </materialDesign:PackIcon>
+                                    </Button>
+
+                                    <Button Margin="5,0" Grid.Column="5" Width="60" HorizontalAlignment="Center" VerticalAlignment="Center" ToolTip="ネットワークと同期する" Command="{Binding SyncWithNetowrkCommand}">
+                                        <materialDesign:PackIcon Kind="DatabaseSync">
+                                            <materialDesign:PackIcon.RenderTransform>
+                                                <ScaleTransform CenterY="7" CenterX="8" ScaleX="1.7" ScaleY="1.7"/>
+                                            </materialDesign:PackIcon.RenderTransform>
+                                        </materialDesign:PackIcon>
+                                    </Button>
                                 </StackPanel>
                             </Grid>
-                            <Separator/>
-                            <StackPanel Margin="0 5" Orientation="Horizontal">
-                                <Label Content="優先解像度:" Margin="0 0 5 0"/>
-                                <ComboBox ItemsSource="{Binding Resolutions}" DisplayMemberPath="DisplayValue" SelectedItem="{Binding SelectedResolution,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}"/>
-                            </StackPanel>
-                            <Separator/>
-                            <Grid Margin="0 5">
-                                <Grid.RowDefinitions>
-                                    <RowDefinition Height="auto"/>
-                                    <RowDefinition Height="auto"/>
-                                </Grid.RowDefinitions>
-                                <Label Content="オプション"/>
-                                <DockPanel  Grid.Row="1">
-                                    <CheckBox Margin="5 0" Content="同名時に上書き" IsChecked="{Binding IsOverwriteEnable,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}"/>
-                                    <CheckBox Margin="5 0" Content="ダウンロード済をスキップ" IsChecked="{Binding IsSkippingEnable,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}"/>
-                                    <CheckBox Margin="5 0" Content="ファイルを別フォルダーからコピー" IsChecked="{Binding IsCopyFromAnotherFolderEnable,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}"/>
-                                    <DockPanel HorizontalAlignment="Right">
-                                        <Button Content="中断" HorizontalAlignment="Right" Margin="10 0" Command="{Binding CancelCommand}"/>
-                                        <Button Content="ダウンロード" HorizontalAlignment="Right" Margin="10 0" Command="{Binding DownloadCommand}"/>
-                                    </DockPanel>
-                                </DockPanel>
+                            <Grid Grid.Row="2">
+                                <ListView Name="videolist" ItemsSource="{Binding Videos,UpdateSourceTrigger=PropertyChanged,Mode=OneWay}" BorderThickness="1" BorderBrush="#e7e7e7" >
+                                    <i:Interaction.Behaviors>
+                                        <vm:VideoListBehavior/>
+                                    </i:Interaction.Behaviors>
+                                    <ListView.View>
+                                        <GridView>
+                                            <GridViewColumn Header="選択">
+                                                <GridViewColumn.CellTemplate>
+                                                    <DataTemplate>
+                                                        <CheckBox IsChecked="{Binding IsSelected,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}"/>
+                                                    </DataTemplate>
+                                                </GridViewColumn.CellTemplate>
+                                            </GridViewColumn>
+                                            <GridViewColumn >
+                                                <GridViewColumn.CellTemplate>
+                                                    <DataTemplate>
+                                                        <Image Source="{Binding BindableThumbPath,UpdateSourceTrigger=PropertyChanged}" Height="80"/>
+                                                    </DataTemplate>
+                                                </GridViewColumn.CellTemplate>
+                                            </GridViewColumn>
+                                            <GridViewColumn Width="150" Header="ID" DisplayMemberBinding="{Binding NiconicoId}"/>
+                                            <GridViewColumn Header="タイトル" DisplayMemberBinding="{Binding Title}"/>
+                                            <GridViewColumn Header="投稿日" DisplayMemberBinding="{Binding UploadedOn, StringFormat=yyyy年MM月dd日 HH:mm}"/>
+                                            <GridViewColumn Header="再生回数" DisplayMemberBinding="{Binding ViewCount}"/>
+                                            <GridViewColumn Header="状態" DisplayMemberBinding="{Binding Message}"/>
+                                        </GridView>
+                                    </ListView.View>
+                                    <ListView.ItemContainerStyle>
+                                        <Style TargetType="ListViewItem" BasedOn="{StaticResource MaterialDesignGridViewItem}">
+                                            <Setter Property="VerticalContentAlignment" Value="Center"/>
+                                            <Setter Property="HorizontalContentAlignment" Value="Center"/>
+                                            <Setter Property="Padding" Value="10"/>
+                                            <Setter Property="Tag" Value="{Binding RelativeSource={RelativeSource AncestorType={x:Type ListView}, Mode=FindAncestor}, Path=DataContext}"/>
+                                            <Setter Property="ContextMenu">
+                                                <Setter.Value>
+                                                    <ContextMenu DataContext="{Binding Path=PlacementTarget.Tag,RelativeSource={RelativeSource Self}}">
+                                                        <MenuItem Header="動画を削除する" Command="{Binding RemoveVideoCommand}"
+                                                          CommandParameter="{Binding PlacementTarget.DataContext,RelativeSource={RelativeSource AncestorType=ContextMenu}}">
+                                                            <MenuItem.Icon>
+                                                                <materialDesign:PackIcon Kind="Delete"/>
+                                                            </MenuItem.Icon>
+                                                        </MenuItem>
+                                                        <MenuItem Header="ニコニコで視聴する" Command="{Binding WatchOnNiconicoCommand}"
+                                                          CommandParameter="{Binding PlacementTarget.DataContext,RelativeSource={RelativeSource AncestorType=ContextMenu}}">
+                                                            <MenuItem.Icon>
+                                                                <materialDesign:PackIcon Kind="Web"/>
+                                                            </MenuItem.Icon>
+                                                        </MenuItem>
+                                                        <MenuItem Header="保存フォルダーを開く" Command="{Binding OpenPlaylistFolder}">
+                                                            <MenuItem.Icon>
+                                                                <materialDesign:PackIcon Kind="Folder"/>
+                                                            </MenuItem.Icon>
+                                                        </MenuItem>
+
+                                                        <MenuItem Header="選択">
+                                                            <MenuItem Header="全て選択する" Command="{Binding SelectAllVideosCommand}"/>
+                                                            <MenuItem Header="全て選択解除する" Command="{Binding DisSelectAllVideosCommand}"/>
+                                                            <MenuItem Header="未ダウンロードの動画を選択する" Command="{Binding SelectAllNotDownloadedVideosCommand}"/>
+                                                            <MenuItem Header="未ダウンロードの動画を選択解除する" Command="{Binding DisSelectAllNotDownloadedVideosCommand}"/>
+                                                            <MenuItem Header="ダウンロード済の動画を選択する" Command="{Binding SelectAllDownloadedVideosCommand}"/>
+                                                            <MenuItem Header="ダウンロード済の動画を選択解除する" Command="{Binding DisSelectAllDownloadedVideosCommand}"/>
+                                                        </MenuItem>
+                                                        <MenuItem Header="開く">
+                                                            <MenuItem Header="アプリで開く(A)" Command="{Binding OpenInPlayerAcommand}"
+                                                          CommandParameter="{Binding PlacementTarget.DataContext,RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
+                                                            <MenuItem Header="アプリで開く(B)" Command="{Binding OpenInPlayerBcommand}"
+                                                          CommandParameter="{Binding PlacementTarget.DataContext,RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
+                                                        </MenuItem>
+                                                        <MenuItem Header="送る">
+                                                            <MenuItem Header="アプリにURLを送る" Command="{Binding SendUrlToappCommand}"
+                                                          CommandParameter="{Binding PlacementTarget.DataContext,RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
+                                                            <MenuItem Header="アプリにIDを送る" Command="{Binding SendIdToappCommand}"
+                                                          CommandParameter="{Binding PlacementTarget.DataContext,RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
+                                                        </MenuItem>
+                                                        <MenuItem Header="プレイリストを作成">
+                                                            <MenuItem Header=".aimppl4形式のファイルを作成する" Command="{Binding CreatePlaylistCommand}" CommandParameter="aimp"/>
+                                                        </MenuItem>
+                                                    </ContextMenu>
+                                                </Setter.Value>
+                                            </Setter>
+                                        </Style>
+                                    </ListView.ItemContainerStyle>
+                                    <ListView.Resources>
+                                        <Style TargetType="{x:Type GridViewColumnHeader}" BasedOn="{StaticResource {x:Type GridViewColumnHeader}}">
+                                            <Style.Triggers>
+                                                <Trigger Property="Tag" Value="Selected">
+                                                    <Setter Property="Background" Value="#757575"/>
+                                                </Trigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </ListView.Resources>
+                                </ListView>
+                                <materialDesign:Snackbar HorizontalAlignment="Stretch" HorizontalContentAlignment="Center" Margin="300 0" Grid.Row="1" MessageQueue="{Binding SnackbarMessageQueue}"/>
                             </Grid>
-                            <ProgressBar Margin="2 5" IsIndeterminate="{Binding IsDownloading,UpdateSourceTrigger=PropertyChanged,Mode=OneWay}"/>
-                        </StackPanel>
-                    </TabItem>
-                    <TabItem Header="出力">
-                        <Grid>
-                            <Grid.RowDefinitions>
-                                <RowDefinition Height="2*"/>
-                                <RowDefinition Height="5*"/>
-                            </Grid.RowDefinitions>
-                            <StackPanel HorizontalAlignment="Left" VerticalAlignment="Center" Orientation="Horizontal">
-                                <Button Width="auto" Margin="4" Command="{Binding ClearMessageCommand}" ToolTip="出力をクリアする">
-                                    <materialDesign:PackIcon Kind="Delete"/>
-                                </Button>
-                                <Button Width="auto" Margin="4" Command="{Binding CopyMessageCommand}" ToolTip="出力内容をクリップボードにコピーする">
-                                    <materialDesign:PackIcon Kind="Clipboard"/>
-                                </Button>
-                                <Button Width="auto" Margin="4" Command="{Binding OpenLogWindowCommand}" ToolTip="出力内容を別ウィンドウで開く">
-                                    <materialDesign:PackIcon Kind="DockWindow"/>
-                                </Button>
-                            </StackPanel>
-                            <TextBox Grid.Row="1" Text="{Binding Message,Mode=OneWay,UpdateSourceTrigger=PropertyChanged}" Padding="4" IsReadOnly="True"
+                            <TabControl Grid.Row="3" Margin="8">
+                                <TabItem Header="設定">
+                                    <StackPanel Orientation="Vertical">
+                                        <StackPanel.DataContext>
+                                            <vm:DownloadSettingsViewModel/>
+                                        </StackPanel.DataContext>
+                                        <Grid Margin="0 5">
+                                            <Grid.RowDefinitions>
+                                                <RowDefinition Height="auto"/>
+                                                <RowDefinition Height="auto"/>
+                                            </Grid.RowDefinitions>
+                                            <Label Content="ダウンロードする項目"/>
+                                            <StackPanel Orientation="Horizontal" Grid.Row="1">
+                                                <CheckBox Margin="5 0" Content="動画" IsChecked="{Binding IsDownloadingVideoEnable,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}"/>
+                                                <CheckBox Margin="5 0" Content="コメント" IsChecked="{Binding IsDownloadingCommentEnable,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}"/>
+                                                <CheckBox Margin="5 0" Content="過去ログ" IsChecked="{Binding IsDownloadingCommentLogEnable,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}"/>
+                                                <CheckBox Margin="5 0" Content="投稿者コメント" IsChecked="{Binding IsDownloadingOwnerComment,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}"/>
+                                                <CheckBox Margin="5 0" Content="かんたんコメント" IsChecked="{Binding IsDownloadingEasyComment,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}"/>
+                                                <CheckBox Margin="5 0" Content="サムネイル" IsChecked="{Binding IsDownloadingThumbEnable,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}"/>
+                                            </StackPanel>
+                                        </Grid>
+                                        <Separator/>
+                                        <StackPanel Margin="0 5" Orientation="Horizontal">
+                                            <Label Content="優先解像度:" Margin="0 0 5 0"/>
+                                            <ComboBox ItemsSource="{Binding Resolutions}" DisplayMemberPath="DisplayValue" SelectedItem="{Binding SelectedResolution,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}"/>
+                                        </StackPanel>
+                                        <Separator/>
+                                        <Grid Margin="0 5">
+                                            <Grid.RowDefinitions>
+                                                <RowDefinition Height="auto"/>
+                                                <RowDefinition Height="auto"/>
+                                            </Grid.RowDefinitions>
+                                            <Label Content="オプション"/>
+                                            <DockPanel  Grid.Row="1">
+                                                <CheckBox Margin="5 0" Content="同名時に上書き" IsChecked="{Binding IsOverwriteEnable,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}"/>
+                                                <CheckBox Margin="5 0" Content="ダウンロード済をスキップ" IsChecked="{Binding IsSkippingEnable,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}"/>
+                                                <CheckBox Margin="5 0" Content="ファイルを別フォルダーからコピー" IsChecked="{Binding IsCopyFromAnotherFolderEnable,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}"/>
+                                                <DockPanel HorizontalAlignment="Right">
+                                                    <Button Content="ステージ" HorizontalAlignment="Right" Margin="10 0" Command="{Binding StageVideosCommand}"/>
+                                                    <Button Content="中断" HorizontalAlignment="Right" Margin="10 0" Command="{Binding CancelCommand}"/>
+                                                    <Button Content="ダウンロード" HorizontalAlignment="Right" Margin="10 0" Command="{Binding DownloadCommand}"/>
+                                                </DockPanel>
+                                            </DockPanel>
+                                        </Grid>
+                                        <ProgressBar Margin="2 5" IsIndeterminate="{Binding IsDownloading,UpdateSourceTrigger=PropertyChanged,Mode=OneWay}"/>
+                                    </StackPanel>
+                                </TabItem>
+                                <TabItem Header="出力">
+                                    <Grid>
+                                        <Grid.RowDefinitions>
+                                            <RowDefinition Height="2*"/>
+                                            <RowDefinition Height="5*"/>
+                                        </Grid.RowDefinitions>
+                                        <StackPanel HorizontalAlignment="Left" VerticalAlignment="Center" Orientation="Horizontal">
+                                            <Button Width="auto" Margin="4" Command="{Binding ClearMessageCommand}" ToolTip="出力をクリアする">
+                                                <materialDesign:PackIcon Kind="Delete"/>
+                                            </Button>
+                                            <Button Width="auto" Margin="4" Command="{Binding CopyMessageCommand}" ToolTip="出力内容をクリップボードにコピーする">
+                                                <materialDesign:PackIcon Kind="Clipboard"/>
+                                            </Button>
+                                            <Button Width="auto" Margin="4" Command="{Binding OpenLogWindowCommand}" ToolTip="出力内容を別ウィンドウで開く">
+                                                <materialDesign:PackIcon Kind="DockWindow"/>
+                                            </Button>
+                                        </StackPanel>
+                                        <TextBox Grid.Row="1" Text="{Binding Message,Mode=OneWay,UpdateSourceTrigger=PropertyChanged}" Padding="4" IsReadOnly="True"
                                          BorderThickness="0 1 0 0" TextWrapping="Wrap"/>
-                            </Grid>
-                        </TabItem>
-                    </TabControl >
+                                    </Grid>
+                                </TabItem>
+                            </TabControl >
+                        </Grid>
+                    </Grid>
                 </Grid>
-            </Grid>
-        </Grid>
+
+            </materialDesign:DrawerHost>
+        </DockPanel>
     </materialDesign:DialogHost>
 </Window>

--- a/Niconicome/Views/MainWindow.xaml
+++ b/Niconicome/Views/MainWindow.xaml
@@ -147,7 +147,7 @@
                                 <ColumnDefinition Width="3*"/>
                             </Grid.ColumnDefinitions>
                             <TextBox Text="{Binding InputString,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}" Style="{DynamicResource MaterialDesignTextBox}" FontSize="20" Margin="5,0" VerticalContentAlignment="Bottom" materialDesign:HintAssist.Hint="ID・検索キーワード入力窓" Padding="5 0"/>
-                            <Button Content="登録" Grid.Column="1" Margin="5,0" ToolTip="入力した動画を登録する" Command="{Binding AddVideoCommand}"/>
+                            <Button Content="登録" Grid.Column="1" Margin="5,0" ToolTip="入力した動画を登録する（インテリインプット）" Command="{Binding AddVideoCommand}"/>
                         </Grid>
                         <StackPanel Grid.Column="1" Orientation="Horizontal">
                             <Button Margin="5,0" Grid.Column="0" Width="60" HorizontalAlignment="Center" VerticalAlignment="Center" ToolTip="入力したキーワードでフィルター" Command="{Binding FilterCommand}">
@@ -312,7 +312,7 @@
                             </Style>
                         </ListView.Resources>
                     </ListView>
-                    <materialDesign:Snackbar HorizontalAlignment="Stretch" HorizontalContentAlignment="Center" Margin="120 0" Grid.Row="1" MessageQueue="{Binding SnackbarMessageQueue}"/>
+                    <materialDesign:Snackbar HorizontalAlignment="Stretch" HorizontalContentAlignment="Center" Margin="300 0" Grid.Row="1" MessageQueue="{Binding SnackbarMessageQueue}"/>
                 </Grid>
                 <TabControl Grid.Row="3" Margin="8">
                     <TabItem Header="設定">

--- a/Niconicome/Views/MainWindow.xaml
+++ b/Niconicome/Views/MainWindow.xaml
@@ -356,6 +356,7 @@
                                                 <CheckBox Margin="5 0" Content="投稿者コメント" IsChecked="{Binding IsDownloadingOwnerComment,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}"/>
                                                 <CheckBox Margin="5 0" Content="かんたんコメント" IsChecked="{Binding IsDownloadingEasyComment,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}"/>
                                                 <CheckBox Margin="5 0" Content="サムネイル" IsChecked="{Binding IsDownloadingThumbEnable,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}"/>
+                                                <CheckBox Margin="5 0" Content="動画情報" IsChecked="{Binding IsDownloadingVideoInfoEnable,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}"/>
                                                 <CheckBox Margin="5 0" Content="コメント取得数を制限" IsChecked="{Binding IsLimittingCommentCountEnable,UpdateSourceTrigger=PropertyChanged}" x:Name="limitComments"/>
                                                 <TextBox Margin="5 0" materialDesign:HintAssist.Hint="最大コメント数（数値）" Text="{Binding MaxCommentsCount,UpdateSourceTrigger=PropertyChanged}" Visibility="{Binding ElementName=limitComments,Path=IsChecked,Converter={StaticResource BooleanToVisibilityConverter}}" Width="150" HorizontalContentAlignment="Right"/>
                                             </StackPanel>

--- a/Niconicome/Views/MainWindow.xaml
+++ b/Niconicome/Views/MainWindow.xaml
@@ -252,7 +252,7 @@
                                             <GridViewColumn Header="選択">
                                                 <GridViewColumn.CellTemplate>
                                                     <DataTemplate>
-                                                        <CheckBox IsChecked="{Binding IsSelected,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}"/>
+                                                            <CheckBox IsChecked="{Binding IsSelected,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}"/>
                                                     </DataTemplate>
                                                 </GridViewColumn.CellTemplate>
                                             </GridViewColumn>
@@ -264,7 +264,13 @@
                                                 </GridViewColumn.CellTemplate>
                                             </GridViewColumn>
                                             <GridViewColumn Width="150" Header="ID" DisplayMemberBinding="{Binding NiconicoId}"/>
-                                            <GridViewColumn Header="タイトル" DisplayMemberBinding="{Binding Title}"/>
+                                            <GridViewColumn Header="タイトル">
+                                                <GridViewColumn.CellTemplate>
+                                                    <DataTemplate>
+                                                        <TextBlock Text="{Binding Title}" ToolTip="{Binding Title}"/>
+                                                    </DataTemplate>
+                                                </GridViewColumn.CellTemplate>
+                                            </GridViewColumn>
                                             <GridViewColumn Header="投稿日" DisplayMemberBinding="{Binding UploadedOn, StringFormat=yyyy年MM月dd日 HH:mm}"/>
                                             <GridViewColumn Header="再生回数" DisplayMemberBinding="{Binding ViewCount}"/>
                                             <GridViewColumn Header="状態" DisplayMemberBinding="{Binding Message}"/>

--- a/Niconicome/Views/MainWindow.xaml
+++ b/Niconicome/Views/MainWindow.xaml
@@ -148,10 +148,7 @@
                                 </Button>
                             </DockPanel>
                         </DockPanel>
-                        <Grid Grid.Row="1">
-                            <Grid.DataContext>
-                                <vm:VideoListViewModel/>
-                            </Grid.DataContext>
+                        <Grid Grid.Row="1" x:Name="videoList" d:DataContext="{d:DesignInstance {x:Type vm:VideoListViewModelD},IsDesignTimeCreatable=True}">
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="3*"/>
                                 <RowDefinition Height="3*"/>
@@ -344,11 +341,8 @@
                                 <materialDesign:Snackbar HorizontalAlignment="Stretch" HorizontalContentAlignment="Center" Margin="300 0" Grid.Row="1" MessageQueue="{Binding SnackbarMessageQueue}"/>
                             </Grid>
                             <TabControl Grid.Row="3" Margin="8">
-                                <TabItem Header="設定">
-                                    <StackPanel Orientation="Vertical">
-                                        <StackPanel.DataContext>
-                                            <vm:DownloadSettingsViewModel/>
-                                        </StackPanel.DataContext>
+                                <TabItem Header="設定" d:DataContext="{d:DesignInstance {x:Type vm:DownloadSettingsViewModelD},IsDesignTimeCreatable=True}">
+                                    <StackPanel Orientation="Vertical" x:Name="downloadSettings">
                                         <Grid Margin="0 5">
                                             <Grid.RowDefinitions>
                                                 <RowDefinition Height="auto"/>
@@ -362,6 +356,8 @@
                                                 <CheckBox Margin="5 0" Content="投稿者コメント" IsChecked="{Binding IsDownloadingOwnerComment,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}"/>
                                                 <CheckBox Margin="5 0" Content="かんたんコメント" IsChecked="{Binding IsDownloadingEasyComment,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}"/>
                                                 <CheckBox Margin="5 0" Content="サムネイル" IsChecked="{Binding IsDownloadingThumbEnable,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}"/>
+                                                <CheckBox Margin="5 0" Content="コメント取得数を制限" IsChecked="{Binding IsLimittingCommentCountEnable,UpdateSourceTrigger=PropertyChanged}" x:Name="limitComments"/>
+                                                <TextBox Margin="5 0" materialDesign:HintAssist.Hint="最大コメント数（数値）" Text="{Binding MaxCommentsCount,UpdateSourceTrigger=PropertyChanged}" Visibility="{Binding ElementName=limitComments,Path=IsChecked,Converter={StaticResource BooleanToVisibilityConverter}}" Width="150" HorizontalContentAlignment="Right"/>
                                             </StackPanel>
                                         </Grid>
                                         <Separator/>
@@ -415,7 +411,6 @@
                         </Grid>
                     </Grid>
                 </Grid>
-
             </materialDesign:DrawerHost>
         </DockPanel>
     </materialDesign:DialogHost>

--- a/Niconicome/Views/MainWindow.xaml
+++ b/Niconicome/Views/MainWindow.xaml
@@ -65,7 +65,6 @@
                     <TreeView.ItemContainerStyle>
                         <Style TargetType="{x:Type TreeViewItem}" BasedOn="{StaticResource {x:Type TreeViewItem}}">
                             <Setter Property="Tag" Value="{Binding Path=DataContext, RelativeSource={RelativeSource AncestorType=TreeView, Mode=FindAncestor}}"/>
-                            <Setter Property="Background" Value="White"/>
                             <Setter Property="ContextMenu">
                                 <Setter.Value>
                                     <ContextMenu StaysOpen="False" DataContext="{Binding Path=PlacementTarget.Tag, RelativeSource={RelativeSource Self}}" >

--- a/Niconicome/Views/MainWindow.xaml
+++ b/Niconicome/Views/MainWindow.xaml
@@ -24,273 +24,275 @@
     <Window.DataContext>
         <vm:MainWindowViewModel/>
     </Window.DataContext>
-    <Grid>
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="3*"/>
-            <ColumnDefinition Width="17*"/>
-        </Grid.ColumnDefinitions>
-        <Grid Grid.Column= "0" Background="#e7e7e7">
-            <Grid.DataContext>
-                <vm:PlaylistTreeViewModel/>
-            </Grid.DataContext>
-            <Grid.RowDefinitions>
-                <RowDefinition Height="2*"/>
-                <RowDefinition Height="18*"/>
-            </Grid.RowDefinitions>
-            <StackPanel Orientation="Horizontal" Margin="5">
-                <Button Width="auto" HorizontalAlignment="Left" Command="{Binding PlaylistRefreshcommand}" ToolTip="プレイリストを更新する">
-                    <materialDesign:PackIcon Kind="Refresh" />
-                </Button>
-            </StackPanel>
-            <TreeView ItemsSource="{Binding PlaylistTree}" Grid.Row="1" >
-                <i:Interaction.Behaviors>
-                    <vm:PlaylistTreeBehavior/>
-                </i:Interaction.Behaviors>
-                <TreeView.ItemTemplate>
-                    <HierarchicalDataTemplate DataType="tree:ITreePlaylistInfo" ItemsSource="{Binding Children}">
-                        <StackPanel>
-                            <Grid Background="{Binding BackgroundColor}">
-                                <Grid.ToolTip>
-                                    <TextBlock Text="{Binding Videos.Count,StringFormat={}{0}件の動画}"/>
-                                </Grid.ToolTip>
-                                <Separator BorderThickness="1" Visibility="{Binding BeforeSeparatorVisibility,Mode=OneWay,UpdateSourceTrigger=PropertyChanged}" BorderBrush="#000"/>
-                                <TextBlock Text="{Binding Name}"/>
-                                <Separator BorderThickness="1" Visibility="{Binding AfterSeparatorVisibility,Mode=OneWay,UpdateSourceTrigger=PropertyChanged}" BorderBrush="#000"/>
-                            </Grid>
-                        </StackPanel>
-                    </HierarchicalDataTemplate>
-                </TreeView.ItemTemplate>
-                <TreeView.ItemContainerStyle>
-                    <Style TargetType="{x:Type TreeViewItem}" BasedOn="{StaticResource {x:Type TreeViewItem}}">
-                        <Setter Property="Tag" Value="{Binding Path=DataContext, RelativeSource={RelativeSource AncestorType=TreeView, Mode=FindAncestor}}"/>
-                        <Setter Property="Background" Value="White"/>
-                        <Setter Property="ContextMenu">
-                            <Setter.Value>
-                                <ContextMenu StaysOpen="False" DataContext="{Binding Path=PlacementTarget.Tag, RelativeSource={RelativeSource Self}}" >
-                                    <MenuItem Header="プレイリストを追加する"
-                                                  Command="{Binding AddPlaylist}"
-                                                  CommandParameter="{Binding  Path=PlacementTarget.DataContext.Id, RelativeSource={RelativeSource AncestorType=ContextMenu}}">
-                                        <MenuItem.Icon>
-                                            <materialDesign:PackIcon Kind="Plus"/>
-                                        </MenuItem.Icon>
-                                    </MenuItem>
-                                    <MenuItem Header="このプレイリストを削除する"
-                                                  Command="{Binding RemovePlaylist}"
-                                                  CommandParameter="{Binding  Path=PlacementTarget.DataContext.Id, RelativeSource={RelativeSource AncestorType=ContextMenu}}">
-                                        <MenuItem.Icon>
-                                            <materialDesign:PackIcon Kind="Delete"/>
-                                        </MenuItem.Icon>
-                                    </MenuItem>
-                                    <MenuItem Header="このプレイリストを編集する"
-                                                  Command="{Binding EditPlaylistCommand}"
-                                                  CommandParameter="{Binding  Path=PlacementTarget.DataContext, RelativeSource={RelativeSource AncestorType=ContextMenu}}">
-                                        <MenuItem.Icon>
-                                            <materialDesign:PackIcon Kind="Edit"/>
-                                        </MenuItem.Icon>
-                                    </MenuItem>
-                                </ContextMenu>
-                            </Setter.Value>
-                        </Setter>
-                        <Setter Property="IsExpanded" Value="{Binding IsExpanded,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}"/>
-                    </Style>
-                </TreeView.ItemContainerStyle>
-            </TreeView>
-        </Grid>
-        <Grid Grid.Column="1">
-            <Grid.RowDefinitions>
-                <RowDefinition Height="1*"/>
-                <RowDefinition Height="19*"/>
-            </Grid.RowDefinitions>
-            <DockPanel HorizontalAlignment="Right">
-                <Grid HorizontalAlignment="Right" Grid.Column="1">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="auto"/>
-                        <ColumnDefinition Width="auto"/>
-                        <ColumnDefinition Width="auto"/>
-                    </Grid.ColumnDefinitions>
-                    <Button Content="{Binding LoginBtnVal}" Command="{Binding LoginCommand}" Margin="10 0" Grid.Column="2" ToolTip="{Binding LoginBtnTooltip}"/>
-                    <TextBlock Text="{Binding Username}" Grid.Column="1" Style="{DynamicResource MaterialDesignBody1TextBlock}" VerticalAlignment="Center" />
-                    <Image Source="{Binding UserImage}"  Grid.Column="0" Margin="5">
-                        <i:Interaction.Behaviors>
-                            <vm:UserImageBehavior/>
-                        </i:Interaction.Behaviors>
-                    </Image>
-                </Grid>
-                <Button Margin="10,0" Grid.Column="0" Width="60" HorizontalAlignment="Left" VerticalAlignment="Center" ToolTip="アプリケーション設定" Command="{Binding OpenSettingCommand}">
-                    <materialDesign:PackIcon Kind="cog">
-                        <materialDesign:PackIcon.RenderTransform>
-                            <ScaleTransform CenterY="8" CenterX="7" ScaleX="1.7" ScaleY="1.7"/>
-                        </materialDesign:PackIcon.RenderTransform>
-                    </materialDesign:PackIcon>
-                </Button>
-            </DockPanel>
-            <Grid Grid.Row="1">
+    <materialDesign:DialogHost Identifier="default">
+
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="3*"/>
+                <ColumnDefinition Width="17*"/>
+            </Grid.ColumnDefinitions>
+            <Grid Grid.Column= "0" Background="#e7e7e7">
                 <Grid.DataContext>
-                    <vm:VideoListViewModel/>
+                    <vm:PlaylistTreeViewModel/>
                 </Grid.DataContext>
                 <Grid.RowDefinitions>
-                    <RowDefinition Height="3*"/>
-                    <RowDefinition Height="3*"/>
-                    <RowDefinition Height="23*"/>
-                    <RowDefinition Height="14*"/>
+                    <RowDefinition Height="2*"/>
+                    <RowDefinition Height="18*"/>
                 </Grid.RowDefinitions>
-                <TextBlock FontSize="30" Text="{Binding PlaylistTitle,UpdateSourceTrigger=PropertyChanged}" Margin="10 0"/>
-                <Grid Grid.Row="1">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="1*"/>
-                        <ColumnDefinition Width="1*"/>
-                    </Grid.ColumnDefinitions>
-                    <Grid>
+                <StackPanel Orientation="Horizontal" Margin="5">
+                    <Button Width="auto" HorizontalAlignment="Left" Command="{Binding PlaylistRefreshcommand}" ToolTip="プレイリストを更新する">
+                        <materialDesign:PackIcon Kind="Refresh" />
+                    </Button>
+                </StackPanel>
+                <TreeView ItemsSource="{Binding PlaylistTree}" Grid.Row="1" >
+                    <i:Interaction.Behaviors>
+                        <vm:PlaylistTreeBehavior/>
+                    </i:Interaction.Behaviors>
+                    <TreeView.ItemTemplate>
+                        <HierarchicalDataTemplate DataType="tree:ITreePlaylistInfo" ItemsSource="{Binding Children}">
+                            <StackPanel>
+                                <Grid Background="{Binding BackgroundColor}">
+                                    <Grid.ToolTip>
+                                        <TextBlock Text="{Binding Videos.Count,StringFormat={}{0}件の動画}"/>
+                                    </Grid.ToolTip>
+                                    <Separator BorderThickness="1" Visibility="{Binding BeforeSeparatorVisibility,Mode=OneWay,UpdateSourceTrigger=PropertyChanged}" BorderBrush="#000"/>
+                                    <TextBlock Text="{Binding Name}"/>
+                                    <Separator BorderThickness="1" Visibility="{Binding AfterSeparatorVisibility,Mode=OneWay,UpdateSourceTrigger=PropertyChanged}" BorderBrush="#000"/>
+                                </Grid>
+                            </StackPanel>
+                        </HierarchicalDataTemplate>
+                    </TreeView.ItemTemplate>
+                    <TreeView.ItemContainerStyle>
+                        <Style TargetType="{x:Type TreeViewItem}" BasedOn="{StaticResource {x:Type TreeViewItem}}">
+                            <Setter Property="Tag" Value="{Binding Path=DataContext, RelativeSource={RelativeSource AncestorType=TreeView, Mode=FindAncestor}}"/>
+                            <Setter Property="Background" Value="White"/>
+                            <Setter Property="ContextMenu">
+                                <Setter.Value>
+                                    <ContextMenu StaysOpen="False" DataContext="{Binding Path=PlacementTarget.Tag, RelativeSource={RelativeSource Self}}" >
+                                        <MenuItem Header="プレイリストを追加する"
+                                                  Command="{Binding AddPlaylist}"
+                                                  CommandParameter="{Binding  Path=PlacementTarget.DataContext.Id, RelativeSource={RelativeSource AncestorType=ContextMenu}}">
+                                            <MenuItem.Icon>
+                                                <materialDesign:PackIcon Kind="Plus"/>
+                                            </MenuItem.Icon>
+                                        </MenuItem>
+                                        <MenuItem Header="このプレイリストを削除する"
+                                                  Command="{Binding RemovePlaylist}"
+                                                  CommandParameter="{Binding  Path=PlacementTarget.DataContext.Id, RelativeSource={RelativeSource AncestorType=ContextMenu}}">
+                                            <MenuItem.Icon>
+                                                <materialDesign:PackIcon Kind="Delete"/>
+                                            </MenuItem.Icon>
+                                        </MenuItem>
+                                        <MenuItem Header="このプレイリストを編集する"
+                                                  Command="{Binding EditPlaylistCommand}"
+                                                  CommandParameter="{Binding  Path=PlacementTarget.DataContext, RelativeSource={RelativeSource AncestorType=ContextMenu}}">
+                                            <MenuItem.Icon>
+                                                <materialDesign:PackIcon Kind="Edit"/>
+                                            </MenuItem.Icon>
+                                        </MenuItem>
+                                    </ContextMenu>
+                                </Setter.Value>
+                            </Setter>
+                            <Setter Property="IsExpanded" Value="{Binding IsExpanded,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}"/>
+                        </Style>
+                    </TreeView.ItemContainerStyle>
+                </TreeView>
+            </Grid>
+            <Grid Grid.Column="1">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="1*"/>
+                    <RowDefinition Height="19*"/>
+                </Grid.RowDefinitions>
+                <DockPanel HorizontalAlignment="Right">
+                    <Grid HorizontalAlignment="Right" Grid.Column="1">
                         <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="17*"/>
-                            <ColumnDefinition Width="3*"/>
+                            <ColumnDefinition Width="auto"/>
+                            <ColumnDefinition Width="auto"/>
+                            <ColumnDefinition Width="auto"/>
                         </Grid.ColumnDefinitions>
-                        <TextBox Text="{Binding InputString,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}" Style="{DynamicResource MaterialDesignTextBox}" FontSize="20" Margin="5,0" VerticalContentAlignment="Bottom" materialDesign:HintAssist.Hint="ID・検索キーワード入力窓" Padding="5 0"/>
-                        <Button Content="登録" Grid.Column="1" Margin="5,0" ToolTip="入力した動画を登録する" Command="{Binding AddVideoCommand}"/>
+                        <Button Content="{Binding LoginBtnVal}" Command="{Binding LoginCommand}" Margin="10 0" Grid.Column="2" ToolTip="{Binding LoginBtnTooltip}"/>
+                        <TextBlock Text="{Binding Username}" Grid.Column="1" Style="{DynamicResource MaterialDesignBody1TextBlock}" VerticalAlignment="Center" />
+                        <Image Source="{Binding UserImage}"  Grid.Column="0" Margin="5">
+                            <i:Interaction.Behaviors>
+                                <vm:UserImageBehavior/>
+                            </i:Interaction.Behaviors>
+                        </Image>
                     </Grid>
-                    <StackPanel Grid.Column="1" Orientation="Horizontal">
-                        <Button Margin="5,0" Grid.Column="0" Width="60" HorizontalAlignment="Center" VerticalAlignment="Center" ToolTip="入力したキーワードでフィルター" Command="{Binding FilterCommand}">
-                            <materialDesign:PackIcon Kind="{Binding FilterIcon}">
-                                <materialDesign:PackIcon.RenderTransform>
-                                    <ScaleTransform CenterY="7" CenterX="8" ScaleX="1.8" ScaleY="1.8"/>
-                                </materialDesign:PackIcon.RenderTransform>
-                            </materialDesign:PackIcon>
-                            <Button.Style>
-                                <Style TargetType="Button" BasedOn="{StaticResource MaterialDesignFlatMidBgButton}">
-                                    <Setter Property="Tag" Value="{Binding DataContext, RelativeSource={RelativeSource Mode=Self}}"/>
+                    <Button Margin="10,0" Grid.Column="0" Width="60" HorizontalAlignment="Left" VerticalAlignment="Center" ToolTip="アプリケーション設定" Command="{Binding OpenSettingCommand}">
+                        <materialDesign:PackIcon Kind="cog">
+                            <materialDesign:PackIcon.RenderTransform>
+                                <ScaleTransform CenterY="8" CenterX="7" ScaleX="1.7" ScaleY="1.7"/>
+                            </materialDesign:PackIcon.RenderTransform>
+                        </materialDesign:PackIcon>
+                    </Button>
+                </DockPanel>
+                <Grid Grid.Row="1">
+                    <Grid.DataContext>
+                        <vm:VideoListViewModel/>
+                    </Grid.DataContext>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="3*"/>
+                        <RowDefinition Height="3*"/>
+                        <RowDefinition Height="23*"/>
+                        <RowDefinition Height="14*"/>
+                    </Grid.RowDefinitions>
+                    <TextBlock FontSize="30" Text="{Binding PlaylistTitle,UpdateSourceTrigger=PropertyChanged}" Margin="10 0"/>
+                    <Grid Grid.Row="1">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="1*"/>
+                            <ColumnDefinition Width="1*"/>
+                        </Grid.ColumnDefinitions>
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="17*"/>
+                                <ColumnDefinition Width="3*"/>
+                            </Grid.ColumnDefinitions>
+                            <TextBox Text="{Binding InputString,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}" Style="{DynamicResource MaterialDesignTextBox}" FontSize="20" Margin="5,0" VerticalContentAlignment="Bottom" materialDesign:HintAssist.Hint="ID・検索キーワード入力窓" Padding="5 0"/>
+                            <Button Content="登録" Grid.Column="1" Margin="5,0" ToolTip="入力した動画を登録する" Command="{Binding AddVideoCommand}"/>
+                        </Grid>
+                        <StackPanel Grid.Column="1" Orientation="Horizontal">
+                            <Button Margin="5,0" Grid.Column="0" Width="60" HorizontalAlignment="Center" VerticalAlignment="Center" ToolTip="入力したキーワードでフィルター" Command="{Binding FilterCommand}">
+                                <materialDesign:PackIcon Kind="{Binding FilterIcon}">
+                                    <materialDesign:PackIcon.RenderTransform>
+                                        <ScaleTransform CenterY="7" CenterX="8" ScaleX="1.8" ScaleY="1.8"/>
+                                    </materialDesign:PackIcon.RenderTransform>
+                                </materialDesign:PackIcon>
+                                <Button.Style>
+                                    <Style TargetType="Button" BasedOn="{StaticResource MaterialDesignFlatMidBgButton}">
+                                        <Setter Property="Tag" Value="{Binding DataContext, RelativeSource={RelativeSource Mode=Self}}"/>
+                                        <Setter Property="ContextMenu">
+                                            <Setter.Value>
+                                                <ContextMenu DataContext="{Binding PlacementTarget.Tag,RelativeSource={RelativeSource Mode=Self}}">
+                                                    <MenuItem IsCheckable="True" Header="タグのみでフィルター" IsChecked="{Binding IsFilteringOnlyByTag}"/>
+                                                    <MenuItem IsCheckable="True" Header="データベースの全ての動画からフィルター" IsChecked="{Binding IsFilteringFromAllVideos}"/>
+                                                </ContextMenu>
+                                            </Setter.Value>
+                                        </Setter>
+                                    </Style>
+                                </Button.Style>
+                            </Button>
+
+                            <Button Margin="5,0" Grid.Column="0" Width="60" HorizontalAlignment="Center" VerticalAlignment="Center" ToolTip="クリップボードから一括登録" Command="{Binding AddVideoFromClipboardCommand}">
+                                <materialDesign:PackIcon Kind="Clipboard">
+                                    <materialDesign:PackIcon.RenderTransform>
+                                        <ScaleTransform CenterY="7" CenterX="8" ScaleX="1.8" ScaleY="1.8"/>
+                                    </materialDesign:PackIcon.RenderTransform>
+                                </materialDesign:PackIcon>
+                            </Button>
+
+                            <Button Margin="5,0" Grid.Column="1" Width="60" HorizontalAlignment="Center" VerticalAlignment="Center" ToolTip="検索して登録" Command="{Binding SearchCommand}">
+                                <materialDesign:PackIcon Kind="Magnify">
+                                    <materialDesign:PackIcon.RenderTransform>
+                                        <ScaleTransform CenterY="7" CenterX="8" ScaleX="1.8" ScaleY="1.8"/>
+                                    </materialDesign:PackIcon.RenderTransform>
+                                </materialDesign:PackIcon>
+                            </Button>
+                            <Button Margin="5,0" Grid.Column="2" Width="60" HorizontalAlignment="Center" VerticalAlignment="Center" ToolTip="オンライン上のコンテンツとの同期設定" Command="{Binding OpenNetworkSettingsCommand}">
+                                <materialDesign:PackIcon Kind="Attachment">
+                                    <materialDesign:PackIcon.RenderTransform>
+                                        <ScaleTransform CenterY="8" CenterX="7" ScaleX="2" ScaleY="2"/>
+                                    </materialDesign:PackIcon.RenderTransform>
+                                </materialDesign:PackIcon>
+                            </Button>
+
+                            <Button Margin="5,0" Grid.Column="3" Width="60" HorizontalAlignment="Center" VerticalAlignment="Center" ToolTip="名前を編集" Command="{Binding EditPlaylistCommand}">
+                                <materialDesign:PackIcon Kind="Pencil">
+                                    <materialDesign:PackIcon.RenderTransform>
+                                        <ScaleTransform CenterY="7" CenterX="8" ScaleX="1.7" ScaleY="1.7"/>
+                                    </materialDesign:PackIcon.RenderTransform>
+                                </materialDesign:PackIcon>
+                            </Button>
+
+                            <Button Margin="5,0" Grid.Column="4" Width="60" HorizontalAlignment="Center" VerticalAlignment="Center" ToolTip="動画情報を更新する" Command="{Binding UpdateVideoCommand}">
+                                <materialDesign:PackIcon Kind="{Binding RefreshCommandIcon}">
+                                    <materialDesign:PackIcon.RenderTransform>
+                                        <ScaleTransform CenterY="7" CenterX="8" ScaleX="1.7" ScaleY="1.7"/>
+                                    </materialDesign:PackIcon.RenderTransform>
+                                </materialDesign:PackIcon>
+                            </Button>
+
+                            <Button Margin="5,0" Grid.Column="5" Width="60" HorizontalAlignment="Center" VerticalAlignment="Center" ToolTip="ネットワークと同期する" Command="{Binding SyncWithNetowrkCommand}">
+                                <materialDesign:PackIcon Kind="DatabaseSync">
+                                    <materialDesign:PackIcon.RenderTransform>
+                                        <ScaleTransform CenterY="7" CenterX="8" ScaleX="1.7" ScaleY="1.7"/>
+                                    </materialDesign:PackIcon.RenderTransform>
+                                </materialDesign:PackIcon>
+                            </Button>
+                        </StackPanel>
+                    </Grid>
+                    <Grid Grid.Row="2">
+                        <ListView Name="videolist" ItemsSource="{Binding Videos,UpdateSourceTrigger=PropertyChanged,Mode=OneWay}" BorderThickness="1" BorderBrush="#e7e7e7" >
+                            <i:Interaction.Behaviors>
+                                <vm:VideoListBehavior/>
+                            </i:Interaction.Behaviors>
+                            <ListView.View>
+                                <GridView>
+                                    <GridViewColumn Header="選択">
+                                        <GridViewColumn.CellTemplate>
+                                            <DataTemplate>
+                                                <CheckBox IsChecked="{Binding IsSelected,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}"/>
+                                            </DataTemplate>
+                                        </GridViewColumn.CellTemplate>
+                                    </GridViewColumn>
+                                    <GridViewColumn >
+                                        <GridViewColumn.CellTemplate>
+                                            <DataTemplate>
+                                                <Image Source="{Binding BindableThumbPath,UpdateSourceTrigger=PropertyChanged}" Height="80"/>
+                                            </DataTemplate>
+                                        </GridViewColumn.CellTemplate>
+                                    </GridViewColumn>
+                                    <GridViewColumn Width="150" Header="ID" DisplayMemberBinding="{Binding NiconicoId}"/>
+                                    <GridViewColumn Header="タイトル" DisplayMemberBinding="{Binding Title}"/>
+                                    <GridViewColumn Header="投稿日" DisplayMemberBinding="{Binding UploadedOn, StringFormat=yyyy年MM月dd日 HH:mm}"/>
+                                    <GridViewColumn Header="再生回数" DisplayMemberBinding="{Binding ViewCount}"/>
+                                    <GridViewColumn Header="状態" DisplayMemberBinding="{Binding Message}"/>
+                                </GridView>
+                            </ListView.View>
+                            <ListView.ItemContainerStyle>
+                                <Style TargetType="ListViewItem" BasedOn="{StaticResource MaterialDesignGridViewItem}">
+                                    <Setter Property="VerticalContentAlignment" Value="Center"/>
+                                    <Setter Property="HorizontalContentAlignment" Value="Center"/>
+                                    <Setter Property="Padding" Value="10"/>
+                                    <Setter Property="Tag" Value="{Binding RelativeSource={RelativeSource AncestorType={x:Type ListView}, Mode=FindAncestor}, Path=DataContext}"/>
                                     <Setter Property="ContextMenu">
                                         <Setter.Value>
-                                            <ContextMenu DataContext="{Binding PlacementTarget.Tag,RelativeSource={RelativeSource Mode=Self}}">
-                                                <MenuItem IsCheckable="True" Header="タグのみでフィルター" IsChecked="{Binding IsFilteringOnlyByTag}"/>
-                                                <MenuItem IsCheckable="True" Header="データベースの全ての動画からフィルター" IsChecked="{Binding IsFilteringFromAllVideos}"/>
-                                            </ContextMenu>
-                                        </Setter.Value>
-                                    </Setter>
-                                </Style>
-                            </Button.Style>
-                        </Button>
-
-                        <Button Margin="5,0" Grid.Column="0" Width="60" HorizontalAlignment="Center" VerticalAlignment="Center" ToolTip="クリップボードから一括登録" Command="{Binding AddVideoFromClipboardCommand}">
-                            <materialDesign:PackIcon Kind="Clipboard">
-                                <materialDesign:PackIcon.RenderTransform>
-                                    <ScaleTransform CenterY="7" CenterX="8" ScaleX="1.8" ScaleY="1.8"/>
-                                </materialDesign:PackIcon.RenderTransform>
-                            </materialDesign:PackIcon>
-                        </Button>
-
-                        <Button Margin="5,0" Grid.Column="1" Width="60" HorizontalAlignment="Center" VerticalAlignment="Center" ToolTip="検索して登録" Command="{Binding SearchCommand}">
-                            <materialDesign:PackIcon Kind="Magnify">
-                                <materialDesign:PackIcon.RenderTransform>
-                                    <ScaleTransform CenterY="7" CenterX="8" ScaleX="1.8" ScaleY="1.8"/>
-                                </materialDesign:PackIcon.RenderTransform>
-                            </materialDesign:PackIcon>
-                        </Button>
-                        <Button Margin="5,0" Grid.Column="2" Width="60" HorizontalAlignment="Center" VerticalAlignment="Center" ToolTip="オンライン上のコンテンツとの同期設定" Command="{Binding OpenNetworkSettingsCommand}">
-                            <materialDesign:PackIcon Kind="Attachment">
-                                <materialDesign:PackIcon.RenderTransform>
-                                    <ScaleTransform CenterY="8" CenterX="7" ScaleX="2" ScaleY="2"/>
-                                </materialDesign:PackIcon.RenderTransform>
-                            </materialDesign:PackIcon>
-                        </Button>
-
-                        <Button Margin="5,0" Grid.Column="3" Width="60" HorizontalAlignment="Center" VerticalAlignment="Center" ToolTip="名前を編集" Command="{Binding EditPlaylistCommand}">
-                            <materialDesign:PackIcon Kind="Pencil">
-                                <materialDesign:PackIcon.RenderTransform>
-                                    <ScaleTransform CenterY="7" CenterX="8" ScaleX="1.7" ScaleY="1.7"/>
-                                </materialDesign:PackIcon.RenderTransform>
-                            </materialDesign:PackIcon>
-                        </Button>
-
-                        <Button Margin="5,0" Grid.Column="4" Width="60" HorizontalAlignment="Center" VerticalAlignment="Center" ToolTip="動画情報を更新する" Command="{Binding UpdateVideoCommand}">
-                            <materialDesign:PackIcon Kind="{Binding RefreshCommandIcon}">
-                                <materialDesign:PackIcon.RenderTransform>
-                                    <ScaleTransform CenterY="7" CenterX="8" ScaleX="1.7" ScaleY="1.7"/>
-                                </materialDesign:PackIcon.RenderTransform>
-                            </materialDesign:PackIcon>
-                        </Button>
-
-                        <Button Margin="5,0" Grid.Column="5" Width="60" HorizontalAlignment="Center" VerticalAlignment="Center" ToolTip="ネットワークと同期する" Command="{Binding SyncWithNetowrkCommand}">
-                            <materialDesign:PackIcon Kind="DatabaseSync">
-                                <materialDesign:PackIcon.RenderTransform>
-                                    <ScaleTransform CenterY="7" CenterX="8" ScaleX="1.7" ScaleY="1.7"/>
-                                </materialDesign:PackIcon.RenderTransform>
-                            </materialDesign:PackIcon>
-                        </Button>
-                    </StackPanel>
-                </Grid>
-                <Grid Grid.Row="2">
-                    <ListView Name="videolist" ItemsSource="{Binding Videos,UpdateSourceTrigger=PropertyChanged,Mode=OneWay}" BorderThickness="1" BorderBrush="#e7e7e7" >
-                        <i:Interaction.Behaviors>
-                            <vm:VideoListBehavior/>
-                        </i:Interaction.Behaviors>
-                        <ListView.View>
-                            <GridView>
-                                <GridViewColumn Header="選択">
-                                    <GridViewColumn.CellTemplate>
-                                        <DataTemplate>
-                                            <CheckBox IsChecked="{Binding IsSelected,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}"/>
-                                        </DataTemplate>
-                                    </GridViewColumn.CellTemplate>
-                                </GridViewColumn>
-                                <GridViewColumn >
-                                    <GridViewColumn.CellTemplate>
-                                        <DataTemplate>
-                                            <Image Source="{Binding BindableThumbPath,UpdateSourceTrigger=PropertyChanged}" Height="80"/>
-                                        </DataTemplate>
-                                    </GridViewColumn.CellTemplate>
-                                </GridViewColumn>
-                                <GridViewColumn Width="150" Header="ID" DisplayMemberBinding="{Binding NiconicoId}"/>
-                                <GridViewColumn Header="タイトル" DisplayMemberBinding="{Binding Title}"/>
-                                <GridViewColumn Header="投稿日" DisplayMemberBinding="{Binding UploadedOn, StringFormat=yyyy年MM月dd日 HH:mm}"/>
-                                <GridViewColumn Header="再生回数" DisplayMemberBinding="{Binding ViewCount}"/>
-                                <GridViewColumn Header="状態" DisplayMemberBinding="{Binding Message}"/>
-                            </GridView>
-                        </ListView.View>
-                        <ListView.ItemContainerStyle>
-                            <Style TargetType="ListViewItem" BasedOn="{StaticResource MaterialDesignGridViewItem}">
-                                <Setter Property="VerticalContentAlignment" Value="Center"/>
-                                <Setter Property="HorizontalContentAlignment" Value="Center"/>
-                                <Setter Property="Padding" Value="10"/>
-                                <Setter Property="Tag" Value="{Binding RelativeSource={RelativeSource AncestorType={x:Type ListView}, Mode=FindAncestor}, Path=DataContext}"/>
-                                <Setter Property="ContextMenu">
-                                    <Setter.Value>
-                                        <ContextMenu DataContext="{Binding Path=PlacementTarget.Tag,RelativeSource={RelativeSource Self}}">
-                                            <MenuItem Header="動画を削除する" Command="{Binding RemoveVideoCommand}"
+                                            <ContextMenu DataContext="{Binding Path=PlacementTarget.Tag,RelativeSource={RelativeSource Self}}">
+                                                <MenuItem Header="動画を削除する" Command="{Binding RemoveVideoCommand}"
                                                           CommandParameter="{Binding PlacementTarget.DataContext,RelativeSource={RelativeSource AncestorType=ContextMenu}}">
-                                                <MenuItem.Icon>
-                                                    <materialDesign:PackIcon Kind="Delete"/>
-                                                </MenuItem.Icon>
-                                            </MenuItem>
-                                            <MenuItem Header="ニコニコで視聴する" Command="{Binding WatchOnNiconicoCommand}"
+                                                    <MenuItem.Icon>
+                                                        <materialDesign:PackIcon Kind="Delete"/>
+                                                    </MenuItem.Icon>
+                                                </MenuItem>
+                                                <MenuItem Header="ニコニコで視聴する" Command="{Binding WatchOnNiconicoCommand}"
                                                           CommandParameter="{Binding PlacementTarget.DataContext,RelativeSource={RelativeSource AncestorType=ContextMenu}}">
-                                                <MenuItem.Icon>
-                                                    <materialDesign:PackIcon Kind="Web"/>
-                                                </MenuItem.Icon>
-                                            </MenuItem>
-                                            <MenuItem Header="保存フォルダーを開く" Command="{Binding OpenPlaylistFolder}">
-                                                <MenuItem.Icon>
-                                                    <materialDesign:PackIcon Kind="Folder"/>
-                                                </MenuItem.Icon>
-                                            </MenuItem>
+                                                    <MenuItem.Icon>
+                                                        <materialDesign:PackIcon Kind="Web"/>
+                                                    </MenuItem.Icon>
+                                                </MenuItem>
+                                                <MenuItem Header="保存フォルダーを開く" Command="{Binding OpenPlaylistFolder}">
+                                                    <MenuItem.Icon>
+                                                        <materialDesign:PackIcon Kind="Folder"/>
+                                                    </MenuItem.Icon>
+                                                </MenuItem>
 
-                                            <MenuItem Header="選択">
-                                                <MenuItem Header="全て選択する" Command="{Binding SelectAllVideosCommand}"/>
-                                                <MenuItem Header="全て選択解除する" Command="{Binding DisSelectAllVideosCommand}"/>
-                                                <MenuItem Header="未ダウンロードの動画を選択する" Command="{Binding SelectAllNotDownloadedVideosCommand}"/>
-                                                <MenuItem Header="未ダウンロードの動画を選択解除する" Command="{Binding DisSelectAllNotDownloadedVideosCommand}"/>
-                                                <MenuItem Header="ダウンロード済の動画を選択する" Command="{Binding SelectAllDownloadedVideosCommand}"/>
-                                                <MenuItem Header="ダウンロード済の動画を選択解除する" Command="{Binding DisSelectAllDownloadedVideosCommand}"/>
-                                            </MenuItem>
-                                            <MenuItem Header="開く">
-                                                <MenuItem Header="アプリで開く(A)" Command="{Binding OpenInPlayerAcommand}"
+                                                <MenuItem Header="選択">
+                                                    <MenuItem Header="全て選択する" Command="{Binding SelectAllVideosCommand}"/>
+                                                    <MenuItem Header="全て選択解除する" Command="{Binding DisSelectAllVideosCommand}"/>
+                                                    <MenuItem Header="未ダウンロードの動画を選択する" Command="{Binding SelectAllNotDownloadedVideosCommand}"/>
+                                                    <MenuItem Header="未ダウンロードの動画を選択解除する" Command="{Binding DisSelectAllNotDownloadedVideosCommand}"/>
+                                                    <MenuItem Header="ダウンロード済の動画を選択する" Command="{Binding SelectAllDownloadedVideosCommand}"/>
+                                                    <MenuItem Header="ダウンロード済の動画を選択解除する" Command="{Binding DisSelectAllDownloadedVideosCommand}"/>
+                                                </MenuItem>
+                                                <MenuItem Header="開く">
+                                                    <MenuItem Header="アプリで開く(A)" Command="{Binding OpenInPlayerAcommand}"
                                                           CommandParameter="{Binding PlacementTarget.DataContext,RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
-                                                <MenuItem Header="アプリで開く(B)" Command="{Binding OpenInPlayerBcommand}"
+                                                    <MenuItem Header="アプリで開く(B)" Command="{Binding OpenInPlayerBcommand}"
                                                           CommandParameter="{Binding PlacementTarget.DataContext,RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
-                                            </MenuItem>
-                                            <MenuItem Header="送る">
-                                                <MenuItem Header="アプリにURLを送る" Command="{Binding SendUrlToappCommand}"
+                                                </MenuItem>
+                                                <MenuItem Header="送る">
+                                                    <MenuItem Header="アプリにURLを送る" Command="{Binding SendUrlToappCommand}"
                                                           CommandParameter="{Binding PlacementTarget.DataContext,RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
-                                                <MenuItem Header="アプリにIDを送る" Command="{Binding SendIdToappCommand}"
+                                                    <MenuItem Header="アプリにIDを送る" Command="{Binding SendIdToappCommand}"
                                                           CommandParameter="{Binding PlacementTarget.DataContext,RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
                                             </MenuItem>
                                             <MenuItem Header="プレイリストを作成">
@@ -378,10 +380,11 @@
                             </StackPanel>
                             <TextBox Grid.Row="1" Text="{Binding Message,Mode=OneWay,UpdateSourceTrigger=PropertyChanged}" Padding="4" IsReadOnly="True"
                                          BorderThickness="0 1 0 0" TextWrapping="Wrap"/>
-                        </Grid>
-                    </TabItem>
-                </TabControl >
+                            </Grid>
+                        </TabItem>
+                    </TabControl >
+                </Grid>
             </Grid>
         </Grid>
-    </Grid>
+    </materialDesign:DialogHost>
 </Window>

--- a/Niconicome/Views/MainWindow.xaml.cs
+++ b/Niconicome/Views/MainWindow.xaml.cs
@@ -12,6 +12,7 @@ using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Navigation;
 using System.Windows.Shapes;
+using Niconicome.ViewModels.Mainpage;
 
 namespace Niconicome
 {
@@ -23,6 +24,8 @@ namespace Niconicome
         public MainWindow()
         {
             this.InitializeComponent();
+            this.downloadSettings.DataContext = new DownloadSettingsViewModel();
+            this.videoList.DataContext = new VideoListViewModel();
         }
 
         private void CheckBox_Checked(object sender, RoutedEventArgs e)

--- a/Niconicome/Views/Setting/Pages/AppinfoPage.xaml
+++ b/Niconicome/Views/Setting/Pages/AppinfoPage.xaml
@@ -167,6 +167,23 @@
                         </Hyperlink>
                             </TextBlock>
 
+                            <TextBlock Style="{StaticResource LicenseTitle}">
+                        <Hyperlink NavigateUri="https://github.com/dotnet/efcore/">
+                            <i:Interaction.Behaviors>
+                                <mainvm:HyperlinkBehavior/>
+                            </i:Interaction.Behaviors>
+                            Microsoft.Data.SQLite
+                        </Hyperlink>
+                            </TextBlock>
+                            <TextBlock Style="{StaticResource LicenseBlock}">
+                        <Hyperlink NavigateUri="https://github.com/dotnet/efcore/blob/main/LICENSE.txt">
+                            <i:Interaction.Behaviors>
+                                <mainvm:HyperlinkBehavior/>
+                            </i:Interaction.Behaviors>
+                            Read license on github.com
+                        </Hyperlink>
+                            </TextBlock>
+                            
                         </StackPanel>
                     </ScrollViewer>
                 </Expander>

--- a/Niconicome/Views/Setting/Pages/AppinfoPage.xaml
+++ b/Niconicome/Views/Setting/Pages/AppinfoPage.xaml
@@ -42,133 +42,135 @@
         <Border BorderThickness="0 0 0 1" BorderBrush="#e7e7e7">
             <TextBlock Text="アプリ情報" FontSize="24" Margin="16 0" VerticalAlignment="Bottom"/>
         </Border>
-        <StackPanel Margin="8" Grid.Row="1">
-            <DockPanel>
-                <materialDesign:PackIcon Kind="InfoCircle" Foreground="SkyBlue" VerticalAlignment="Center" >
-                    <materialDesign:PackIcon.RenderTransform>
-                        <ScaleTransform ScaleX="1.4" ScaleY="1.4" CenterY="9"/>
-                    </materialDesign:PackIcon.RenderTransform>
-                </materialDesign:PackIcon>
-                <Label Content="アプリケーションバージョン" Margin="4 0" FontSize="20"/>
-                <TextBlock Margin="5 0" VerticalAlignment="Center" Text="{Binding Version}" HorizontalAlignment="Right"/>
-            </DockPanel>
-            <Separator BorderThickness="1" BorderBrush="#e7e7e7" Margin="0 8"/>
-            <StackPanel Orientation="Horizontal">
-                <materialDesign:PackIcon Kind="Link" Foreground="SkyBlue" VerticalAlignment="Center" >
-                    <materialDesign:PackIcon.RenderTransform>
-                        <ScaleTransform ScaleX="1.6" ScaleY="1.6" CenterY="9"/>
-                    </materialDesign:PackIcon.RenderTransform>
-                </materialDesign:PackIcon>
-                <TextBlock Margin="10 0" Text="リンク"/>
-            </StackPanel>
-            <TextBlock Padding="20 0">
+        <ScrollViewer Grid.Row="1" Margin="8">
+            <StackPanel>
+                <DockPanel>
+                    <materialDesign:PackIcon Kind="InfoCircle" Foreground="SkyBlue" VerticalAlignment="Center" >
+                        <materialDesign:PackIcon.RenderTransform>
+                            <ScaleTransform ScaleX="1.4" ScaleY="1.4" CenterY="9"/>
+                        </materialDesign:PackIcon.RenderTransform>
+                    </materialDesign:PackIcon>
+                    <Label Content="アプリケーションバージョン" Margin="4 0" FontSize="20"/>
+                    <TextBlock Margin="5 0" VerticalAlignment="Center" Text="{Binding Version}" HorizontalAlignment="Right"/>
+                </DockPanel>
+                <Separator BorderThickness="1" BorderBrush="#e7e7e7" Margin="0 8"/>
+                <StackPanel Orientation="Horizontal">
+                    <materialDesign:PackIcon Kind="Link" Foreground="SkyBlue" VerticalAlignment="Center" >
+                        <materialDesign:PackIcon.RenderTransform>
+                            <ScaleTransform ScaleX="1.6" ScaleY="1.6" CenterY="9"/>
+                        </materialDesign:PackIcon.RenderTransform>
+                    </materialDesign:PackIcon>
+                    <TextBlock Margin="10 0" Text="リンク"/>
+                </StackPanel>
+                <TextBlock Padding="20 0">
                 <Hyperlink NavigateUri="https://github.com/Hayao-H/Niconicome"><i:Interaction.Behaviors><mainvm:HyperlinkBehavior/></i:Interaction.Behaviors>プロジェクトページ</Hyperlink><LineBreak/>
                 <Hyperlink NavigateUri="https://join.slack.com/t/niconicome/shared_invite/zt-m6lkfs8x-FOFfXexhB0JlhnUVps0qEA"><i:Interaction.Behaviors><mainvm:HyperlinkBehavior/></i:Interaction.Behaviors>Slack</Hyperlink><LineBreak/>
                 <Hyperlink NavigateUri="https://twitter.com/NiconicomeD"><i:Interaction.Behaviors><mainvm:HyperlinkBehavior/></i:Interaction.Behaviors>Twitter</Hyperlink><LineBreak/>
                 <Hyperlink NavigateUri="https://github.com/Hayao-H/Niconicome/wiki"><i:Interaction.Behaviors><mainvm:HyperlinkBehavior/></i:Interaction.Behaviors>wiki</Hyperlink>
-            </TextBlock>
-            <Separator BorderThickness="1" BorderBrush="#e7e7e7" Margin="0 8"/>
-            <Expander>
-                <Expander.Header>
-                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                        <materialDesign:PackIcon Kind="License" Foreground="SkyBlue">
-                            <materialDesign:PackIcon.RenderTransform>
-                                <TranslateTransform Y="1"/>
-                            </materialDesign:PackIcon.RenderTransform>
-                        </materialDesign:PackIcon>
-                        <TextBlock Text="ライセンス情報"/>
-                    </StackPanel>
-                </Expander.Header>
-                <ScrollViewer VerticalScrollBarVisibility="Visible" Height="430">
-                    <StackPanel>
-                        <TextBlock Style="{StaticResource LicenseTitle}">
+                </TextBlock>
+                <Separator BorderThickness="1" BorderBrush="#e7e7e7" Margin="0 8"/>
+                <Expander>
+                    <Expander.Header>
+                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                            <materialDesign:PackIcon Kind="License" Foreground="SkyBlue">
+                                <materialDesign:PackIcon.RenderTransform>
+                                    <TranslateTransform Y="1"/>
+                                </materialDesign:PackIcon.RenderTransform>
+                            </materialDesign:PackIcon>
+                            <TextBlock Text="ライセンス情報"/>
+                        </StackPanel>
+                    </Expander.Header>
+                    <ScrollViewer VerticalScrollBarVisibility="Visible" Height="430">
+                        <StackPanel>
+                            <TextBlock Style="{StaticResource LicenseTitle}">
                         <Hyperlink NavigateUri="http://materialdesigninxaml.net/">
                             <i:Interaction.Behaviors>
                                 <mainvm:HyperlinkBehavior/>
                             </i:Interaction.Behaviors>
                             MaterialDesignInXamlToolkit
                         </Hyperlink>
-                        </TextBlock>
-                        <TextBlock Style="{StaticResource LicenseBlock}">
+                            </TextBlock>
+                            <TextBlock Style="{StaticResource LicenseBlock}">
                         <Hyperlink NavigateUri="https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/blob/master/LICENSE">
                             <i:Interaction.Behaviors>
                                 <mainvm:HyperlinkBehavior/>
                             </i:Interaction.Behaviors>
                             Read license on github.com
                         </Hyperlink>
-                        </TextBlock>
-                        
-                        <TextBlock Style="{StaticResource LicenseTitle}">
+                            </TextBlock>
+
+                            <TextBlock Style="{StaticResource LicenseTitle}">
                         <Hyperlink NavigateUri="https://github.com/ilyalozovyy/credentialmanagement">
                             <i:Interaction.Behaviors>
                                 <mainvm:HyperlinkBehavior/>
                             </i:Interaction.Behaviors>
                             credentialmanagement
                         </Hyperlink>
-                        </TextBlock>
-                        <TextBlock Style="{StaticResource LicenseBlock}">
+                            </TextBlock>
+                            <TextBlock Style="{StaticResource LicenseBlock}">
                         <Hyperlink NavigateUri="https://github.com/ilyalozovyy/credentialmanagement/blob/master/LICENSE">
                             <i:Interaction.Behaviors>
                                 <mainvm:HyperlinkBehavior/>
                             </i:Interaction.Behaviors>
                             Read license on github.com
                         </Hyperlink>
-                        </TextBlock>
-                        
-                        <TextBlock Style="{StaticResource LicenseTitle}">
+                            </TextBlock>
+
+                            <TextBlock Style="{StaticResource LicenseTitle}">
                         <Hyperlink NavigateUri="https://github.com/contre/Windows-API-Code-Pack-1.1">
                             <i:Interaction.Behaviors>
                                 <mainvm:HyperlinkBehavior/>
                             </i:Interaction.Behaviors>
                             Windows-API-Code-Pack-1.1
                         </Hyperlink>
-                        </TextBlock>
-                        <TextBlock Style="{StaticResource LicenseBlock}">
+                            </TextBlock>
+                            <TextBlock Style="{StaticResource LicenseBlock}">
                         <Hyperlink NavigateUri="https://github.com/aybe/Windows-API-Code-Pack-1.1/blob/master/LICENCE">
                             <i:Interaction.Behaviors>
                                 <mainvm:HyperlinkBehavior/>
                             </i:Interaction.Behaviors>
                             Read license on github.com
                         </Hyperlink>
-                        </TextBlock>
+                            </TextBlock>
 
-                        <TextBlock Style="{StaticResource LicenseTitle}">
+                            <TextBlock Style="{StaticResource LicenseTitle}">
                         <Hyperlink NavigateUri="https://www.litedb.org/">
                             <i:Interaction.Behaviors>
                                 <mainvm:HyperlinkBehavior/>
                             </i:Interaction.Behaviors>
                             LiteDB
                         </Hyperlink>
-                        </TextBlock>
-                        <TextBlock Style="{StaticResource LicenseBlock}">
+                            </TextBlock>
+                            <TextBlock Style="{StaticResource LicenseBlock}">
                         <Hyperlink NavigateUri="https://github.com/mbdavid/LiteDB/blob/master/LICENSE">
                             <i:Interaction.Behaviors>
                                 <mainvm:HyperlinkBehavior/>
                             </i:Interaction.Behaviors>
                             Read license on github.com
                         </Hyperlink>
-                        </TextBlock>
+                            </TextBlock>
 
-                        <TextBlock Style="{StaticResource LicenseTitle}">
+                            <TextBlock Style="{StaticResource LicenseTitle}">
                         <Hyperlink NavigateUri="https://anglesharp.github.io/">
                             <i:Interaction.Behaviors>
                                 <mainvm:HyperlinkBehavior/>
                             </i:Interaction.Behaviors>
                             AngleSharp
                         </Hyperlink>
-                        </TextBlock>
-                        <TextBlock Style="{StaticResource LicenseBlock}">
+                            </TextBlock>
+                            <TextBlock Style="{StaticResource LicenseBlock}">
                         <Hyperlink NavigateUri="https://github.com/AngleSharp/AngleSharp/blob/master/LICENSE">
                             <i:Interaction.Behaviors>
                                 <mainvm:HyperlinkBehavior/>
                             </i:Interaction.Behaviors>
                             Read license on github.com
                         </Hyperlink>
-                        </TextBlock>
+                            </TextBlock>
 
-                    </StackPanel>
-                </ScrollViewer>
-            </Expander>
-        </StackPanel>
+                        </StackPanel>
+                    </ScrollViewer>
+                </Expander>
+            </StackPanel>
+        </ScrollViewer>
     </Grid>
 </Page>

--- a/Niconicome/Views/Setting/Pages/DownloadSettingPage.xaml
+++ b/Niconicome/Views/Setting/Pages/DownloadSettingPage.xaml
@@ -38,16 +38,6 @@
                 <TextBox HorizontalAlignment="Right" Margin="10 0" Width="60" Text="{Binding CommentOffsetFIeld,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}" HorizontalContentAlignment="Right"/>
             </DockPanel>
             <Separator BorderThickness="1" BorderBrush="#e7e7e7" Margin="0 8"/>
-             <DockPanel Visibility="Collapsed">
-                <materialDesign:PackIcon Kind="AutoFix" Foreground="SkyBlue">
-                    <materialDesign:PackIcon.RenderTransform>
-                        <TranslateTransform Y="7"/>
-                    </materialDesign:PackIcon.RenderTransform>
-                </materialDesign:PackIcon>
-                <Label Content="公式動画でコメントのオフセットを無効にする(推奨)"/>
-                <ToggleButton HorizontalAlignment="Right" Margin="10 0" IsChecked="{Binding IsAutoSwitchOffsetEnable}"/>
-            </DockPanel>
-            <Separator BorderThickness="1" BorderBrush="#e7e7e7" Margin="0 8"/>
             <DockPanel>
                 <materialDesign:PackIcon Kind="DownloadMultiple" Foreground="SkyBlue">
                     <materialDesign:PackIcon.RenderTransform>
@@ -55,7 +45,7 @@
                     </materialDesign:PackIcon.RenderTransform>
                 </materialDesign:PackIcon>
                 <Label Content="最大並列ダウンロード数" ToolTip="大きなすぎる場合、失敗する確率が高くなります"/>
-                <TextBox Text="{Binding MaxParallelDownloadCount,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}" HorizontalAlignment="Right" Margin="10 0" Width="60" HorizontalContentAlignment="Right" />
+                <ComboBox SelectedItem="{Binding MaxParallelDownloadCount,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}" HorizontalAlignment="Right" Margin="10 0" Width="60" HorizontalContentAlignment="Right" ItemsSource="{Binding SelectableMaxParallelDownloadCount}" DisplayMemberPath="DisplayValue"/>
             </DockPanel>
             <Separator BorderThickness="1" BorderBrush="#e7e7e7" Margin="0 8"/>
             <DockPanel>
@@ -65,7 +55,7 @@
                     </materialDesign:PackIcon.RenderTransform>
                 </materialDesign:PackIcon>
                 <Label Content="HLSセグメントファイルの最大並列ダウンロード数（推奨値：1）" />
-                <TextBox Text="{Binding MaxParallelSegmentDownloadCount,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}" HorizontalAlignment="Right" Margin="10 0" Width="60" HorizontalContentAlignment="Right" />
+                <ComboBox SelectedItem="{Binding MaxParallelSegmentDownloadCount,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}" HorizontalAlignment="Right" Margin="10 0" Width="60" HorizontalContentAlignment="Right" ItemsSource="{Binding SelectableMaxParallelDownloadCount}" DisplayMemberPath="DisplayValue" />
             </DockPanel>
             <Separator BorderThickness="1" BorderBrush="#e7e7e7" Margin="0 8"/>
             <DockPanel>
@@ -99,7 +89,7 @@
             </DockPanel>
             <Separator BorderThickness="1" BorderBrush="#e7e7e7" Margin="0 8"/>
             <DockPanel>
-                <materialDesign:PackIcon Kind="SortCalendarDescending" Foreground="SkyBlue">
+                <materialDesign:PackIcon Kind="CodeJson" Foreground="SkyBlue">
                     <materialDesign:PackIcon.RenderTransform>
                         <TranslateTransform Y="7"/>
                     </materialDesign:PackIcon.RenderTransform>

--- a/Niconicome/Views/Setting/Pages/DownloadSettingPage.xaml
+++ b/Niconicome/Views/Setting/Pages/DownloadSettingPage.xaml
@@ -97,6 +97,16 @@
                 <Label Content="動画ファイルの更新日時を投稿日時にする" />
                 <ToggleButton IsChecked="{Binding IsOverrideVideoFileDTToUploadedDT}" HorizontalAlignment="Right" Margin="10 0" Width="60" HorizontalContentAlignment="Right" />
             </DockPanel>
+            <Separator BorderThickness="1" BorderBrush="#e7e7e7" Margin="0 8"/>
+            <DockPanel>
+                <materialDesign:PackIcon Kind="SortCalendarDescending" Foreground="SkyBlue">
+                    <materialDesign:PackIcon.RenderTransform>
+                        <TranslateTransform Y="7"/>
+                    </materialDesign:PackIcon.RenderTransform>
+                </materialDesign:PackIcon>
+                <Label Content="動画情報ファイルの保存形式をJSONにする" />
+                <ToggleButton IsChecked="{Binding IsDownloadVideoInfoInJsonEnable}" HorizontalAlignment="Right" Margin="10 0" Width="60" HorizontalContentAlignment="Right" />
+            </DockPanel>
         </StackPanel>
 
 

--- a/Niconicome/Views/Setting/Pages/DownloadSettingPage.xaml
+++ b/Niconicome/Views/Setting/Pages/DownloadSettingPage.xaml
@@ -25,7 +25,7 @@
             <RowDefinition Height="15*"/>
         </Grid.RowDefinitions>
         <Border BorderThickness="0 0 0 1" BorderBrush="#e7e7e7">
-            <TextBlock Text="ダウンドード設定" FontSize="24" Margin="16 0" VerticalAlignment="Bottom"/>
+            <TextBlock Text="ダウンロード設定" FontSize="24" Margin="16 0" VerticalAlignment="Bottom"/>
         </Border>
         <StackPanel Margin="8" Grid.Row="1">
             <DockPanel>

--- a/Niconicome/Views/Setting/Pages/DownloadSettingPage.xaml
+++ b/Niconicome/Views/Setting/Pages/DownloadSettingPage.xaml
@@ -87,6 +87,16 @@
                 <Label Content="ステージ時の重複（同一プレイリスト内での登録）を許可する（非推奨）" ToolTip="無効にするとひとつのプレイリストから同じ動画を同時にDLすることが出来ません" />
                 <ToggleButton IsChecked="{Binding IsDupeOnStageAllowed}" HorizontalAlignment="Right" Margin="10 0" Width="60" HorizontalContentAlignment="Right" />
             </DockPanel>
+            <Separator BorderThickness="1" BorderBrush="#e7e7e7" Margin="0 8"/>
+            <DockPanel>
+                <materialDesign:PackIcon Kind="SortCalendarDescending" Foreground="SkyBlue">
+                    <materialDesign:PackIcon.RenderTransform>
+                        <TranslateTransform Y="7"/>
+                    </materialDesign:PackIcon.RenderTransform>
+                </materialDesign:PackIcon>
+                <Label Content="動画ファイルの更新日時を投稿日時にする" />
+                <ToggleButton IsChecked="{Binding IsOverrideVideoFileDTToUploadedDT}" HorizontalAlignment="Right" Margin="10 0" Width="60" HorizontalContentAlignment="Right" />
+            </DockPanel>
         </StackPanel>
 
 

--- a/Niconicome/Views/Setting/Pages/DownloadSettingPage.xaml
+++ b/Niconicome/Views/Setting/Pages/DownloadSettingPage.xaml
@@ -35,10 +35,10 @@
                     </materialDesign:PackIcon.RenderTransform>
                 </materialDesign:PackIcon>
                 <Label Content="コメントのオフセット"/>
-                <TextBox HorizontalAlignment="Right" Margin="10 0" Width="60" Text="{Binding CommentOffsetFIeld,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}"/>
+                <TextBox HorizontalAlignment="Right" Margin="10 0" Width="60" Text="{Binding CommentOffsetFIeld,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}" HorizontalContentAlignment="Right"/>
             </DockPanel>
             <Separator BorderThickness="1" BorderBrush="#e7e7e7" Margin="0 8"/>
-             <DockPanel Visibility="Hidden">
+             <DockPanel Visibility="Collapsed">
                 <materialDesign:PackIcon Kind="AutoFix" Foreground="SkyBlue">
                     <materialDesign:PackIcon.RenderTransform>
                         <TranslateTransform Y="7"/>
@@ -46,6 +46,26 @@
                 </materialDesign:PackIcon>
                 <Label Content="公式動画でコメントのオフセットを無効にする(推奨)"/>
                 <ToggleButton HorizontalAlignment="Right" Margin="10 0" IsChecked="{Binding IsAutoSwitchOffsetEnable}"/>
+            </DockPanel>
+            <Separator BorderThickness="1" BorderBrush="#e7e7e7" Margin="0 8"/>
+            <DockPanel>
+                <materialDesign:PackIcon Kind="DownloadMultiple" Foreground="SkyBlue">
+                    <materialDesign:PackIcon.RenderTransform>
+                        <TranslateTransform Y="7"/>
+                    </materialDesign:PackIcon.RenderTransform>
+                </materialDesign:PackIcon>
+                <Label Content="最大並列ダウンロード数" ToolTip="大きなすぎる場合、失敗する確率が高くなります"/>
+                <TextBox Text="{Binding MaxParallelDownloadCount,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}" HorizontalAlignment="Right" Margin="10 0" Width="60" HorizontalContentAlignment="Right" />
+            </DockPanel>
+            <Separator BorderThickness="1" BorderBrush="#e7e7e7" Margin="0 8"/>
+            <DockPanel>
+                <materialDesign:PackIcon Kind="DownloadMultiple" Foreground="SkyBlue">
+                    <materialDesign:PackIcon.RenderTransform>
+                        <TranslateTransform Y="7"/>
+                    </materialDesign:PackIcon.RenderTransform>
+                </materialDesign:PackIcon>
+                <Label Content="HLSセグメントファイルの最大並列ダウンロード数（推奨値：1）" />
+                <TextBox Text="{Binding MaxParallelSegmentDownloadCount,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}" HorizontalAlignment="Right" Margin="10 0" Width="60" HorizontalContentAlignment="Right" />
             </DockPanel>
             <Separator BorderThickness="1" BorderBrush="#e7e7e7" Margin="0 8"/>
         </StackPanel>

--- a/Niconicome/Views/Setting/Pages/DownloadSettingPage.xaml
+++ b/Niconicome/Views/Setting/Pages/DownloadSettingPage.xaml
@@ -68,6 +68,25 @@
                 <TextBox Text="{Binding MaxParallelSegmentDownloadCount,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}" HorizontalAlignment="Right" Margin="10 0" Width="60" HorizontalContentAlignment="Right" />
             </DockPanel>
             <Separator BorderThickness="1" BorderBrush="#e7e7e7" Margin="0 8"/>
+            <DockPanel>
+                <materialDesign:PackIcon Kind="Queue" Foreground="SkyBlue">
+                    <materialDesign:PackIcon.RenderTransform>
+                        <TranslateTransform Y="7"/>
+                    </materialDesign:PackIcon.RenderTransform>
+                </materialDesign:PackIcon>
+                <Label Content="メインページのダウンロードボタンでキューのタスク全てをDLする" ToolTip="無効にすると現在のプレイリストの動画のみDLします" />
+                <ToggleButton IsChecked="{Binding IsDownloadFromQueueEnable}" HorizontalAlignment="Right" Margin="10 0" Width="60" HorizontalContentAlignment="Right" />
+            </DockPanel>
+            <Separator BorderThickness="1" BorderBrush="#e7e7e7" Margin="0 8"/>
+            <DockPanel>
+                <materialDesign:PackIcon Kind="ContentCopy" Foreground="SkyBlue">
+                    <materialDesign:PackIcon.RenderTransform>
+                        <TranslateTransform Y="7"/>
+                    </materialDesign:PackIcon.RenderTransform>
+                </materialDesign:PackIcon>
+                <Label Content="ステージ時の重複（同一プレイリスト内での登録）を許可する（非推奨）" ToolTip="無効にするとひとつのプレイリストから同じ動画を同時にDLすることが出来ません" />
+                <ToggleButton IsChecked="{Binding IsDupeOnStageAllowed}" HorizontalAlignment="Right" Margin="10 0" Width="60" HorizontalContentAlignment="Right" />
+            </DockPanel>
         </StackPanel>
 
 

--- a/Niconicome/Views/Setting/Pages/FileSettingsPage.xaml
+++ b/Niconicome/Views/Setting/Pages/FileSettingsPage.xaml
@@ -14,11 +14,9 @@
         TextOptions.TextRenderingMode="Auto"
         Background="{DynamicResource MaterialDesignBackground}"
         FontFamily="Yu Gothic"
+        d:DataContext="{d:DesignInstance {x:Type vm:FileSettingsViewModelD},IsDesignTimeCreatable=True}"
       d:DesignHeight="450" d:DesignWidth="800"
       Title="ファイル設定">
-    <Page.DataContext>
-        <vm:FileSettingsViewModel/>
-    </Page.DataContext>
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="1*"/>
@@ -54,7 +52,7 @@
                     ※「\」でフォルダーを作成します。[&lt;id&gt;]&lt;title&gt;でxenoのデフォルトと同じフォーマットになります。
                 </TextBlock>
             </StackPanel>
-            <Separator BorderThickness="1" BorderBrush="#e7e7e7"/>
+            <Separator BorderThickness="1" BorderBrush="#e7e7e7" Margin="0 8"/>
             <StackPanel>
                 <StackPanel Orientation="Horizontal">
                     <materialDesign:PackIcon Kind="ContentSave" Foreground="SkyBlue">
@@ -66,7 +64,17 @@
                 </StackPanel>
                 <TextBox Margin="10 0 0 0" Text="{Binding DefaultFolder,Mode=TwoWay,UpdateSourceTrigger=LostFocus}" x:Name="defaultfolder"/>
             </StackPanel>
-            <Separator BorderThickness="1" BorderBrush="#e7e7e7"/>
+            <Separator BorderThickness="1" BorderBrush="#e7e7e7" Margin="0 8"/>
+            <DockPanel>
+                <materialDesign:PackIcon Kind="FindReplace" Foreground="SkyBlue">
+                    <materialDesign:PackIcon.RenderTransform>
+                        <TranslateTransform Y="7"/>
+                    </materialDesign:PackIcon.RenderTransform>
+                </materialDesign:PackIcon>
+                <Label Content="禁則文字をマルチバイト文字に置き換える" />
+                <ToggleButton IsChecked="{Binding IsReplaceSBToSBEnable,UpdateSourceTrigger=PropertyChanged}" HorizontalAlignment="Right"/>
+            </DockPanel>
+            <Separator BorderThickness="1" BorderBrush="#e7e7e7" Margin="0 8"/>
         </StackPanel>
     </Grid>
 </Page>

--- a/Niconicome/Views/Setting/Pages/FileSettingsPage.xaml
+++ b/Niconicome/Views/Setting/Pages/FileSettingsPage.xaml
@@ -48,7 +48,9 @@
                     &lt;title&gt; :動画タイトル,
                     &lt;id&gt; :動画ID,
                     &lt;uploadedon&gt; :投稿日時,<LineBreak/>
+                    &lt;downloadon&gt; :DL日時<LineBreak/>
                     &lt;owner&gt; :投稿者のニックネーム<LineBreak/>
+                    ※カスタム書式を利用できます。詳しくはwikiをご覧ください。<LineBreak/>
                     ※「\」でフォルダーを作成します。[&lt;id&gt;]&lt;title&gt;でxenoのデフォルトと同じフォーマットになります。
                 </TextBlock>
             </StackPanel>

--- a/Niconicome/Views/Setting/Pages/FileSettingsPage.xaml.cs
+++ b/Niconicome/Views/Setting/Pages/FileSettingsPage.xaml.cs
@@ -1,17 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
+﻿using System.Windows.Controls;
+using Niconicome.ViewModels.Setting.Pages;
 
 namespace Niconicome.Views.Setting.Pages
 {
@@ -22,7 +10,8 @@ namespace Niconicome.Views.Setting.Pages
     {
         public FileSettingsPage()
         {
-            InitializeComponent();
+            this.InitializeComponent();
+            this.DataContext = new FileSettingsViewModel();
         }
     }
 }

--- a/Niconicome/Views/Setting/Pages/GeneralPage.xaml
+++ b/Niconicome/Views/Setting/Pages/GeneralPage.xaml
@@ -68,6 +68,16 @@
                 <ComboBox SelectedItem="{Binding FetchSleepInterval,UpdateSourceTrigger=PropertyChanged}" ItemsSource="{Binding SelectablefetchSleepInterval}" DisplayMemberPath="DisplayValue" HorizontalContentAlignment="Right" HorizontalAlignment="Right" Width="100"/>
             </DockPanel>
             <Separator BorderThickness="1" BorderBrush="#e7e7e7" Margin="0 8"/>
+            <DockPanel>
+                <materialDesign:PackIcon Kind="ShieldOff" Foreground="SkyBlue">
+                    <materialDesign:PackIcon.RenderTransform>
+                        <TranslateTransform Y="7"/>
+                    </materialDesign:PackIcon.RenderTransform>
+                </materialDesign:PackIcon>
+                <Label Content="SSL証明書の検証をスキップする(強く非推奨)" ToolTip="安全性が著しく低下します。ほかの回避手段がない場合にのみ有効にしてください。"/>
+                <ToggleButton HorizontalAlignment="Right" IsChecked="{Binding IsSkippingSSLVerificationEnable}"/>
+            </DockPanel>
+            <Separator BorderThickness="1" BorderBrush="#e7e7e7" Margin="0 8"/>
         </StackPanel>
         
     </Grid>

--- a/Niconicome/Views/Setting/Pages/GeneralPage.xaml
+++ b/Niconicome/Views/Setting/Pages/GeneralPage.xaml
@@ -1,0 +1,54 @@
+﻿<Page x:Class="Niconicome.Views.Setting.Pages.GeneralPage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+      xmlns:local="clr-namespace:Niconicome.Views.Setting.Pages"
+        xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+        xmlns:vm="clr-namespace:Niconicome.ViewModels.Setting.Pages"
+        xmlns:mainvm ="clr-namespace:Niconicome.ViewModels.Setting"
+        xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
+        mc:Ignorable="d"
+        TextElement.Foreground="{DynamicResource MaterialDesignBody}"
+        TextElement.FontWeight="Regular"
+        TextElement.FontSize="13"
+        TextOptions.TextFormattingMode="Ideal"
+        TextOptions.TextRenderingMode="Auto"
+        Background="{DynamicResource MaterialDesignBackground}"
+        d:DataContext="{d:DesignInstance {x:Type vm:GeneralSettingsPageViewModelD},IsDesignTimeCreatable=True}"
+        FontFamily="Yu Gothic"
+      d:DesignHeight="450" d:DesignWidth="800"
+      Title="GeneralPage">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="1*"/>
+            <RowDefinition Height="15*"/>
+        </Grid.RowDefinitions>
+        <Border BorderThickness="0 0 0 1" BorderBrush="#e7e7e7">
+            <TextBlock Text="一般設定" FontSize="24" Margin="16 0" VerticalAlignment="Bottom"/>
+        </Border>
+        <StackPanel Margin="8" Grid.Row="1">
+            <DockPanel>
+                <materialDesign:PackIcon Kind="AccountArrowLeftOutline" Foreground="SkyBlue">
+                    <materialDesign:PackIcon.RenderTransform>
+                        <TranslateTransform Y="7"/>
+                    </materialDesign:PackIcon.RenderTransform>
+                </materialDesign:PackIcon>
+                <Label Content="自動ログイン" ToolTip="アプリケーション起動時にニコニコへのログインを自動で試行します。"/>
+                <ToggleButton HorizontalAlignment="Right" IsChecked="{Binding IsAutologinEnable}"/>
+            </DockPanel>
+            <Separator BorderThickness="1" BorderBrush="#e7e7e7" Margin="0 8"/>
+            <DockPanel>
+                <materialDesign:PackIcon Kind="AccountCog" Foreground="SkyBlue">
+                    <materialDesign:PackIcon.RenderTransform>
+                        <TranslateTransform Y="7"/>
+                    </materialDesign:PackIcon.RenderTransform>
+                </materialDesign:PackIcon>
+                <Label Content="自動ログインの種別"/>
+                <ComboBox HorizontalAlignment="Right" Width="300" ItemsSource="{Binding SelectableAutoLoginTypes}" SelectedItem="{Binding SelectedAutoLoginType}" DisplayMemberPath="DisplayValue"/>
+            </DockPanel>
+            <Separator BorderThickness="1" BorderBrush="#e7e7e7" Margin="0 8"/>
+        </StackPanel>
+        
+    </Grid>
+</Page>

--- a/Niconicome/Views/Setting/Pages/GeneralPage.xaml
+++ b/Niconicome/Views/Setting/Pages/GeneralPage.xaml
@@ -48,6 +48,26 @@
                 <ComboBox HorizontalAlignment="Right" Width="300" ItemsSource="{Binding SelectableAutoLoginTypes}" SelectedItem="{Binding SelectedAutoLoginType}" DisplayMemberPath="DisplayValue"/>
             </DockPanel>
             <Separator BorderThickness="1" BorderBrush="#e7e7e7" Margin="0 8"/>
+            <DockPanel>
+                <materialDesign:PackIcon Kind="DownloadNetwork" Foreground="SkyBlue">
+                    <materialDesign:PackIcon.RenderTransform>
+                        <TranslateTransform Y="7"/>
+                    </materialDesign:PackIcon.RenderTransform>
+                </materialDesign:PackIcon>
+                <Label Content="動画情報取得時の並列取得数"/>
+                <ComboBox SelectedItem="{Binding MaxFetchParallelCount,UpdateSourceTrigger=PropertyChanged}" ItemsSource="{Binding SelectableMaxParallelFetch}" DisplayMemberPath="DisplayValue" HorizontalContentAlignment="Right" HorizontalAlignment="Right" Width="100"/>
+            </DockPanel>
+            <Separator BorderThickness="1" BorderBrush="#e7e7e7" Margin="0 8"/>
+            <DockPanel>
+                <materialDesign:PackIcon Kind="Sleep" Foreground="SkyBlue">
+                    <materialDesign:PackIcon.RenderTransform>
+                        <TranslateTransform Y="7"/>
+                    </materialDesign:PackIcon.RenderTransform>
+                </materialDesign:PackIcon>
+                <Label Content="動画情報取得時の待機間隔(動画数)"/>
+                <ComboBox SelectedItem="{Binding FetchSleepInterval,UpdateSourceTrigger=PropertyChanged}" ItemsSource="{Binding SelectablefetchSleepInterval}" DisplayMemberPath="DisplayValue" HorizontalContentAlignment="Right" HorizontalAlignment="Right" Width="100"/>
+            </DockPanel>
+            <Separator BorderThickness="1" BorderBrush="#e7e7e7" Margin="0 8"/>
         </StackPanel>
         
     </Grid>

--- a/Niconicome/Views/Setting/Pages/GeneralPage.xaml.cs
+++ b/Niconicome/Views/Setting/Pages/GeneralPage.xaml.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+using Niconicome.ViewModels.Setting.Pages;
+
+namespace Niconicome.Views.Setting.Pages
+{
+    /// <summary>
+    /// GeneralPage.xaml の相互作用ロジック
+    /// </summary>
+    public partial class GeneralPage : Page
+    {
+        public GeneralPage()
+        {
+            this.InitializeComponent();
+            this.DataContext = new GeneralSettingsPageViewModel();
+        }
+    }
+}

--- a/Niconicome/Views/Setting/SettingWindow.xaml
+++ b/Niconicome/Views/Setting/SettingWindow.xaml
@@ -31,6 +31,16 @@
                 </i:Interaction.Behaviors>
                 <Border BorderThickness="6 0 0 0" Padding="5 4">
                     <DockPanel>
+                        <materialDesign:PackIcon Kind="CogOutline" Foreground="#898989">
+                            <materialDesign:PackIcon.RenderTransform>
+                                <ScaleTransform ScaleX="1.4" ScaleY="1.4" CenterY="-15"/>
+                            </materialDesign:PackIcon.RenderTransform>
+                        </materialDesign:PackIcon>
+                        <TextBlock Padding="8 2 0 0" Text="一般設定" FontSize="20" Cursor="Hand"/>
+                    </DockPanel>
+                </Border>
+                <Border BorderThickness="6 0 0 0" Padding="5 4">
+                    <DockPanel>
                         <materialDesign:PackIcon Kind="File" Foreground="#898989">
                             <materialDesign:PackIcon.RenderTransform>
                                 <ScaleTransform ScaleX="1.4" ScaleY="1.4" CenterY="-15"/>

--- a/Niconicome/Workspaces/LoginPage.cs
+++ b/Niconicome/Workspaces/LoginPage.cs
@@ -6,12 +6,13 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Utils = Niconicome.Models.Domain.Utils;
 using Auth = Niconicome.Models.Auth;
+using Niconico = Niconicome.Models.Domain.Niconico;
 
 namespace Niconicome.Workspaces
 {
     class LoginPage
     {
-        public static Auth::IAccountManager AccountManager { get; private set; } = Utils::DIFactory.Provider.GetRequiredService<Auth::IAccountManager>();
+        public static Niconico::IAccountManager AccountManager { get; private set; } = Utils::DIFactory.Provider.GetRequiredService<Niconico::IAccountManager>();
         public static Auth::ISession Session { get; private set; } = Utils::DIFactory.Provider.GetRequiredService<Auth::ISession>();
     }
 }

--- a/Niconicome/Workspaces/Mainpage.cs
+++ b/Niconicome/Workspaces/Mainpage.cs
@@ -28,5 +28,6 @@ namespace Niconicome.Workspaces
         public static ISnackbarHandler SnaclbarHandler { get; private set; } = DIFactory.Provider.GetRequiredService<ISnackbarHandler>();
         public static IShutdown Shutdown { get; private set; } = DIFactory.Provider.GetRequiredService<IShutdown>();
         public static IStartUp StartUp { get; private set; } = DIFactory.Provider.GetRequiredService<IStartUp>();
+        public static IVideoIDHandler VideoIDHandler { get; private set; } = DIFactory.Provider.GetRequiredService<IVideoIDHandler>();
     }
 }

--- a/Niconicome/Workspaces/Mainpage.cs
+++ b/Niconicome/Workspaces/Mainpage.cs
@@ -25,7 +25,8 @@ namespace Niconicome.Workspaces
         public static IVideoFilter VideoFilter { get; private set; } = DIFactory.Provider.GetRequiredService<IVideoFilter>();
         public static ILocalSettingHandler SettingHandler { get; private set; } = DIFactory.Provider.GetRequiredService<ILocalSettingHandler>();
         public static IPlaylistCreator PlaylistCreator { get; private set; } = DIFactory.Provider.GetRequiredService<IPlaylistCreator>();
-        public static MaterialDesign::SnackbarMessageQueue SnackbarMessageQueue { get; private set; } = new MaterialDesign::SnackbarMessageQueue();
+        public static ISnackbarHandler SnaclbarHandler { get; private set; } = DIFactory.Provider.GetRequiredService<ISnackbarHandler>();
         public static IShutdown Shutdown { get; private set; } = DIFactory.Provider.GetRequiredService<IShutdown>();
+        public static IStartUp StartUp { get; private set; } = DIFactory.Provider.GetRequiredService<IStartUp>();
     }
 }

--- a/Niconicome/Workspaces/Mainpage.cs
+++ b/Niconicome/Workspaces/Mainpage.cs
@@ -7,6 +7,7 @@ using Niconicome.Models.Local;
 using MaterialDesign = MaterialDesignThemes.Wpf;
 using Niconicome.Models.Local.Application;
 using Niconicome.Models.Local.State;
+using Niconicome.Models.Network.Download;
 
 namespace Niconicome.Workspaces
 {
@@ -29,5 +30,6 @@ namespace Niconicome.Workspaces
         public static IShutdown Shutdown { get; private set; } = DIFactory.Provider.GetRequiredService<IShutdown>();
         public static IStartUp StartUp { get; private set; } = DIFactory.Provider.GetRequiredService<IStartUp>();
         public static IVideoIDHandler VideoIDHandler { get; private set; } = DIFactory.Provider.GetRequiredService<IVideoIDHandler>();
+        public static IDownloadTasksHandler DownloadTasksHandler { get; private set; } = DIFactory.Provider.GetRequiredService<IDownloadTasksHandler>();
     }
 }

--- a/NiconicomeTest/Local/Cookies/BrowserCookieUnitTest.cs
+++ b/NiconicomeTest/Local/Cookies/BrowserCookieUnitTest.cs
@@ -1,0 +1,25 @@
+﻿using Niconicome.Models.Domain.Local.SQLite;
+using NiconicomeTest.Stabs.Models.Domain.Utils;
+using NUnit.Framework;
+
+namespace NiconicomeTest.Local.Cookies
+{
+    class BrowserCookieUnitTest
+    {
+        private ISqliteCookieLoader? loader;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.loader = new SqliteCookieLoader(new SQliteLoader(new LoggerStab()));
+        }
+
+        [Test]
+        public void ファイル名を取得()
+        {
+            var wv2 = this.loader!.GetCookiePath(CookieType.Webview2);
+
+            Assert.That(wv2, Is.EqualTo(@"Niconicome.exe.WebView2\EBWebView\Default\Cookies"));
+        }
+    }
+}

--- a/NiconicomeTest/Local/Cookies/LocalStateUnitTest.cs
+++ b/NiconicomeTest/Local/Cookies/LocalStateUnitTest.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Niconicome.Models.Domain.Local.LocalFile;
+using Niconicome.Models.Domain.Local.SQLite;
+using NiconicomeTest.Stabs.Models.Domain.Utils;
+using NUnit.Framework;
+
+namespace NiconicomeTest.Local.Cookies
+{
+    class LocalStateUnitTest
+    {
+        private CookieJsonLoader? loader;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.loader = new CookieJsonLoader(new LoggerStab());
+        }
+
+        [Test]
+        public void ファイル名を取得()
+        {
+            var name = this.loader!.GetJsonPath(CookieType.Webview2);
+
+            Assert.That(name, Is.EqualTo(@"Niconicome.exe.WebView2\EBWebView\Local State"));
+        }
+
+    }
+}

--- a/NiconicomeTest/Local/PlaylistUnitTest.cs
+++ b/NiconicomeTest/Local/PlaylistUnitTest.cs
@@ -110,8 +110,8 @@ namespace NiconicomeTest
                     var playlist1 = this.playlistStorehandler.GetPlaylist(playlist1Id);
                     var playlist2 = this.playlistStorehandler.GetPlaylist(playlist2Id);
 
-                    Assert.IsTrue(playlist1.IsRemotePlaylist);
-                    Assert.IsTrue(playlist2.IsRemotePlaylist);
+                    Assert.IsTrue(playlist1!.IsRemotePlaylist);
+                    Assert.IsTrue(playlist2!.IsRemotePlaylist);
                     Assert.IsTrue(playlist1.IsMylist);
                     Assert.IsTrue(playlist2.IsUserVideos);
                     Assert.IsFalse(playlist1.IsUserVideos);
@@ -131,7 +131,7 @@ namespace NiconicomeTest
 
                     var playlist = this.playlistStorehandler.GetPlaylist(playlistId);
 
-                    Assert.IsFalse(playlist.IsRemotePlaylist);
+                    Assert.IsFalse(playlist!.IsRemotePlaylist);
                     Assert.IsFalse(playlist.IsMylist);
                     Assert.IsFalse(playlist.IsUserVideos);
                 }

--- a/NiconicomeTest/NetWork/Download/DownloadTask/DownloadTaskPoolUnitTest.cs
+++ b/NiconicomeTest/NetWork/Download/DownloadTask/DownloadTaskPoolUnitTest.cs
@@ -1,0 +1,71 @@
+﻿using System.Collections.Generic;
+using Niconicome.Models.Network.Download;
+using Niconicome.Models.Playlist;
+using NUnit.Framework;
+using Download = Niconicome.Models.Network.Download;
+
+namespace NiconicomeTest.NetWork.Download.DownloadTask
+{
+    class DownloadTaskPoolUnitTest
+    {
+        private Download::IDownloadTaskPool? downloadTaskPool;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.downloadTaskPool = new Download::DownloadTaskPool();
+        }
+
+        [Test]
+        public void タスクを追加する()
+        {
+            var task = new Download::DownloadTask(new BindableVIdeoListInfo(), new DownloadSettings());
+            this.downloadTaskPool!.AddTask(task);
+
+            Assert.That(this.downloadTaskPool!.Count, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void 複数のタスクを追加する()
+        {
+            var task1 = new Download::DownloadTask(new BindableVIdeoListInfo(), new DownloadSettings());
+            var task2 = new Download::DownloadTask(new BindableVIdeoListInfo(), new DownloadSettings());
+            var tasks = new List<Download::IDownloadTask>() { task1, task2 };
+            this.downloadTaskPool!.AddTasks(tasks);
+
+            Assert.That(this.downloadTaskPool!.Count, Is.EqualTo(2));
+        }
+
+        [Test]
+        public void 追加イベントをチェックする()
+        {
+            int id = 0;
+            var task = new Download::DownloadTask(new BindableVIdeoListInfo() { Id = 1 }, new DownloadSettings());
+            this.downloadTaskPool!.TaskPoolChange += (_, e) => id = e.Task.Video.Id;
+            this.downloadTaskPool!.AddTask(task);
+
+            Assert.That(id, Is.EqualTo(task.Video.Id));
+        }
+
+        [Test]
+        public void タスクを削除する()
+        {
+            var task = new Download::DownloadTask(new BindableVIdeoListInfo(), new DownloadSettings());
+            this.downloadTaskPool!.AddTask(task);
+            this.downloadTaskPool!.RemoveTask(task);
+
+            Assert.That(this.downloadTaskPool!.Count, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void タスクの存在をチェックする()
+        {
+            var task = new Download::DownloadTask(new BindableVIdeoListInfo(), new DownloadSettings());
+            this.downloadTaskPool!.AddTask(task);
+
+            var result = this.downloadTaskPool!.HasTask(t => t.ID == task.ID);
+
+            Assert.That(result, Is.True);
+        }
+    }
+}

--- a/NiconicomeTest/NetWork/Download/DownloadTask/DownloadTaskPoolUnitTest.cs
+++ b/NiconicomeTest/NetWork/Download/DownloadTask/DownloadTaskPoolUnitTest.cs
@@ -19,7 +19,7 @@ namespace NiconicomeTest.NetWork.Download.DownloadTask
         [Test]
         public void タスクを追加する()
         {
-            var task = new Download::DownloadTask(new BindableVIdeoListInfo(), new DownloadSettings());
+            var task = new Download::DownloadTask("", "", 1, new DownloadSettings());
             this.downloadTaskPool!.AddTask(task);
 
             Assert.That(this.downloadTaskPool!.Count, Is.EqualTo(1));
@@ -28,8 +28,8 @@ namespace NiconicomeTest.NetWork.Download.DownloadTask
         [Test]
         public void 複数のタスクを追加する()
         {
-            var task1 = new Download::DownloadTask(new BindableVIdeoListInfo(), new DownloadSettings());
-            var task2 = new Download::DownloadTask(new BindableVIdeoListInfo(), new DownloadSettings());
+            var task1 = new Download::DownloadTask("", "", 1, new DownloadSettings());
+            var task2 = new Download::DownloadTask("", "", 1, new DownloadSettings());
             var tasks = new List<Download::IDownloadTask>() { task1, task2 };
             this.downloadTaskPool!.AddTasks(tasks);
 
@@ -40,17 +40,17 @@ namespace NiconicomeTest.NetWork.Download.DownloadTask
         public void 追加イベントをチェックする()
         {
             int id = 0;
-            var task = new Download::DownloadTask(new BindableVIdeoListInfo() { Id = 1 }, new DownloadSettings());
-            this.downloadTaskPool!.TaskPoolChange += (_, e) => id = e.Task.Video.Id;
+            var task = new Download::DownloadTask("", "", 1, new DownloadSettings());
+            this.downloadTaskPool!.TaskPoolChange += (_, e) => id = e.Task.VideoID;
             this.downloadTaskPool!.AddTask(task);
 
-            Assert.That(id, Is.EqualTo(task.Video.Id));
+            Assert.That(id, Is.EqualTo(task.VideoID));
         }
 
         [Test]
         public void タスクを削除する()
         {
-            var task = new Download::DownloadTask(new BindableVIdeoListInfo(), new DownloadSettings());
+            var task = new Download::DownloadTask("", "", 1, new DownloadSettings());
             this.downloadTaskPool!.AddTask(task);
             this.downloadTaskPool!.RemoveTask(task);
 
@@ -60,7 +60,7 @@ namespace NiconicomeTest.NetWork.Download.DownloadTask
         [Test]
         public void タスクの存在をチェックする()
         {
-            var task = new Download::DownloadTask(new BindableVIdeoListInfo(), new DownloadSettings());
+            var task = new Download::DownloadTask("", "", 1, new DownloadSettings());
             this.downloadTaskPool!.AddTask(task);
 
             var result = this.downloadTaskPool!.HasTask(t => t.ID == task.ID);

--- a/NiconicomeTest/NetWork/Download/DownloadTask/DownloadTaskUnitTest.cs
+++ b/NiconicomeTest/NetWork/Download/DownloadTask/DownloadTaskUnitTest.cs
@@ -11,16 +11,11 @@ namespace NiconicomeTest.NetWork.Download.DownloadTask
         [Test]
         public void 動画情報を変換する()
         {
-            var video = new NonBindableVideoListInfo()
-            {
-                Title = "Hello World",
-                Id = 1,
-            };
-            var converted = new Download::DownloadTask(video, new DownloadSettings() { VerticalResolution = (uint)1080, FolderPath = @"fuga\hoge", PlaylistID = 1 });
+            var converted = new Download::DownloadTask("", "Hello World", 1, new DownloadSettings() { VerticalResolution = (uint)1080, FolderPath = @"fuga\hoge", PlaylistID = 1 });
 
-            Assert.That(converted.Video.Title, Is.EqualTo("Hello World"));
+            Assert.That(converted.Title, Is.EqualTo("Hello World"));
             Assert.That(converted.DirectoryPath, Is.EqualTo(@"fuga\hoge"));
-            Assert.That(converted.Video.Id, Is.EqualTo(1));
+            Assert.That(converted.VideoID, Is.EqualTo(1));
             Assert.That(converted.PlaylistID, Is.EqualTo(1));
             Assert.That(converted.VerticalResolution, Is.EqualTo((uint)1080));
             Assert.That(converted.ID, Is.Not.Null.Or.Not.EqualTo(default));

--- a/NiconicomeTest/NetWork/Download/DownloadTask/DownloadTaskUnitTest.cs
+++ b/NiconicomeTest/NetWork/Download/DownloadTask/DownloadTaskUnitTest.cs
@@ -1,0 +1,29 @@
+﻿using Niconicome.Models.Network.Download;
+using Niconicome.Models.Playlist;
+using NUnit.Framework;
+using Download = Niconicome.Models.Network.Download;
+
+namespace NiconicomeTest.NetWork.Download.DownloadTask
+{
+    [TestFixture]
+    class DownloadTaskUnitTest
+    {
+        [Test]
+        public void 動画情報を変換する()
+        {
+            var video = new NonBindableVideoListInfo()
+            {
+                Title = "Hello World",
+                Id = 1,
+            };
+            var converted = new Download::DownloadTask(video, new DownloadSettings() { VerticalResolution = (uint)1080, FolderPath = @"fuga\hoge", PlaylistID = 1 });
+
+            Assert.That(converted.Video.Title, Is.EqualTo("Hello World"));
+            Assert.That(converted.DirectoryPath, Is.EqualTo(@"fuga\hoge"));
+            Assert.That(converted.Video.Id, Is.EqualTo(1));
+            Assert.That(converted.PlaylistID, Is.EqualTo(1));
+            Assert.That(converted.VerticalResolution, Is.EqualTo((uint)1080));
+            Assert.That(converted.ID, Is.Not.Null.Or.Not.EqualTo(default));
+        }
+    }
+}

--- a/NiconicomeTest/Utils/NiconicoUtilsUnitTest.cs
+++ b/NiconicomeTest/Utils/NiconicoUtilsUnitTest.cs
@@ -1,6 +1,7 @@
 using NUnit.Framework;
 using System;
 using Niconicome.Models.Domain.Utils;
+using Niconicome.Models.Playlist;
 
 namespace NiconicomeTest.Utils
 {
@@ -43,6 +44,61 @@ namespace NiconicomeTest.Utils
         public void ファイル名からIDを取得する(string filename,string id)
         {
             var result = this.utils!.GetIdFromFIleName("[<id>]<title>", filename);
+            Assert.That(result, Is.EqualTo(id));
+        }
+
+        [TestCase("[123]hoge.mp4","123")]
+        [TestCase("[sm123]hoge","sm123")]
+        [TestCase("sm123hoge","sm123")]
+        [TestCase("hoge(nm2)","nm2")]
+        [TestCase("ssssso123hoge","so123")]
+        public void フォーマットなしでファイル名からIDを取得する(string filename,string id)
+        {
+            var result = this.utils!.GetIdFromFIleName(filename);
+            Assert.That(result, Is.EqualTo(id));
+        }
+
+        [TestCase("sm9",true)]
+        [TestCase("so123",true)]
+        [TestCase("123",true)]
+        [TestCase("nm9",true)]
+        [TestCase("nm123",true)]
+        [TestCase("hsm9", false)]
+        [TestCase("sm91a", false)]
+        [TestCase("a12", false)]
+        [TestCase("12d", false)]
+        public void ニコニコのIDをテストする(string testString,bool expectedResult)
+        {
+            var result = this.utils!.IsNiconicoID(testString);
+
+            Assert.That(result, Is.EqualTo(expectedResult));
+        }
+
+        [TestCase("https://www.nicovideo.jp/user/000/mylist/000?ref=pc_userpage_menu", RemoteType.Mylist)]
+        [TestCase("https://www.nicovideo.jp/my/watchlater?ref=pc_mypage_menu", RemoteType.WatchLater)]
+        [TestCase("https://ch.nicovideo.jp/elfenlied", RemoteType.Channel)]
+        [TestCase("https://www.nicovideo.jp/user/000/video?ref=pc_userpage_menud", RemoteType.UserVideos)]
+        [TestCase("https://www.nicovideo.jp/watch/sm9?hello_world", RemoteType.WatchPage)]
+        [TestCase("https://www.nicovideo.jp/watch/sm9", RemoteType.WatchPage)]
+        public void リモートプレイリストの種別を取得する(string url,RemoteType expectedType)
+        {
+            var type = this.utils!.GetRemoteType(url);
+
+            Assert.That(expectedType, Is.EqualTo(type));
+        }
+
+        [TestCase("https://www.nicovideo.jp/user/000/mylist/000?ref=pc_userpage_menu",RemoteType.Mylist, "000")]
+        [TestCase("https://www.nicovideo.jp/user/000/mylist/000/?ref=pc_userpage_menu", RemoteType.Mylist, "000")]
+        [TestCase("https://ch.nicovideo.jp/elfenlied",RemoteType.Channel, "elfenlied")]
+        [TestCase("https://ch.nicovideo.jp/elfenlied/", RemoteType.Channel, "elfenlied")]
+        [TestCase("https://www.nicovideo.jp/user/000/video?ref=pc_userpage_menud", RemoteType.UserVideos,"000")]
+        [TestCase("https://www.nicovideo.jp/user/000/video/?ref=pc_userpage_menud", RemoteType.UserVideos, "000")]
+        [TestCase("https://www.nicovideo.jp/watch/sm9?hello_world", RemoteType.WatchPage,"sm9")]
+        [TestCase("https://www.nicovideo.jp/watch/sm9", RemoteType.WatchPage,"sm9")]
+        public void リモートプレイリストのIDを取得する(string url,RemoteType type,string id)
+        {
+            var result = this.utils!.GetID(url,type);
+
             Assert.That(result, Is.EqualTo(id));
         }
     }

--- a/NiconicomeTest/Utils/NiconicoUtilsUnitTest.cs
+++ b/NiconicomeTest/Utils/NiconicoUtilsUnitTest.cs
@@ -2,6 +2,7 @@ using NUnit.Framework;
 using System;
 using Niconicome.Models.Domain.Utils;
 using Niconicome.Models.Playlist;
+using Niconicome.Models.Domain.Niconico.Watch;
 
 namespace NiconicomeTest.Utils
 {
@@ -39,35 +40,35 @@ namespace NiconicomeTest.Utils
             Assert.AreEqual("123456", result[4]);
         }
 
-        [TestCase("[123]hoge.mp4","123")]
-        [TestCase("[sm123]hoge","sm123")]
-        public void ファイル名からIDを取得する(string filename,string id)
+        [TestCase("[123]hoge.mp4", "123")]
+        [TestCase("[sm123]hoge", "sm123")]
+        public void ファイル名からIDを取得する(string filename, string id)
         {
             var result = this.utils!.GetIdFromFIleName("[<id>]<title>", filename);
             Assert.That(result, Is.EqualTo(id));
         }
 
-        [TestCase("[123]hoge.mp4","123")]
-        [TestCase("[sm123]hoge","sm123")]
-        [TestCase("sm123hoge","sm123")]
-        [TestCase("hoge(nm2)","nm2")]
-        [TestCase("ssssso123hoge","so123")]
-        public void フォーマットなしでファイル名からIDを取得する(string filename,string id)
+        [TestCase("[123]hoge.mp4", "123")]
+        [TestCase("[sm123]hoge", "sm123")]
+        [TestCase("sm123hoge", "sm123")]
+        [TestCase("hoge(nm2)", "nm2")]
+        [TestCase("ssssso123hoge", "so123")]
+        public void フォーマットなしでファイル名からIDを取得する(string filename, string id)
         {
             var result = this.utils!.GetIdFromFIleName(filename);
             Assert.That(result, Is.EqualTo(id));
         }
 
-        [TestCase("sm9",true)]
-        [TestCase("so123",true)]
-        [TestCase("123",true)]
-        [TestCase("nm9",true)]
-        [TestCase("nm123",true)]
+        [TestCase("sm9", true)]
+        [TestCase("so123", true)]
+        [TestCase("123", true)]
+        [TestCase("nm9", true)]
+        [TestCase("nm123", true)]
         [TestCase("hsm9", false)]
         [TestCase("sm91a", false)]
         [TestCase("a12", false)]
         [TestCase("12d", false)]
-        public void ニコニコのIDをテストする(string testString,bool expectedResult)
+        public void ニコニコのIDをテストする(string testString, bool expectedResult)
         {
             var result = this.utils!.IsNiconicoID(testString);
 
@@ -80,26 +81,50 @@ namespace NiconicomeTest.Utils
         [TestCase("https://www.nicovideo.jp/user/000/video?ref=pc_userpage_menud", RemoteType.UserVideos)]
         [TestCase("https://www.nicovideo.jp/watch/sm9?hello_world", RemoteType.WatchPage)]
         [TestCase("https://www.nicovideo.jp/watch/sm9", RemoteType.WatchPage)]
-        public void リモートプレイリストの種別を取得する(string url,RemoteType expectedType)
+        public void リモートプレイリストの種別を取得する(string url, RemoteType expectedType)
         {
             var type = this.utils!.GetRemoteType(url);
 
             Assert.That(expectedType, Is.EqualTo(type));
         }
 
-        [TestCase("https://www.nicovideo.jp/user/000/mylist/000?ref=pc_userpage_menu",RemoteType.Mylist, "000")]
+        [TestCase("https://www.nicovideo.jp/user/000/mylist/000?ref=pc_userpage_menu", RemoteType.Mylist, "000")]
         [TestCase("https://www.nicovideo.jp/user/000/mylist/000/?ref=pc_userpage_menu", RemoteType.Mylist, "000")]
-        [TestCase("https://ch.nicovideo.jp/elfenlied",RemoteType.Channel, "elfenlied")]
+        [TestCase("https://ch.nicovideo.jp/elfenlied", RemoteType.Channel, "elfenlied")]
         [TestCase("https://ch.nicovideo.jp/elfenlied/", RemoteType.Channel, "elfenlied")]
-        [TestCase("https://www.nicovideo.jp/user/000/video?ref=pc_userpage_menud", RemoteType.UserVideos,"000")]
+        [TestCase("https://www.nicovideo.jp/user/000/video?ref=pc_userpage_menud", RemoteType.UserVideos, "000")]
         [TestCase("https://www.nicovideo.jp/user/000/video/?ref=pc_userpage_menud", RemoteType.UserVideos, "000")]
-        [TestCase("https://www.nicovideo.jp/watch/sm9?hello_world", RemoteType.WatchPage,"sm9")]
-        [TestCase("https://www.nicovideo.jp/watch/sm9", RemoteType.WatchPage,"sm9")]
-        public void リモートプレイリストのIDを取得する(string url,RemoteType type,string id)
+        [TestCase("https://www.nicovideo.jp/watch/sm9?hello_world", RemoteType.WatchPage, "sm9")]
+        [TestCase("https://www.nicovideo.jp/watch/sm9", RemoteType.WatchPage, "sm9")]
+        public void リモートプレイリストのIDを取得する(string url, RemoteType type, string id)
         {
-            var result = this.utils!.GetID(url,type);
+            var result = this.utils!.GetID(url, type);
 
             Assert.That(result, Is.EqualTo(id));
+        }
+
+        [TestCase("[<id>]<title>", "[sm9]新・豪血寺一族 -煩悩解放 - レッツゴー！陰陽師")]
+        [TestCase("[<id>]<title>（<owner>）", "[sm9]新・豪血寺一族 -煩悩解放 - レッツゴー！陰陽師（中の）")]
+        [TestCase("[<id>]<title>（<uploadedon>）", "[sm9]新・豪血寺一族 -煩悩解放 - レッツゴー！陰陽師（2007-03-06 00-33-00）")]
+        [TestCase("[<id>]<title>（<downloadon>）", "[sm9]新・豪血寺一族 -煩悩解放 - レッツゴー！陰陽師（2021-03-26 20-30-00）")]
+        [TestCase("[<id>]<title>（<uploadedon:yyyy年MM月dd日 HH時mm分ss秒>）", "[sm9]新・豪血寺一族 -煩悩解放 - レッツゴー！陰陽師（2007年03月06日 00時33分00秒）")]
+        [TestCase("[<id>]<title>（<downloadon:yyyy年MM月dd日 HH時mm分ss秒>）", "[sm9]新・豪血寺一族 -煩悩解放 - レッツゴー！陰陽師（2021年03月26日 20時30分00秒）")]
+        public void 動画ファイル名を取得する(string format, string expectedResult)
+        {
+            var dt = DateTime.Parse("2007-03-06T00:33:00");
+            var dt2 = DateTime.Parse("2021-03-26T20:30:00");
+            var dmc = new DmcInfo()
+            {
+                UploadedOn = dt,
+                DownloadStartedOn = dt2,
+                Title = "新・豪血寺一族 -煩悩解放 - レッツゴー！陰陽師",
+                Owner = "中の",
+                Id = "sm9",
+            };
+
+            var result = this.utils!.GetFileName(format, dmc, string.Empty, true);
+
+            Assert.That(result, Is.EqualTo(expectedResult));
         }
     }
 }

--- a/NiconicomeTest/Utils/NiconicoUtilsUnitTest.cs
+++ b/NiconicomeTest/Utils/NiconicoUtilsUnitTest.cs
@@ -101,7 +101,7 @@ namespace NiconicomeTest.Utils
             var result = this.utils!.GetID(url, type);
 
             Assert.That(result, Is.EqualTo(id));
-        }
+        } 
 
         [TestCase("[<id>]<title>", "[sm9]新・豪血寺一族 -煩悩解放 - レッツゴー！陰陽師")]
         [TestCase("[<id>]<title>（<owner>）", "[sm9]新・豪血寺一族 -煩悩解放 - レッツゴー！陰陽師（中の）")]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Niconicome(α)
 [![.Net5 CI/CD](https://github.com/Hayao-H/Niconicome/workflows/.Net5%20CI/CD/badge.svg)](https://github.com/Hayao-H/Niconicome/actions?query=workflow%3A%22.Net5+CI%2FCD%22) 
 [![GitHub license](https://img.shields.io/github/license/Hayao-H/Niconicome)](https://github.com/Hayao-H/Niconicome/blob/main/LICENSE)
-[![Github Release](https://img.shields.io/badge/release-v0.2.4-blue)](https://github.com/Hayao-H/Niconicome/releases)
+[![Github Release](https://img.shields.io/badge/release-v0.3.0-blue)](https://github.com/Hayao-H/Niconicome/releases)
 [![GitHub stars](https://img.shields.io/github/stars/Hayao-H/Niconicome)](https://github.com/Hayao-H/Niconicome/stargazers)
 [![Twitter Follow](https://img.shields.io/twitter/follow/NiconicomeD?label=Twitter%E3%81%A7%E3%83%95%E3%82%A9%E3%83%AD%E3%83%BC&style=social)](https://twitter.com/intent/follow?screen_name=niconicomeD)
 


### PR DESCRIPTION
# 概要
## 追加
- NicoXenoのように入力窓に直接URLやローカルパスを入力できるようにした close #86
- チャンネル動画追加時のチャンネル名ヒント表示を追加 close #85
- タイトルのツールチップ表示を追加 close #133
- 並列処理数をコントロールできるようにした　close #138
- 同時DL数の設定機能を追加 close #111
- 動画説明文のDLをサポート close #87
- 自動ログイン機能を追加 close #83
- メインメニューの実装 close #89
- 日付のカスタム書式機能を追加 close #130
- ファイルフォーマットに保存日を追加 close #129
- 使用できない文字を2バイトに置き換える機能を追加 close #121
- 動画ファイルの更新日時を投稿日にする機能を追加 #110
- DL中の動画の解像度を表示する機能を追加 close #118
- コメント取得数の上限を定める機能を追加 close #108
- SSL証明書の検証をスキップできるようにした slose #122
## 変更
- ``MessabeBox``をマテリアルデザインにした close #88 
## 修正
- リモートプレイリスト更新時に、すでに存在する動画も含めて更新される問題を修正 fix #92
- ダウンロード設定のタイトルを誤字を修正 fix #109
- 違うプレイリストを選択するとそれ以降動画のDL状態等が表示されなくなる問題を修正 fix #113
- サブディレクトリを作成できない問題を修正 fix #120
- 一度ログアウトした後に再度ログインしようとすると前回のセッションが再利用される問題を修正 fix #101
- 動画情報の更新時にクラッシュする問題を修正 fix #134
- コメントダウンロード時などに存在しないディレクトリーが作成されない問題を修正 close #125