### PR TITLE
release/v0.6.2

### DIFF
--- a/Niconicome/Models/Domain/Niconico/Download/Comment/CommentCollection.cs
+++ b/Niconicome/Models/Domain/Niconico/Download/Comment/CommentCollection.cs
@@ -17,7 +17,7 @@ namespace Niconicome.Models.Domain.Niconico.Download.Comment
         long Thread { get; }
         int Fork { get; }
         bool IsDefaultPostTarget { get; }
-        void Add(Response::Comment comment, bool sort = true);
+        void Add(Response::Comment comment);
         void Add(List<Response::Comment> comments, bool addSafe = true);
         void Clear();
         void Distinct();
@@ -187,7 +187,7 @@ namespace Niconicome.Models.Domain.Niconico.Download.Comment
         /// </summary>
         /// <param name="comment"></param>
         /// <param name="sort"></param>
-        public void Add(Response::Comment comment, bool sort = true)
+        public void Add(Response::Comment comment)
         {
             if (this.isRoot)
             {
@@ -230,10 +230,6 @@ namespace Niconicome.Models.Domain.Niconico.Download.Comment
                 {
                     this.commentsfield.AddFirst(comment);
                     this.isSorted = false;
-                    if (!this.unsafeHandle)
-                    {
-                        this.Distinct();
-                    }
                 }
                 else
                 {
@@ -280,19 +276,24 @@ namespace Niconicome.Models.Domain.Niconico.Download.Comment
 
                 foreach (var _ in Enumerable.Range(0, this.comThroughSetting))
                 {
-                    chats.RemoveLast();
+                    chats.RemoveFirst();
                 }
             }
 
             foreach (var item in chats)
             {
-                this.Add(item, false);
+                this.Add(item);
+            }
+
+            if (!this.unsafeHandle)
+            {
+                this.Distinct();
             }
 
             var thread = comments.FirstOrDefault(c => c.Thread is not null);
             if (thread is not null)
             {
-                this.Add(thread, false);
+                this.Add(thread);
             }
         }
 

--- a/Niconicome/Models/Domain/Utils/NiconicoUtils.cs
+++ b/Niconicome/Models/Domain/Utils/NiconicoUtils.cs
@@ -178,7 +178,7 @@ namespace Niconicome.Models.Domain.Utils
             {
                 return RemoteType.UserVideos;
             }
-            else if (Regex.IsMatch(url, @"^https?://(www\.)?nicovideo\.jp/watch/(sm|nm|so)\d+.*"))
+            else if (Regex.IsMatch(url, @"^https?://(www\.)?nicovideo\.jp/watch/(sm|nm|so)?\d+.*"))
             {
                 return RemoteType.WatchPage;
             }

--- a/Niconicome/Models/Network/VideoIDHandler.cs
+++ b/Niconicome/Models/Network/VideoIDHandler.cs
@@ -151,6 +151,8 @@ namespace Niconicome.Models.Network
                     IsFailed = true
                 };
 
+                this.IsProcessing.Value = false;
+
                 return result;
             }
 

--- a/Niconicome/Niconicome.csproj
+++ b/Niconicome/Niconicome.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net5.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <Nullable>enable</Nullable>
-    <AssemblyVersion>0.6.1.*</AssemblyVersion>
+    <AssemblyVersion>0.6.2.*</AssemblyVersion>
     <FileVersion>0.0.0.0</FileVersion>
     <StartupObject>Niconicome.App</StartupObject>
     <AnalysisLevel>latest</AnalysisLevel>
@@ -15,7 +15,7 @@
     <PublishTrimmed>false</PublishTrimmed>
     <Deterministic>false</Deterministic>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
-    <Version>0.6.1</Version>
+    <Version>0.6.2</Version>
     <PackageProjectUrl>https://github.com/Hayao-H/Niconicome</PackageProjectUrl>
     <Copyright>c2021 Hayao-H</Copyright>
     <Authors>Hayao-H</Authors>

--- a/Niconicome/ViewModels/Mainpage/VideoListViewmodel.cs
+++ b/Niconicome/ViewModels/Mainpage/VideoListViewmodel.cs
@@ -151,9 +151,10 @@ namespace Niconicome.ViewModels.Mainpage
 
                   WS::Mainpage.VideoListContainer.AddRange(videos, playlistId);
 
-                  WS::Mainpage.PlaylistHandler.Refresh();
+                  WS::Mainpage.VideoListContainer.Refresh();
 
                   this.SnackbarMessageQueue.Enqueue($"{videos.Count}件の動画を追加しました");
+                  WS::Mainpage.Messagehandler.AppendMessage ($"{videos.Count}件の動画を追加しました");
 
                   if (!videos.First().ChannelID.Value.IsNullOrEmpty())
                   {

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Niconicome(α)
 [![.Net5 CI/CD](https://github.com/Hayao-H/Niconicome/workflows/.Net5%20CI/CD/badge.svg)](https://github.com/Hayao-H/Niconicome/actions?query=workflow%3A%22.Net5+CI%2FCD%22) 
 [![GitHub license](https://img.shields.io/github/license/Hayao-H/Niconicome)](https://github.com/Hayao-H/Niconicome/blob/main/LICENSE)
-[![Github Release](https://img.shields.io/badge/release-v0.6.1-blue)](https://github.com/Hayao-H/Niconicome/releases)
+[![Github Release](https://img.shields.io/badge/release-v0.6.2-blue)](https://github.com/Hayao-H/Niconicome/releases)
 [![GitHub stars](https://img.shields.io/github/stars/Hayao-H/Niconicome)](https://github.com/Hayao-H/Niconicome/stargazers)
 [![Twitter Follow](https://img.shields.io/twitter/follow/NiconicomeD?label=Twitter%E3%81%A7%E3%83%95%E3%82%A9%E3%83%AD%E3%83%BC&style=social)](https://twitter.com/intent/follow?screen_name=niconicomeD)
 


### PR DESCRIPTION
# 概要
## 修正
- IDに接頭辞がつかない動画の視聴URLからの登録に失敗する問題を修正 f #291
- コメント取得数を調節出来ない問題を修正 #292 
## 変更
- 動画を追加する際のプレイリストツリー全体の再読み込み処理をなくしてパフォーマンスを改善
- コメントのユニーク化処理を効率化してコメント取得時のパフォーマンスを改善