### PR TITLE
specify DateTimeKind as Unspecified, remove invalid characters in Chat.Text before serialize to prevent exception and comment DL failure

### DIFF
--- a/Niconicome/Models/Domain/Niconico/Download/Comment/V2/Core/Comment.cs
+++ b/Niconicome/Models/Domain/Niconico/Download/Comment/V2/Core/Comment.cs
@@ -93,8 +93,10 @@ namespace Niconicome.Models.Domain.Niconico.Download.Comment.V2.Core
 
         public DateTime Date { get; set; }
 
-        public long UnixDate => (new DateTimeOffset(this.Date, TimeSpan.FromHours(9))).ToUnixTimeSeconds();
+        //public long UnixDate => (new DateTimeOffset(this.Date, TimeSpan.FromHours(9))).ToUnixTimeSeconds();
 
+        public long UnixDate => (new DateTimeOffset(DateTime.SpecifyKind(this.Date, DateTimeKind.Unspecified), TimeSpan.FromHours(9))).ToUnixTimeSeconds();
+        
 
     }
 }

--- a/Niconicome/Models/Domain/Niconico/Download/Comment/V2/Core/Converter/LocalCommentConverter.cs
+++ b/Niconicome/Models/Domain/Niconico/Download/Comment/V2/Core/Converter/LocalCommentConverter.cs
@@ -61,7 +61,7 @@ namespace Niconicome.Models.Domain.Niconico.Download.Comment.V2.Core.Converter
                 No = comment.No,
                 Vpos = comment.Vpos / 10,
                 Score = comment.Score,
-                Date = new DateTimeOffset(comment.Date, TimeSpan.FromHours(9)).ToUnixTimeSeconds(),
+                Date = new DateTimeOffset(DateTime.SpecifyKind(comment.Date, DateTimeKind.Unspecified), TimeSpan.FromHours(9)).ToUnixTimeSeconds(),
             };
 
             return chat;

--- a/Niconicome/Models/Domain/Niconico/Download/Comment/V2/Local/CommentWriter.cs
+++ b/Niconicome/Models/Domain/Niconico/Download/Comment/V2/Local/CommentWriter.cs
@@ -10,6 +10,8 @@ using Niconicome.Models.Helper.Result;
 using Converter = Niconicome.Models.Domain.Niconico.Download.Comment.V2.Core.Converter;
 using Core = Niconicome.Models.Domain.Niconico.Download.Comment.V2.Core;
 using V2 = Niconicome.Models.Domain.Niconico.Net.Xml.Comment.V2;
+using System.Text.RegularExpressions;
+
 
 namespace Niconicome.Models.Domain.Niconico.Download.Comment.V2.Local
 {
@@ -59,6 +61,18 @@ namespace Niconicome.Models.Domain.Niconico.Download.Comment.V2.Local
 
             var data = new V2::PacketElement();
             data.Chat.AddRange(comments.Select(c => this._converter.ConvertCoreCommentToChat(c)).OrderBy(c => c.Vpos));
+            char[] invalidChars = { '\x08', '\x0B', '\x0C', '\x1F' };
+            for (int i = 0; i < data.Chat.Count; i++)
+            {
+                Net.Xml.Comment.V2.ChatElement element = data.Chat[i];
+
+                
+                // Modify the element
+                element.Text = Regex.Replace(element.Text, @"[\x08\x0B\x0C\x1F]", "");
+
+                // Update the modified element back in the collection
+                data.Chat[i] = element;
+            }
 
             try
             {
@@ -71,6 +85,7 @@ namespace Niconicome.Models.Domain.Niconico.Download.Comment.V2.Local
             }
 
             builder.AppendLine(content);
+
 
             try
             {

--- a/Niconicome/Models/Domain/Niconico/Download/Description/VideoInfoContentProducer.cs
+++ b/Niconicome/Models/Domain/Niconico/Download/Description/VideoInfoContentProducer.cs
@@ -96,7 +96,7 @@ namespace Niconicome.Models.Domain.Niconico.Download.Description
             data.Thumb.Title = info.Title;
             data.Thumb.Description = info.Description;
             data.Thumb.ThumbnailUrl = info.ThumbInfo.GetSpecifiedThumbnail(ThumbSize.Large);
-            data.Thumb.FirstRetrieve = new DateTimeOffset(info.UploadedOn, TimeSpan.FromHours(9)).ToString("yyyy-MM-ddTHH:mm:sszzz");
+            data.Thumb.FirstRetrieve = new DateTimeOffset(DateTime.SpecifyKind(info.UploadedOn, DateTimeKind.Unspecified), TimeSpan.FromHours(9)).ToString("yyyy-MM-ddTHH:mm:sszzz");
             data.Thumb.Length = $"{Math.Floor((double)info.Duration / 60).ToString().PadLeft(2, '0')}:{info.Duration % 60}";
             data.Thumb.ViewCounter = info.ViewCount;
             data.Thumb.CommentNum = info.CommentCount;

--- a/Niconicome/Models/Domain/Niconico/Net/Xml/Xmlparser.cs
+++ b/Niconicome/Models/Domain/Niconico/Net/Xml/Xmlparser.cs
@@ -32,10 +32,13 @@ namespace Niconicome.Models.Domain.Niconico.Net.Xml
             var stringWriter = new XmlStringWriter();
             var writer = XmlWriter.Create(stringWriter, settings);
 
+
             serializer.Serialize(writer, data, emptyns);
 
             return stringWriter.ToString();
         }
+
+
 
         /// <summary>
         /// XML形式の文字列をデシリアライズする

--- a/Niconicome/ViewModels/Mainpage/Subwindows/SearchViewModel.cs
+++ b/Niconicome/ViewModels/Mainpage/Subwindows/SearchViewModel.cs
@@ -104,8 +104,8 @@ namespace Niconicome.ViewModels.Mainpage.Subwindows
                     SearchType = this.IsTag ? Search::SearchType.Tag : Search::SearchType.Keyword,
                     Genre = this.Genre.Value,
                     SortOption = this.Sort.Value,
-                    UploadedDateTimeStart = this.ConfigureDateTimeManualy ? new DateTimeOffset(this.UploadDTStart, TimeSpan.FromHours(9)) : this.UploadedDT.Value == default ? null : this.UploadedDT.Value,
-                    UploadedDateTimeEnd = this.ConfigureDateTimeManualy ? new DateTimeOffset(this.UploadDTEnd, TimeSpan.FromHours(9)) : null,
+                    UploadedDateTimeStart = this.ConfigureDateTimeManualy ? new DateTimeOffset(DateTime.SpecifyKind(this.UploadDTStart, DateTimeKind.Unspecified), TimeSpan.FromHours(9)) : this.UploadedDT.Value == default ? null : this.UploadedDT.Value,
+                    UploadedDateTimeEnd = this.ConfigureDateTimeManualy ? new DateTimeOffset(DateTime.SpecifyKind(this.UploadDTEnd,DateTimeKind.Unspecified), TimeSpan.FromHours(9)) : null,
                     Page = this.Page,
                 };
 


### PR DESCRIPTION
specify DateTimeKind as Unspecified, remove invalid characters in Chat.Text before serialize to prevent exception and comment DL failure