### PR TITLE
Bug/official video register

### DIFF
--- a/Niconicome/Models/Domain/Utils/NiconicoUtils.cs
+++ b/Niconicome/Models/Domain/Utils/NiconicoUtils.cs
@@ -178,7 +178,7 @@ namespace Niconicome.Models.Domain.Utils
             {
                 return RemoteType.UserVideos;
             }
-            else if (Regex.IsMatch(url, @"^https?://(www\.)?nicovideo\.jp/watch/(sm|nm|so)\d+.*"))
+            else if (Regex.IsMatch(url, @"^https?://(www\.)?nicovideo\.jp/watch/(sm|nm|so)?\d+.*"))
             {
                 return RemoteType.WatchPage;
             }

--- a/Niconicome/Models/Network/VideoIDHandler.cs
+++ b/Niconicome/Models/Network/VideoIDHandler.cs
@@ -151,6 +151,8 @@ namespace Niconicome.Models.Network
                     IsFailed = true
                 };
 
+                this.IsProcessing.Value = false;
+
                 return result;
             }
 

--- a/Niconicome/ViewModels/Mainpage/VideoListViewmodel.cs
+++ b/Niconicome/ViewModels/Mainpage/VideoListViewmodel.cs
@@ -151,9 +151,10 @@ namespace Niconicome.ViewModels.Mainpage
 
                   WS::Mainpage.VideoListContainer.AddRange(videos, playlistId);
 
-                  WS::Mainpage.PlaylistHandler.Refresh();
+                  WS::Mainpage.VideoListContainer.Refresh();
 
                   this.SnackbarMessageQueue.Enqueue($"{videos.Count}件の動画を追加しました");
+                  WS::Mainpage.Messagehandler.AppendMessage ($"{videos.Count}件の動画を追加しました");
 
                   if (!videos.First().ChannelID.Value.IsNullOrEmpty())
                   {


### PR DESCRIPTION
# 概要
## 修正
- IDに接頭辞がつかない動画の視聴URLからの登録に失敗する問題を修正 fix #291
## 変更
- 動画を追加する際のプレイリストツリー全体の再読み込み処理をなくしてパフォーマンスを改善