### PR TITLE
Bug/search by

### DIFF
--- a/Niconicome/Models/Domain/Local/Store/Types/Settings.cs
+++ b/Niconicome/Models/Domain/Local/Store/Types/Settings.cs
@@ -176,5 +176,6 @@ namespace Niconicome.Models.Domain.Local.Store.Types
         public static string ApplicationTheme { get; private set; } = "applicationtheme";
         public static string ConfirmIfDownloading { get; private set; } = "confirmifdownloading";
         public static string FFmpegFormat { get; private set; } = "ffmpegformat";
+        public static string SearchVideosByID { get; private set; } = "searchvideosbyid";
     }
 }

--- a/Niconicome/Models/Domain/Utils/NiconicoUtils.cs
+++ b/Niconicome/Models/Domain/Utils/NiconicoUtils.cs
@@ -55,6 +55,7 @@ namespace Niconicome.Models.Domain.Utils
                 NiconicoID = dmcInfo.Id,
                 UploadedOn = dmcInfo.UploadedOn,
                 DownloadStartedOn = dmcInfo.DownloadStartedOn,
+                OwnerID = dmcInfo.OwnerID.ToString(),
             };
 
             return this.GetFilenameInternal(format, info, extension, replaceStricted, suffix);
@@ -78,6 +79,7 @@ namespace Niconicome.Models.Domain.Utils
                 NiconicoID = video.NiconicoId.Value,
                 UploadedOn = video.UploadedOn.Value,
                 DownloadStartedOn = DateTime.Now,
+                OwnerID = video.OwnerID.Value.ToString(),
             };
 
             return this.GetFilenameInternal(format, info, extension, replaceStricted, suffix);
@@ -318,6 +320,7 @@ namespace Niconicome.Models.Domain.Utils
             string filename = format.Replace("<id>", info.NiconicoID)
              .Replace("<title>", info.Title)
              .Replace("<owner>", info.OwnerName)
+             .Replace("<ownerId>", info.OwnerID)
              + suffix
              + extension;
 
@@ -358,5 +361,7 @@ namespace Niconicome.Models.Domain.Utils
         public string OwnerName { get; set; } = string.Empty;
 
         public string NiconicoID { get; set; } = string.Empty;
+
+        public string OwnerID { get; set; } = string.Empty;
     }
 }

--- a/Niconicome/Models/Local/LocalVideoUtils.cs
+++ b/Niconicome/Models/Local/LocalVideoUtils.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Niconicome.Models.Const;
+using Niconicome.Models.Domain.Local.IO;
 using Niconicome.Models.Domain.Local.Store;
 using Niconicome.Models.Domain.Utils;
 using Niconicome.Models.Playlist;
@@ -13,17 +14,26 @@ namespace Niconicome.Models.Local
 {
     public interface ILocalVideoUtils
     {
-        string GetFilePath(IListVideoInfo video, string folderPath, string format, bool replaceStricted);
+        string GetFilePath(IListVideoInfo video, string folderPath, string format, bool replaceStricted, bool searchByID);
+        void ClearCache();
     }
 
     class LocalVideoUtils : ILocalVideoUtils
     {
-        public LocalVideoUtils(INiconicoUtils niconicoUtils)
+        public LocalVideoUtils(INiconicoUtils niconicoUtils, INicoDirectoryIO directoryIO)
         {
             this.niconicoUtils = niconicoUtils;
+            this.directoryIO = directoryIO;
         }
 
+        #region field
+
         private readonly INiconicoUtils niconicoUtils;
+
+        private readonly INicoDirectoryIO directoryIO;
+
+        private List<string>? cachedFiles;
+        #endregion
 
         /// <summary>
         /// ローカルファイルの取得を試行する
@@ -31,31 +41,63 @@ namespace Niconicome.Models.Local
         /// <param name="video"></param>
         /// <param name="folderPath"></param>
         /// <returns></returns>
-        public string GetFilePath(IListVideoInfo video, string folderPath, string format, bool replaceStricted)
+        public string GetFilePath(IListVideoInfo video, string folderPath, string format, bool replaceStricted, bool searchByID)
         {
+
             if (!Path.IsPathRooted(folderPath))
             {
                 folderPath = Path.Combine(AppContext.BaseDirectory, folderPath);
             }
+
+            if (this.cachedFiles is null)
+            {
+                this.cachedFiles = new List<string>();
+                this.cachedFiles.AddRange(this.directoryIO.GetFiles(folderPath,$"*{FileFolder.Mp4FileExt}",true).Select(p => Path.Combine(folderPath, p)).ToList());
+                this.cachedFiles.AddRange(this.directoryIO.GetFiles(folderPath,$"*{FileFolder.TsFileExt}", true).Select(p => Path.Combine(folderPath, p)).ToList());
+                
+            }
+
+            bool SearchFunc(string currentPath,string targetPath)
+            {
+                if (searchByID)
+                {
+                    return currentPath.Contains(video.NiconicoId.Value);
+                } else
+                {
+                    return currentPath == targetPath;
+                }
+            }
+
             var fn = this.niconicoUtils.GetFileName(format, video, FileFolder.Mp4FileExt, replaceStricted);
             var path = IOUtils.GetPrefixedPath(Path.Combine(folderPath, fn));
 
+            string? firstMp4 = this.cachedFiles.FirstOrDefault(p => SearchFunc(p,path));
             //.mp4ファイルを確認
-            if (File.Exists(path))
+            if (firstMp4 is not null)
             {
-                return path;
+                return firstMp4;
             }
             else
             //.tsファイルを確認
             {
                 fn = this.niconicoUtils.GetFileName(format, video, FileFolder.TsFileExt, replaceStricted);
                 path = IOUtils.GetPrefixedPath(Path.Combine(folderPath, fn));
-                if (File.Exists(path)) return path;
+                string? firstTS = this.cachedFiles.FirstOrDefault(p => SearchFunc(p, path));
+                if (firstTS is not null) return firstTS;
             }
 
             return Path.GetDirectoryName(path) ?? folderPath;
 
         }
+
+        /// <summary>
+        /// キャッシュをクリアする
+        /// </summary>
+        public void ClearCache()
+        {
+            this.cachedFiles = null;
+        }
+
 
     }
 }

--- a/Niconicome/Models/Local/LocalVideoUtils.cs
+++ b/Niconicome/Models/Local/LocalVideoUtils.cs
@@ -52,8 +52,11 @@ namespace Niconicome.Models.Local
             if (this.cachedFiles is null)
             {
                 this.cachedFiles = new List<string>();
-                this.cachedFiles.AddRange(this.directoryIO.GetFiles(folderPath,$"*{FileFolder.Mp4FileExt}",true).Select(p => Path.Combine(folderPath, p)).ToList());
-                this.cachedFiles.AddRange(this.directoryIO.GetFiles(folderPath,$"*{FileFolder.TsFileExt}", true).Select(p => Path.Combine(folderPath, p)).ToList());
+                if (this.directoryIO.Exists(folderPath))
+                {
+                    this.cachedFiles.AddRange(this.directoryIO.GetFiles(folderPath, $"*{FileFolder.Mp4FileExt}", true).Select(p => Path.Combine(folderPath, p)).ToList());
+                    this.cachedFiles.AddRange(this.directoryIO.GetFiles(folderPath, $"*{FileFolder.TsFileExt}", true).Select(p => Path.Combine(folderPath, p)).ToList());
+                }
                 
             }
 

--- a/Niconicome/Models/Local/Settings/LocalSettingHandler.cs
+++ b/Niconicome/Models/Local/Settings/LocalSettingHandler.cs
@@ -187,6 +187,7 @@ namespace Niconicome.Models.Local.Settings
                 SettingsEnum.ConfirmIfDownloading => STypes::SettingNames.ConfirmIfDownloading,
                 SettingsEnum.MWBookMarkColumnWid => STypes::SettingNames.MainWindowBookMarkColumnWidth,
                 SettingsEnum.FFmpegFormat => STypes::SettingNames.FFmpegFormat,
+                SettingsEnum.SearchFileByID => STypes::SettingNames.SearchVideosByID,
                 _ => null
             };
         }
@@ -264,5 +265,6 @@ namespace Niconicome.Models.Local.Settings
         AppTheme,
         ConfirmIfDownloading,
         FFmpegFormat,
+        SearchFileByID,
     }
 }

--- a/Niconicome/Models/Local/Settings/LocalSettingsContainer.cs
+++ b/Niconicome/Models/Local/Settings/LocalSettingsContainer.cs
@@ -6,14 +6,14 @@ using Reactive.Bindings.Extensions;
 
 namespace Niconicome.Models.Local.Settings
 {
-    interface ILocalSettingsContainer
+    public interface ILocalSettingsContainer
     {
         ReactiveProperty<bool> GetReactiveBoolSetting(SettingsEnum settingType);
         ReactiveProperty<int> GetReactiveIntSetting(SettingsEnum settingType, Func<int, bool>? whereFunc = null, Func<int, int>? selectFunc = null);
         ReactiveProperty<string> GetReactiveStringSetting(SettingsEnum settingType, string defaultValue = "", bool disAllowEmpty = false);
     }
 
-    class LocalSettingsContainer : BindableBase, ILocalSettingsContainer
+    public class LocalSettingsContainer : BindableBase, ILocalSettingsContainer
     {
         public LocalSettingsContainer(ILocalSettingHandler settingHandler)
         {

--- a/Niconicome/Models/Network/Download/DownloadSettingsHandler.cs
+++ b/Niconicome/Models/Network/Download/DownloadSettingsHandler.cs
@@ -101,7 +101,7 @@ namespace Niconicome.Models.Network.Download
             bool overrideVideoDT = this.settingHandler.GetBoolSetting(SettingsEnum.OverrideVideoFileDTToUploadedDT);
             bool resumeEnable = this.settingHandler.GetBoolSetting(SettingsEnum.EnableResume);
             bool unsafeHandle = this.settingHandler.GetBoolSetting(SettingsEnum.UnsafeCommentHandle);
-            string folderPath = this.current.SelectedPlaylist.Value.Folderpath.IsNullOrEmpty() ? this.settingHandler.GetStringSetting(SettingsEnum.DefaultFolder) ?? "downloaded" : this.current.SelectedPlaylist.Value.Folderpath;
+            string folderPath = this.current.PlaylistFolderPath;
             string fileFormat = this.settingHandler.GetStringSetting(SettingsEnum.FileNameFormat) ?? Format.FIleFormat;
 
             VideoInfoTypeSettings videoInfoT = this.enumSettingsHandler.GetSetting<VideoInfoTypeSettings>();

--- a/Niconicome/Models/Playlist/VideoList/VideoListRefresher.cs
+++ b/Niconicome/Models/Playlist/VideoList/VideoListRefresher.cs
@@ -96,6 +96,7 @@ namespace Niconicome.Models.Playlist.VideoList
             var format = this.settingHandler.GetStringSetting(SettingsEnum.FileNameFormat) ?? "[<id>]<title>";
             var replaceStricted = this.settingHandler.GetBoolSetting(SettingsEnum.ReplaceSBToMB);
             var folderPath = this.current.PlaylistFolderPath;
+            bool searchByID = this.settingHandler.GetBoolSetting(SettingsEnum.SearchFileByID);
 
             this.videoThumnailUtility.GetFundamentalThumbsIfNotExist();
 
@@ -127,7 +128,7 @@ namespace Niconicome.Models.Playlist.VideoList
                     video.MessageGuid = lightVideo.MessageGuid;
                     video.IsSelected.Value = lightVideo.IsSelected;
                     video.Message.Value = VideoMessenger.GetMessage(lightVideo.MessageGuid);
-                    video.FileName.Value = lightVideo.FileName;
+                    //video.FileName.Value = lightVideo.FileName;
                 }
                 else
                 {
@@ -135,7 +136,7 @@ namespace Niconicome.Models.Playlist.VideoList
                 }
 
 
-                var filename = this.localVideoUtils.GetFilePath(video, folderPath, format, replaceStricted);
+                var filename = this.localVideoUtils.GetFilePath(video, folderPath, format, replaceStricted, searchByID);
                 if (filename.EndsWith(FileFolder.Mp4FileExt) || filename.EndsWith(FileFolder.TsFileExt))
                 {
                     video.FileName.Value = filename;

--- a/Niconicome/ViewModels/Setting/Pages/FileSettingsViewModel.cs
+++ b/Niconicome/ViewModels/Setting/Pages/FileSettingsViewModel.cs
@@ -42,6 +42,8 @@ namespace Niconicome.ViewModels.Setting.Pages
             }).AddTo(this.disposables);
             this.VideoInfoSuffix.Subscribe(value => this.SaveSetting(value, SettingsEnum.VideoinfoSuffix)).AddTo(this.disposables);
             this.IchibaSuffix.Subscribe(value => this.SaveSetting(value, SettingsEnum.IchibaInfoSuffix)).AddTo(this.disposables);
+
+            this.IsSearchingVideosByIDEnable = WS::SettingPage.SettingsContainer.GetReactiveBoolSetting(SettingsEnum.SearchFileByID);
         }
 
         /// <summary>
@@ -79,7 +81,13 @@ namespace Niconicome.ViewModels.Setting.Pages
         /// <summary>
         /// 市場情報の接尾子
         /// </summary>
-        public ReactiveProperty<string> IchibaSuffix { get; init; } 
+        public ReactiveProperty<string> IchibaSuffix { get; init; }
+
+        /// <summary>
+        /// 動画をIDで探索する
+        /// </summary>
+        public ReactiveProperty<bool> IsSearchingVideosByIDEnable { get; init; }
+
 
     }
 
@@ -102,6 +110,7 @@ namespace Niconicome.ViewModels.Setting.Pages
 
         public ReactiveProperty<string> IchibaSuffix { get; init; } = new(Format.DefaultIchibaSuffix);
 
+        public ReactiveProperty<bool> IsSearchingVideosByIDEnable { get; init; } = new(true);
 
     }
 }

--- a/Niconicome/Views/Setting/Pages/FileSettingsPage.xaml
+++ b/Niconicome/Views/Setting/Pages/FileSettingsPage.xaml
@@ -51,6 +51,7 @@
                     &lt;uploadedon&gt; :投稿日時,<LineBreak/>
                     &lt;downloadon&gt; :DL日時<LineBreak/>
                     &lt;owner&gt; :投稿者のニックネーム<LineBreak/>
+                    &lt;ownerId&gt; :投稿者のユーザーID<LineBreak/>
                     ※カスタム書式を利用できます。詳しくはwikiをご覧ください。<LineBreak/>
                     ※「\」でフォルダーを作成します。[&lt;id&gt;]&lt;title&gt;でxenoのデフォルトと同じフォーマットになります。
                     </TextBlock>

--- a/Niconicome/Views/Setting/Pages/FileSettingsPage.xaml
+++ b/Niconicome/Views/Setting/Pages/FileSettingsPage.xaml
@@ -4,16 +4,17 @@
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
       xmlns:local="clr-namespace:Niconicome.Views.Setting.Pages"
-              xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
-        xmlns:vm="clr-namespace:Niconicome.ViewModels.Setting.Pages"
-        mc:Ignorable="d"
-        TextElement.Foreground="{DynamicResource MaterialDesignBody}"
-        TextElement.FontWeight="Regular"
-        TextElement.FontSize="13"
-        TextOptions.TextFormattingMode="Ideal"
-        TextOptions.TextRenderingMode="Auto"
-        FontFamily="Yu Gothic"
-        d:DataContext="{d:DesignInstance {x:Type vm:FileSettingsViewModelD},IsDesignTimeCreatable=True}"
+      xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+      xmlns:vm="clr-namespace:Niconicome.ViewModels.Setting.Pages"
+      mc:Ignorable="d"
+      Background="{StaticResource MaterialDesignPaper}"
+      TextElement.Foreground="{DynamicResource MaterialDesignBody}"
+      TextElement.FontWeight="Regular"
+      TextElement.FontSize="13"
+      TextOptions.TextFormattingMode="Ideal"
+      TextOptions.TextRenderingMode="Auto"
+      FontFamily="Yu Gothic"
+      d:DataContext="{d:DesignInstance {x:Type vm:FileSettingsViewModelD},IsDesignTimeCreatable=True}"
       d:DesignHeight="600" d:DesignWidth="800"
       Title="ファイル設定">
     <Grid>
@@ -131,6 +132,16 @@
                     </materialDesign:PackIcon>
                     <Label Content="禁則文字をマルチバイト文字に置き換える" />
                     <ToggleButton IsChecked="{Binding IsReplaceSBToSBEnable.Value,UpdateSourceTrigger=PropertyChanged}" HorizontalAlignment="Right"/>
+                </DockPanel>
+                <Separator BorderThickness="1" BorderBrush="#e7e7e7" Margin="0 8"/>
+                <DockPanel>
+                    <materialDesign:PackIcon Kind="FindReplace" Foreground="SkyBlue">
+                        <materialDesign:PackIcon.RenderTransform>
+                            <TranslateTransform Y="7"/>
+                        </materialDesign:PackIcon.RenderTransform>
+                    </materialDesign:PackIcon>
+                    <Label Content="保存した動画ファイルををIDで探索する" />
+                    <ToggleButton IsChecked="{Binding IsSearchingVideosByIDEnable.Value,UpdateSourceTrigger=PropertyChanged}" HorizontalAlignment="Right"/>
                 </DockPanel>
                 <Separator BorderThickness="1" BorderBrush="#e7e7e7" Margin="0 8"/>
             </StackPanel>

--- a/NiconicomeTest/Local/PlaylistInfoUnitTest.cs
+++ b/NiconicomeTest/Local/PlaylistInfoUnitTest.cs
@@ -149,6 +149,17 @@ namespace NiconicomeTest.Local.Playlist
             Assert.AreEqual(result, isLastChild);
 
         }
+
+        [Test]
+        public void 親プレイリストのリストを取得する()
+        {
+            List<string> ancester = this.handler!.GetListOfAncestor(5);
+
+            Assert.That(ancester[0], Is.EqualTo("一"));
+            Assert.That(ancester[1], Is.EqualTo("二"));
+            Assert.That(ancester[2], Is.EqualTo("四"));
+            Assert.That(ancester[3], Is.EqualTo("五"));
+        }
     }
 
     class VideoFilterUnitTest

--- a/NiconicomeTest/Utils/NiconicoUtilsUnitTest.cs
+++ b/NiconicomeTest/Utils/NiconicoUtilsUnitTest.cs
@@ -106,6 +106,7 @@ namespace NiconicomeTest.Utils
 
         [TestCase("[<id>]<title>", "[sm9]新・豪血寺一族 -煩悩解放 - レッツゴー！陰陽師")]
         [TestCase("[<id>]<title>（<owner>）", "[sm9]新・豪血寺一族 -煩悩解放 - レッツゴー！陰陽師（中の）")]
+        [TestCase("[<id>]<title>（<ownerId>）", "[sm9]新・豪血寺一族 -煩悩解放 - レッツゴー！陰陽師（1）")]
         [TestCase("[<id>]<title>（<uploadedon>）", "[sm9]新・豪血寺一族 -煩悩解放 - レッツゴー！陰陽師（2007-03-06 00-33-00）")]
         [TestCase("[<id>]<title>（<downloadon>）", "[sm9]新・豪血寺一族 -煩悩解放 - レッツゴー！陰陽師（2021-03-26 20-30-00）")]
         [TestCase("[<id>]<title>（<uploadedon:yyyy年MM月dd日 HH時mm分ss秒>）", "[sm9]新・豪血寺一族 -煩悩解放 - レッツゴー！陰陽師（2007年03月06日 00時33分00秒）")]
@@ -121,6 +122,7 @@ namespace NiconicomeTest.Utils
                 Title = "新・豪血寺一族 -煩悩解放 - レッツゴー！陰陽師",
                 Owner = "中の",
                 Id = "sm9",
+                OwnerID = 1,
             };
 
             var result = this.utils!.GetFileName(format, dmc, string.Empty, true);


### PR DESCRIPTION
# 概要
## 修正
- ファイル名が変わると動画ファイルを追跡出来なくなる問題を修正（別途オプションを有効にする必要有り） fix #300 
## 追加
- 動画ファイルフォーマットに``<ownerId>``を追加 close #306 
- 保存フォルダーの自動マッピング機能を追加 close #332 